### PR TITLE
Enable CI for jiva with vdbench tests (#1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 before_install:
   - sleep 15
   - sudo apt-get install -y
-  - sudo apt-get install -y curl
+  - sudo apt-get install -y curl open-iscsi
   - go env && pwd
   - mkdir -p $HOME/gopath/bin
 script:

--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ _fetch_longhorn:
 	cd $(GOPATH)/src/github.com/openebs/longhorn && git pull && trash .
 
 _customize_longhorn:
-	cp -R $(GOPATH)/src/github.com/openebs/jiva/package/* $(GOPATH)/src/github.com/openebs/longhorn/package/
-	cp -R $(GOPATH)/src/github.com/openebs/jiva/buildscripts/* $(GOPATH)/src/github.com/openebs/longhorn/scripts/
+	cp -R package/* $(GOPATH)/src/github.com/openebs/longhorn/package/
+	cp -R buildscripts/* $(GOPATH)/src/github.com/openebs/longhorn/scripts/
 
 _build_longhorn:
 	cd $(GOPATH)/src/github.com/openebs/longhorn && make

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1,24 +1,29 @@
 #!/bin/bash
 
-JIVA_IMAGE=$(sudo docker images | grep jiva | awk '{print $1":"$2}')
-echo "Run CI tests on $JIVA_IMAGE"
-exit 0
+JI=$(sudo docker images | grep jiva | awk '{print $1":"$2}')
+echo "Run CI tests on $JI"
 
+mkdir /tmp/vol1
+mkdir /tmp/vol2
+sudo docker network create --subnet=172.18.0.0/16 stg-net
 
-sudo docker network create --subnet=172.18.0.0/16 longhorn-net
-sudo docker run -d -it --net longhorn-net --ip 172.18.0.3 -P --expose 9502-9504 -v /mnt/vol1:/vol1  $1 launch replica --frontendIP 172.18.0.2 --listen 172.18.0.3:9502 --size 10g /vol1
-sudo docker run -d --net longhorn-net --ip 172.18.0.2 -P --expose 3260 --expose 9501 --expose 9502-9504 $1 launch controller --frontend gotgt --frontendIP 172.18.0.2 --replica tcp://172.18.0.3:9502 store1
-sudo docker run -d -it --net longhorn-net --ip 172.18.0.4 -P --expose 9502-9504 -v /mnt/vol2:/vol2 $1 launch replica --frontendIP 172.18.0.2 --listen 172.18.0.4:9502 --size 10g /vol2
+sudo docker run -d --net stg-net --ip 172.18.0.2 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI launch controller --frontend gotgt --frontendIP 172.18.0.2 store1
+sudo docker run -d -it --net stg-net --ip 172.18.0.3 -P --expose 9502-9504 -v /tmp/vol1:/vol1 $JI launch replica --frontendIP 172.18.0.2 --listen 172.18.0.3:9502 --size 2g /vol1
+sudo docker run -d -it --net stg-net --ip 172.18.0.4 -P --expose 9502-9504 -v /tmp/vol2:/vol2 $JI launch replica --frontendIP 172.18.0.2 --listen 172.18.0.4:9502 --size 2g /vol2
 
-sudo umount /mnt/store
+sudo docker ps
+
+sudo mkdir -p /mnt/store
 sudo iscsiadm -m node -u
 sudo iscsiadm -m node -o delete
 sudo iscsiadm -m discovery -t st -p 172.18.0.2:3260
 sudo iscsiadm -m node -l
 sleep 1
+
 sudo fdisk -l
 x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
 echo $x
+
 i=0
 while x==""; do
         sleep 4
@@ -30,9 +35,14 @@ while x==""; do
                 continue
         fi
 done
+
 if [ "$x"!="" ]; then
         sudo mkfs.ext2 -F /dev/$x
         sudo mount /dev/$x /mnt/store
         sudo dd if=/dev/urandom of=/mnt/store/file1 bs=4k count=10000
         sudo md5sum /mnt/store/file1 > file1
 fi
+
+sudo mkdir -p /mnt/store/data
+sudo chown 777 /mnt/store/data
+sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest


### PR DESCRIPTION
* Create the vsm on docker-net
* Make the paths relative, helps with forked branches build
* Install iscsiadm for ci
* run the vdbench basic tests
* Run the vdbench tests in foreground