### PR TITLE
 Add endpoint "/metrics" in Controller and replica

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -28,7 +28,7 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 RUN wget -O - https://storage.googleapis.com/golang/go1.7.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint
+    go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
-	"net/http"
-	_ "net/http/pprof" /* for profiling */
-
 	"github.com/gorilla/mux"
 	"github.com/openebs/jiva/replica/rest"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rancher/go-rancher/api"
+	"net/http"
+	_ "net/http/pprof" /* for profiling */
 )
 
 func NewRouter(s *Server) *mux.Router {
@@ -40,6 +40,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/replicas/{id}").Queries("action", "verifyrebuild").Handler(f(schemas, s.VerifyRebuildReplica))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
 	router.Methods("PUT").Path("/v1/replicas/{id}").Handler(f(schemas, s.UpdateReplica))
+	router.Handle("/metrics", promhttp.Handler())
 
 	// Journal
 	router.Methods("POST").Path("/v1/journal").Handler(f(schemas, s.ListJournal))

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -1,12 +1,12 @@
 package rest
 
 import (
-	"net/http"
-	_ "net/http/pprof" /* for profiling */
-
 	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
+	"net/http"
+	_ "net/http/pprof" /* for profiling */
 )
 
 func HandleError(s *client.Schemas, t func(http.ResponseWriter, *http.Request) error) http.Handler {
@@ -52,6 +52,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))
 	router.Methods("GET").Path("/v1/replicas/{id}/volusage").Handler(f(schemas, s.GetVolUsage))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
+	router.Handle("/metrics", promhttp.Handler())
 
 	// Actions
 	actions := map[string]func(http.ResponseWriter, *http.Request) error{


### PR DESCRIPTION
**What this PR does / why we need it**:

* This PR refers issue #16 and [#380](https://github.com/openebs/openebs/issues/380)
* Adds endpoint `/metrics` in controller and replica
* Adds dependency of prometheus in Dockerfile

**How this commit address the issue**:

* Prometheus now collects basic metrics from controller and replica.

**How to verify this change**

* Build new image and binary and then run it locally by `./longhorn --url "http://localhost:9501" controller vol`
* or Run it in Docker container

**Note:**
* Custom metrics not added yet, will be added later an issue #16 is
  created for this
* You need to build a new binary in order to see the metrics in openebs
  setup