### PR TITLE
Add varibales to count volume registration in prometheus

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -34,6 +34,10 @@ type Controller struct {
 	ReadOnly                 bool
 }
 
+func (c *Controller) GetSize() int64 {
+	return c.size
+}
+
 func NewController(name string, frontendIP string, clusterIP string, factory types.BackendFactory, frontend types.Frontend) *Controller {
 	c := &Controller{
 		factory:                  factory,

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openebs/jiva/controller"
 	"github.com/openebs/jiva/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
@@ -63,6 +64,7 @@ type VolumeStats struct {
 	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
 	UsedBlocks        string `json:"UsedBlocks"`
 	SectorSize        string `json:"SectorSize"`
+	Size              string `json:"Size"`
 }
 
 type SnapshotInput struct {
@@ -207,7 +209,9 @@ func NewSchema() *client.Schemas {
 }
 
 type Server struct {
-	c *controller.Controller
+	c               *controller.Controller
+	RequestDuration *prometheus.HistogramVec
+	RequestCounter  *prometheus.CounterVec
 }
 
 func NewServer(c *controller.Controller) *Server {

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -13,6 +13,8 @@ import (
 )
 
 var (
+	// OpenEBSJivaRegestrationRequestDuration gets the response time of the
+	// requested api.
 	OpenEBSJivaRegestrationRequestDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "openebs_jiva_registration_request_duration_seconds",
@@ -23,7 +25,7 @@ var (
 		// endpoint "/v1/volume"
 		[]string{"code", "method"},
 	)
-	// Count the no of request Since a request has been made on /v1/volume
+	// OpenEBSJivaRegestrationRequestCounter Count the no of request Since a request has been made on /v1/volume
 	OpenEBSJivaRegestrationRequestCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "openebs_jiva_registration_requests_total",

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -3,12 +3,44 @@ package rest
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/openebs/jiva/types"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
+
+var (
+	OpenEBSJivaRegestrationRequestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "openebs_jiva_registration_request_duration_seconds",
+			Help:    "Request response time of the /v1/register to register replicas.",
+			Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.5, 1, 2.5, 5, 10},
+		},
+		// code is http code and method is http method returned by
+		// endpoint "/v1/volume"
+		[]string{"code", "method"},
+	)
+	// Count the no of request Since a request has been made on /v1/volume
+	OpenEBSJivaRegestrationRequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "openebs_jiva_registration_requests_total",
+			Help: "Total number of /v1/register requests to register replicas.",
+		},
+		[]string{"code", "method"},
+	)
+)
+
+// init registers Prometheus metrics.It's good to register these varibles here
+// otherwise you need to register it before you are going to use it. So you will
+// have to register it everytime unnecessarily, instead initialize it once and
+// use anywhere at anytime through the code.
+func init() {
+	prometheus.MustRegister(OpenEBSJivaRegestrationRequestDuration)
+	prometheus.MustRegister(OpenEBSJivaRegestrationRequestCounter)
+}
 
 func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
@@ -43,14 +75,39 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 	var (
 		regReplica    RegReplica
 		localRevCount int64
+		code          int
 	)
+	start := time.Now()
 	apiContext := api.GetApiContext(req)
+	s.RequestDuration = OpenEBSJivaRegestrationRequestDuration
+	s.RequestCounter = OpenEBSJivaRegestrationRequestCounter
+
 	if err := apiContext.Read(&regReplica); err != nil {
 		return err
 	}
 
 	localRevCount, _ = strconv.ParseInt(regReplica.RevCount, 10, 64)
-	local := types.RegReplica{Address: regReplica.Address, RevCount: localRevCount, PeerDetail: regReplica.PeerDetails, RepType: regReplica.RepType, UpTime: regReplica.UpTime, RepState: regReplica.RepState}
+	local := types.RegReplica{
+		Address:    regReplica.Address,
+		RevCount:   localRevCount,
+		PeerDetail: regReplica.PeerDetails,
+		RepType:    regReplica.RepType,
+		UpTime:     regReplica.UpTime,
+		RepState:   regReplica.RepState,
+	}
+	code = http.StatusOK
+	rw.WriteHeader(code)
+	defer func() {
+		// This will Display the metrics something similar to
+		// the examples given below
+		// exp: openebs_jiva_registration_request_duration_seconds{code="200", method="POST"}
+		s.RequestDuration.WithLabelValues(strconv.Itoa(code), req.Method).Observe(time.Since(start).Seconds())
+
+		// This will Display the metrics something similar to
+		// the examples given below
+		// exp: openebs_jiva_registration_requests_total{code="200", method="POST"}
+		s.RequestCounter.WithLabelValues(strconv.Itoa(code), req.Method).Inc()
+	}()
 	return s.c.RegisterReplica(local)
 
 }

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -53,6 +53,7 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 		UsedLogicalBlocks: strconv.FormatInt(stats.UsedLogicalBlocks, 10),
 		UsedBlocks:        strconv.FormatInt(stats.UsedBlocks, 10),
 		SectorSize:        strconv.FormatInt(stats.SectorSize, 10),
+		Size:              strconv.FormatInt(s.c.GetSize(), 10),
 	}
 	apiContext.Write(volumeStats)
 	return nil


### PR DESCRIPTION
1. Why is this change necessary ?
- To expose size at `/v1/stats` endpoint
- To monitor `/v1/register`

2. How does this change address the issue ?
- Adds a method bind with controller to get size
- Adds prometheus counter variables that is used to count the
  no of registration so far.

3. How to verify this change ?
- Run `curl controllerIP:Port/v1/stats` while running controller
  locally or with openebs-operator.

4. What side effects does this change have ?
- none

5. Other details
- fix: [#858](https://github.com/openebs/openebs/issues/858)
  fix: [#266](https://github.com/openebs/openebs/issues/266)