### PR TITLE
Add uptime and volume name in stats struct

### DIFF
--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -61,10 +61,12 @@ type VolumeStats struct {
 	TotalWriteTime       string `json:"TotalWriteTime"`
 	TotalWriteBlockCount string `json:"TotatWriteBlockCount"`
 
-	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
-	UsedBlocks        string `json:"UsedBlocks"`
-	SectorSize        string `json:"SectorSize"`
-	Size              string `json:"Size"`
+	UsedLogicalBlocks string  `json:"UsedLogicalBlocks"`
+	UsedBlocks        string  `json:"UsedBlocks"`
+	SectorSize        string  `json:"SectorSize"`
+	Size              string  `json:"Size"`
+	UpTime            float64 `json:"UpTime"`
+	Name              string  `json:"Name"`
 }
 
 type SnapshotInput struct {

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/rancher/go-rancher/api"
@@ -54,6 +55,8 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 		UsedBlocks:        strconv.FormatInt(stats.UsedBlocks, 10),
 		SectorSize:        strconv.FormatInt(stats.SectorSize, 10),
 		Size:              strconv.FormatInt(s.c.GetSize(), 10),
+		UpTime:            time.Since(s.c.StartTime).Seconds(),
+		Name:              s.c.Name,
 	}
 	apiContext.Write(volumeStats)
 	return nil


### PR DESCRIPTION
This commit adds uptime and volume name fields in volumestats struct.
fix: openebs/openebs#886
corresponding changes in maya done PR[#184](https://github.com/openebs/maya/pull/184)