### PR TITLE
Interm fix for handling size formats with i

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -109,6 +110,9 @@ func startReplica(c *cli.Context) error {
 	frontendIP := c.String("frontendIP")
 	size := c.String("size")
 	if size != "" {
+		//Units bails with an error size is provided with i, like Gi
+		//The following will convert - G, Gi, GiB into G
+		size = strings.Split(size, "i")[0]
 		size, err := units.RAMInBytes(size)
 		if err != nil {
 			return err


### PR DESCRIPTION
Most of the kubernetes examples advocate specifying the capacity with "i" like Gi or GiB. The current units -- vendored package doesn't handle it. 

This PR provides and interm fix that will avoid sending openebs volume into errored state during creation. A cleaner fix needs to be implemented to handle different capacity input parameters (See https://github.com/openebs/openebs/issues/541)