### PR TITLE
update ci image on every build

### DIFF
--- a/scripts/push
+++ b/scripts/push
@@ -12,7 +12,9 @@ then
   docker login -u "${DNAME}" -p "${DPASS}"; 
   #Push the development build images to jiva-ci docker hub repository
   docker tag ${IMAGEID} openebs/jiva-ci:${VERSION}
-  docker push openebs/jiva-ci:${VERSION} ; 
+  docker push openebs/jiva-ci:${VERSION};
+  docker tag ${IMAGEID} openebs/jiva:ci
+  docker push openebs/jiva:ci;
   if [ ! -z "${TRAVIS_TAG}" ] || [ ! -z "${RELEASE_TAG}" ]; 
   then
     #Push the release tag image to jiva docker hub repository
@@ -26,8 +28,6 @@ then
     docker push openebs/jiva:${RELEASE_TAG}; 
     docker tag ${IMAGEID} openebs/jiva:latest
     docker push openebs/jiva:latest;
-    docker tag ${IMAGEID} openebs/jiva:ci
-    docker push openebs/jiva:ci;
   fi;
 else
   echo "No docker credentials provided. Skip uploading openebs/jiva:${VERSION} to docker hub"; 

--- a/scripts/push
+++ b/scripts/push
@@ -26,6 +26,8 @@ then
     docker push openebs/jiva:${RELEASE_TAG}; 
     docker tag ${IMAGEID} openebs/jiva:latest
     docker push openebs/jiva:latest;
+    docker tag ${IMAGEID} openebs/jiva:ci
+    docker push openebs/jiva:ci;
   fi;
 else
   echo "No docker credentials provided. Skip uploading openebs/jiva:${VERSION} to docker hub"; 

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,4 +20,4 @@ github.com/jmespath/go-jmespath         c01cf91b011868172fdcd9f41838e80c9d716264
 github.com/yasker/go-iscsi-helper       9910689ad7c88f650262e01557b16bdc0d5b6a94
 github.com/yasker/nsfilelock            90eff0ebb9e2e0ee2f22519cfb8404f9fdd9c008
 github.com/yasker/backupstore           39c822e19eb3d54eca4dc5f75205e426c8357ac1
-github.com/openebs/gotgt		2b7502191b5b96a6ae0481fad735d649a35285cf
+github.com/openebs/gotgt		eff00079de1dfc674c5bf17b518e1f55f8b1c561	


### PR DESCRIPTION
ci image is not tied to release tag anymore. 
probably can remove the repo -- jiva-ci eventually once all the scripts move to using jiva:ci