### PR TITLE
Enhance jiva for clone feature 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,7 +15,7 @@ ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 WORKDIR ${DAPPER_SOURCE}
 
 # Install packages
-RUN apt-get update && \
+RUN apt-get update -o Acquire::CompressionTypes::Order::=gz && apt-get update && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
@@ -27,15 +27,11 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.7.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
+RUN curl -sSL https://get.docker.com | bash && chmod +x /usr/bin/docker
 
 # Build TCMU
 RUN cd /usr/src && \

--- a/app/replica.go
+++ b/app/replica.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/replica/rpc"
+	"github.com/openebs/jiva/sync"
 	"github.com/openebs/jiva/util"
 )
 
@@ -32,6 +33,14 @@ func ReplicaCmd() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "frontendIP",
+				Value: "",
+			},
+			cli.StringFlag{
+				Name:  "cloneIP",
+				Value: "",
+			},
+			cli.StringFlag{
+				Name:  "snapName",
 				Value: "",
 			},
 			cli.StringFlag{
@@ -92,6 +101,17 @@ checkagain:
 	}
 }
 
+func CloneReplica(s *replica.Server, address string, cloneIP string, snapName string) error {
+	var err error
+	url := "http://" + cloneIP + ":9501"
+	task := sync.NewTask(url)
+	task.CloneReplica(url, address, cloneIP, snapName)
+	if s.Replica() != nil {
+		s.Replica().SetCloneStatus("completed")
+	}
+	return err
+}
+
 func startReplica(c *cli.Context) error {
 	if c.NArg() != 1 {
 		return errors.New("directory name is required")
@@ -108,6 +128,8 @@ func startReplica(c *cli.Context) error {
 
 	address := c.String("listen")
 	frontendIP := c.String("frontendIP")
+	cloneIP := c.String("cloneIP")
+	snapName := c.String("snapName")
 	size := c.String("size")
 	if size != "" {
 		//Units bails with an error size is provided with i, like Gi
@@ -190,6 +212,16 @@ func startReplica(c *cli.Context) error {
 		}
 		go AutoConfigureReplica(s, frontendIP, "tcp://"+address, replicaType)
 	}
+	if replicaType == "clone" {
+		logrus.Infof("Starting clone process using frontend %v", cloneIP)
+		if err = CloneReplica(s, "tcp://"+address, cloneIP, snapName); err != nil {
+			return err
+		}
+	}
+	for s.Replica() == nil {
+		time.Sleep(2 * time.Second)
+	}
+	s.Replica().SetCloneStatus("completed")
 
 	return <-resp
 }

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -86,6 +86,10 @@ func (f *Wrapper) GetMonitorChannel() types.MonitorChannel {
 	return nil
 }
 
+func (f *Wrapper) GetCloneStatus() (string, error) {
+	return "", nil
+}
+
 func (f *Wrapper) PingResponse() error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -147,6 +147,17 @@ func (r *Remote) GetRevisionCounter() (int64, error) {
 	return counter, nil
 }
 
+func (r *Remote) GetCloneStatus() (string, error) {
+	replica, err := r.info()
+	if err != nil {
+		return "", err
+	}
+	if replica.State != "open" && replica.State != "dirty" {
+		return "", fmt.Errorf("Invalid state %v for getting revision counter", replica.State)
+	}
+	return replica.CloneStatus, nil
+}
+
 func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	var Details rest.VolUsage
 	var volUsage types.VolUsage

--- a/controller/control.go
+++ b/controller/control.go
@@ -583,6 +583,11 @@ func (c *Controller) Start(addresses ...string) error {
 		if err := c.addReplicaNoLock(newBackend, address, false); err != nil {
 			return err
 		}
+	getCloneStatus:
+		if status, _ := c.backend.GetCloneStatus(address); status != "completed" {
+			time.Sleep(2 * time.Second)
+			goto getCloneStatus
+		}
 		// We will validate this later
 		c.setReplicaModeNoLock(address, types.RW)
 	}

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -430,3 +430,18 @@ func (r *replicator) GetRevisionCounter(address string) (int64, error) {
 
 	return counter, nil
 }
+
+func (r *replicator) GetCloneStatus(address string) (string, error) {
+	backend, ok := r.backends[address]
+	if !ok {
+		return "", fmt.Errorf("Cannot find backend %v", address)
+	}
+
+	status, err := backend.backend.GetCloneStatus()
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Get backend %s clone status", address)
+
+	return status, nil
+}

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -58,6 +58,8 @@ type Replica struct {
 	peerLock  sync.Mutex
 	peerCache types.PeerDetails
 	peerFile  *sparse.DirectFileIoProcessor
+
+	cloneStatus string
 }
 
 type Info struct {
@@ -1043,6 +1045,24 @@ func (r *Replica) GetRemainSnapshotCounts() int {
 	defer r.RUnlock()
 
 	return maximumChainLength - len(r.activeDiskData)
+}
+
+// GetCloneStatus return the current status if clone
+func (r *Replica) GetCloneStatus() string {
+	r.RLock()
+	defer r.RUnlock()
+
+	return r.cloneStatus
+}
+
+// SetCloneStatus will set the status of clone replica as "completed" after
+// verifying the sync and rebuild
+func (r *Replica) SetCloneStatus(status string) error {
+	r.RLock()
+	defer r.RUnlock()
+	logrus.Infof("Setting clone status: %s", status)
+	r.cloneStatus = status
+	return nil
 }
 
 func (r *Replica) getDiskSize(disk string) int64 {

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -24,6 +24,7 @@ type Replica struct {
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
+	CloneStatus       string                      `json:"clonestatus"`
 }
 
 type Stats struct {
@@ -194,6 +195,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.Disks = rep.ListDisks()
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
+		r.CloneStatus = rep.GetCloneStatus()
 	}
 
 	return r

--- a/types/types.go
+++ b/types/types.go
@@ -36,6 +36,7 @@ type Backend interface {
 	SectorSize() (int64, error)
 	RemainSnapshots() (int, error)
 	GetRevisionCounter() (int64, error)
+	GetCloneStatus() (string, error)
 	GetVolUsage() (VolUsage, error)
 	SetRevisionCounter(counter int64) error
 	UpdatePeerDetails(replicaCount int, quorumReplicaCount int) error


### PR DESCRIPTION
Enhance jiva for clone feature  …
1. This PR will add sync and rebuild capabilities in jiva.
2. Now clone replica can be created from the running replicas and can be further use as RO/RW mode.
3. There is 2 new flags has been added, which has to passed while starting a clone replica with a new jiva-controller.
- `cloneIP` : This is frontendIP of running controller, which will be used to make a clone request will be passed as a argument while starting clone replica.
- `type`: Type of replica, now we can pass type as `clone` to trigger the clone API of jiva, which says the new replica is getting added as clone not as usual replica.
