### PR TITLE
Jiva replica clone feature

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,7 +15,7 @@ ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 WORKDIR ${DAPPER_SOURCE}
 
 # Install packages
-RUN apt-get update && \
+RUN apt-get update -o Acquire::CompressionTypes::Order::=gz && apt-get update && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
@@ -27,15 +27,11 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.7.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
+RUN curl -sSL https://get.docker.com | bash && chmod +x /usr/bin/docker
 
 # Build TCMU
 RUN cd /usr/src && \

--- a/app/replica.go
+++ b/app/replica.go
@@ -221,7 +221,9 @@ func startReplica(c *cli.Context) error {
 		logrus.Infof("Starting clone process\n")
 		status := s.Replica().GetCloneStatus()
 		if status != "completed" {
+			s.Replica().SetCloneStatus("inProgress")
 			if err = CloneReplica(s, "tcp://"+address, cloneIP, snapName); err != nil {
+				s.Replica().SetCloneStatus("error")
 				return err
 			}
 		}

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -86,6 +86,10 @@ func (f *Wrapper) GetMonitorChannel() types.MonitorChannel {
 	return nil
 }
 
+func (f *Wrapper) GetCloneStatus() (string, error) {
+	return "", nil
+}
+
 func (f *Wrapper) PingResponse() error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -147,6 +147,17 @@ func (r *Remote) GetRevisionCounter() (int64, error) {
 	return counter, nil
 }
 
+func (r *Remote) GetCloneStatus() (string, error) {
+	replica, err := r.info()
+	if err != nil {
+		return "", err
+	}
+	if replica.State != "open" && replica.State != "dirty" {
+		return "", fmt.Errorf("Invalid state %v for getting revision counter", replica.State)
+	}
+	return replica.CloneStatus, nil
+}
+
 func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	var Details rest.VolUsage
 	var volUsage types.VolUsage

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -152,9 +152,6 @@ func (r *Remote) GetCloneStatus() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if replica.State != "open" && replica.State != "dirty" {
-		return "", fmt.Errorf("Invalid state %v for getting revision counter", replica.State)
-	}
 	return replica.CloneStatus, nil
 }
 

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -5,6 +5,8 @@ JI=$(sudo docker images | grep openebs/jiva | awk '{print $1":"$2}')
 echo "Run CI tests on $JI"
 
 # Prepare environment to run Jiva containers
+sudo rm -rf /tmp/vol*
+sudo rm -rf /mnt/logs
 mkdir /tmp/vol1
 mkdir /tmp/vol2
 mkdir /tmp/vol3
@@ -23,90 +25,101 @@ sudo mkdir -p /mnt/store
 sudo mkdir -p /mnt/store2
 
 # Cleanup existing iSCSI sessions
-sudo iscsiadm -m node -u
-sudo iscsiadm -m node -o delete
-
-# Discover Jiva iSCSI target and Login
-sleep 1
-sudo iscsiadm -m discovery -t st -p 172.18.0.2:3260
-sudo iscsiadm -m node -l
-
-# Wait for iSCSI device node (scsi device) to be created
-sleep 1
-sudo fdisk -l
-x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-echo $x
-
-i=0
-while [ -z $x ]; do
-        sleep 4
-        x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-        i=`expr $i + 1`
-        if [ $i -eq 5 ]; then
-                break;
-        else
-                continue;
-        fi
-done
-
-# Start tests once (i)SCSI device is detected
-if [ "$x"!="" ]; then
-        # Format disk as ext2 FS
-        sudo mkfs.ext2 -F /dev/$x
-
-        # Mount FS onto local mountpoint
-        sudo mount /dev/$x /mnt/store
-
-        # TEST#1: Perform simple data-integrity check on Jiva Vol
-        sudo dd if=/dev/urandom of=file1 bs=4k count=10000
-        hash1=$(sudo md5sum file1 | awk '{print $1}')
-        sudo cp file1 /mnt/store
-        hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
-        if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
-        else
-            echo "DI Test: FAILED"; exit 1
-        fi
-
-	#Create a snapshot for testing clone feature
-	cd /mnt/store; sync; sleep 5; sync; sleep 5; cd ~;
-	sudo blockdev --flushbufs /dev/$x
-	sudo hdparm -F /dev/$x
-	sleep 5
-	id=`curl http://172.18.0.2:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
-	curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://172.18.0.2:9501/v1/volumes/$id?action=snapshot
-
-        # TEST#2: Perform a random I/O workload test on Jiva Vol
-        sudo mkdir -p /mnt/store/data
-        sudo chown 777 /mnt/store/data
-        sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
-        if [ $? -eq 0 ]; then echo "VDbench Test: PASSED"
-        else
-            echo "VDbench Test: FAILED";exit 1
-        fi
-	# Remove iSCSI session
-	sudo umount /mnt/store
+logout_of_volume() {
 	sudo iscsiadm -m node -u
 	sudo iscsiadm -m node -o delete
+}
 
-        # TEST#3: Run the libiscsi compliance suite on Jiva Vol
-        sudo mkdir /mnt/logs
-        sudo docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip 172.18.0.2"
-        tp=$(grep "PASSED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
-        tf=$(grep "FAILED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
-        if [ $tp -ge 146 ] && [ $tf -le 29 ]; then
-           echo "iSCSI Compliance test: PASSED"
-        else
-            echo "iSCSI Compliance test: FAILED"; exit 1
-        fi
+# Discover Jiva iSCSI target and Login
+login_to_volume() {
+	sudo iscsiadm -m discovery -t st -p $1
+	sudo iscsiadm -m node -l
+}
+
+# Wait for iSCSI device node (scsi device) to be created
+get_scsi_disk() {
+	device_name=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+	i=0
+	while [ -z $device_name ]; do
+		sleep 4
+		device_name=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+		i=`expr $i + 1`
+		if [ $i -eq 10 ]; then
+			echo "scsi disk not found";
+			exit;
+		else
+			continue;
+		fi
+	done
+}
+
+login_to_volume "172.18.0.2:3260"
+sleep 5
+get_scsi_disk
+if [ "$device_name"!="" ]; then
+	# Format disk as ext2 FS
+	sudo mkfs.ext2 -F /dev/$device_name
+
+	# Mount FS onto local mountpoint
+	sudo mount /dev/$device_name /mnt/store
+
+	# TEST#1: Perform simple data-integrity check on Jiva Vol
+	sudo dd if=/dev/urandom of=file1 bs=4k count=10000
+	hash1=$(sudo md5sum file1 | awk '{print $1}')
+	sudo cp file1 /mnt/store
+	hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
+	if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
+	else
+		echo "DI Test: FAILED"; exit 1
+	fi
+
+	cd /mnt/store; sync; sleep 5; sync; sleep 5; cd ~;
+	sudo blockdev --flushbufs /dev/$device_name
+	sudo hdparm -F /dev/$device_name
+	sudo umount /mnt/store
+	logout_of_volume
+	sleep 5
 else
-        echo "Unable to detect iSCSI device, login failed"; exit 1
+	echo "Unable to detect iSCSI device, login failed"; exit 1
 fi
 
-sudo umount /mnt/store
-sudo iscsiadm -m node -u
-sudo iscsiadm -m node -o delete
+#Create a snapshot for testing clone feature
+id=`curl http://172.18.0.2:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
+curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://172.18.0.2:9501/v1/volumes/$id?action=snapshot
 
-# Test clone feature
+# TEST#2: Perform a random I/O workload test on Jiva Vol
+login_to_volume "172.18.0.2:3260"
+sleep 5
+get_scsi_disk
+if [ "$device_name"!="" ]; then
+	sudo mount /dev/$device_name /mnt/store
+	sudo mkdir -p /mnt/store/data
+	sudo chown 777 /mnt/store/data
+	sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
+	if [ $? -eq 0 ]; then echo "VDbench Test: PASSED"
+	else
+		echo "VDbench Test: FAILED";exit 1
+	fi
+	sudo umount /mnt/store
+else
+	echo "Unable to detect iSCSI device, login failed"; exit 1
+fi
+logout_of_volume
+
+# TEST#3: Run the libiscsi compliance suite on Jiva Vol
+echo "Run the libiscsi compliance suite on Jiva Vol"
+sudo mkdir /mnt/logs
+sudo docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip 172.18.0.2"
+tp=$(grep "PASSED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
+tf=$(grep "FAILED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
+if [ $tp -ge 146 ] && [ $tf -le 29 ]; then
+	echo "iSCSI Compliance test: PASSED"
+else
+	echo "iSCSI Compliance test: FAILED"; exit 1
+fi
+
+# TEST#4: Test clone feature
+echo "Test clone feature"
 sudo docker run -d --net stg-net --ip 172.18.0.5 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI launch controller --frontend gotgt --frontendIP 172.18.0.5 store1
 sudo docker run -d -it --net stg-net --ip 172.18.0.6 -P --expose 9502-9504 -v /tmp/vol3:/vol3 $JI launch replica --type clone --snapName snap1 --cloneIP 172.18.0.2 --frontendIP 172.18.0.5 --listen 172.18.0.6:9502 --size 2g /vol3
 
@@ -114,16 +127,16 @@ clonestatus=`curl http://172.18.0.6:9502/v1/replicas/1 | jq '.clonestatus' | tr 
 
 i=0
 while [ -z $clonestatus ]; do
-        sleep 3
+	sleep 3
 	clonestatus=`curl http://172.18.0.6:9502/v1/replicas/1 | jq '.clonestatus' | tr -d '"'`
-        i=`expr $i + 1`
-        if [ $i -eq 20 ]; then
+	i=`expr $i + 1`
+	if [ $i -eq 20 ]; then
 		echo "Clone process took longer than usual"
-                exit 1;
-        else
+		exit 1;
+	else
 		echo "Waiting for clone process to complete"
-                continue
-        fi
+		continue
+	fi
 done
 
 # Display running containers
@@ -134,35 +147,22 @@ curl http://172.18.0.5:9501/v1/volumes
 
 # Discover Jiva iSCSI target and Login
 sleep 5
-sudo iscsiadm -m discovery -t st -p 172.18.0.5:3260
-sudo iscsiadm -m node -l
+login_to_volume "172.18.0.5:3260"
+get_scsi_disk
 
-# Wait for iSCSI device node (scsi device) to be created
-sleep 1
-sudo fdisk -l
-x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-echo $x
-
-i=0
-while [ -z $x ]; do
-        sleep 4
-        x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-        i=`expr $i + 1`
-        if [ $i -eq 5 ]; then
-                break
-        else
-                continue
-        fi
-done
-
-if [ "$x"!="" ]; then
-# Mount FS onto local mountpoint
-	sudo mount /dev/$x /mnt/store2
+if [ "$device_name"!="" ]; then
+	# Mount FS onto local mountpoint
+	sudo mount /dev/$device_name /mnt/store2
 
 	# TEST#1: Perform simple data-integrity check on Jiva Vol
 	hash3=$(sudo md5sum /mnt/store2/file1 | awk '{print $1}')
-	if [ $hash1 == $hash3 ]; then echo "DI Test: PASSED"
+	if [ $hash1 == $hash3 ]; then
+		sudo umount /mnt/store2
+		logout_of_volume
+		echo "DI Test: PASSED"
 	else
+		sudo umount /mnt/store2
+		logout_of_volume
 		echo "DI Test: FAILED"; exit 1
 	fi
 else

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -68,7 +68,10 @@ if [ "$x"!="" ]; then
         fi
 
 	#Create a snapshot for testing clone feature
-	cd /mnt/store; sync;
+	cd /mnt/store; sync; sleep 5; sync; sleep 5; cd ~;
+	sudo blockdev --flushbufs /dev/$x
+	sudo hdparm -F /dev/$x
+	sleep 5
 	id=`curl http://172.18.0.2:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
 	curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://172.18.0.2:9501/v1/volumes/$id?action=snapshot
 

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -20,12 +20,14 @@ sudo docker ps
 
 # Create a local mountpoint
 sudo mkdir -p /mnt/store
+sudo mkdir -p /mnt/store2
 
 # Cleanup existing iSCSI sessions
 sudo iscsiadm -m node -u
 sudo iscsiadm -m node -o delete
 
 # Discover Jiva iSCSI target and Login
+sleep 1
 sudo iscsiadm -m discovery -t st -p 172.18.0.2:3260
 sudo iscsiadm -m node -l
 
@@ -128,6 +130,7 @@ sudo docker ps
 curl http://172.18.0.5:9501/v1/volumes
 
 # Discover Jiva iSCSI target and Login
+sleep 5
 sudo iscsiadm -m discovery -t st -p 172.18.0.5:3260
 sudo iscsiadm -m node -l
 
@@ -141,7 +144,7 @@ i=0
 while [ -z $x ]; do
         sleep 4
         x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-        i=`expr $i+1`
+        i=`expr $i + 1`
         if [ $i -eq 5 ]; then
                 break
         else
@@ -151,10 +154,10 @@ done
 
 if [ "$x"!="" ]; then
 # Mount FS onto local mountpoint
-	sudo mount /dev/$x /mnt/store
+	sudo mount /dev/$x /mnt/store2
 
 	# TEST#1: Perform simple data-integrity check on Jiva Vol
-	hash3=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
+	hash3=$(sudo md5sum /mnt/store2/file1 | awk '{print $1}')
 	if [ $hash1 == $hash3 ]; then echo "DI Test: PASSED"
 	else
 		echo "DI Test: FAILED"; exit 1

--- a/controller/control.go
+++ b/controller/control.go
@@ -585,7 +585,7 @@ func (c *Controller) Start(addresses ...string) error {
 		}
 	getCloneStatus:
 		if status, _ := c.backend.GetCloneStatus(address); status != "completed" && status != "NA" {
-			fmt.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
+			logrus.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
 			time.Sleep(2 * time.Second)
 			goto getCloneStatus
 		}

--- a/controller/control.go
+++ b/controller/control.go
@@ -583,6 +583,12 @@ func (c *Controller) Start(addresses ...string) error {
 		if err := c.addReplicaNoLock(newBackend, address, false); err != nil {
 			return err
 		}
+	getCloneStatus:
+		if status, _ := c.backend.GetCloneStatus(address); status != "completed" && status != "NA" {
+			fmt.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
+			time.Sleep(2 * time.Second)
+			goto getCloneStatus
+		}
 		// We will validate this later
 		c.setReplicaModeNoLock(address, types.RW)
 	}

--- a/controller/control.go
+++ b/controller/control.go
@@ -535,8 +535,12 @@ func (c *Controller) startFrontend() error {
 }
 
 func (c *Controller) Start(addresses ...string) error {
-	var expectedRevision int64
-	var sendSignal int
+	var (
+		expectedRevision int64
+		sendSignal       int
+		status           string
+		err1             error
+	)
 
 	c.Lock()
 	defer c.Unlock()
@@ -584,10 +588,15 @@ func (c *Controller) Start(addresses ...string) error {
 			return err
 		}
 	getCloneStatus:
-		if status, _ := c.backend.GetCloneStatus(address); status != "completed" && status != "NA" {
+		if status, err1 = c.backend.GetCloneStatus(address); err1 != nil {
+			return err1
+		}
+		if status == "" || status == "inProgress" {
 			logrus.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
 			time.Sleep(2 * time.Second)
 			goto getCloneStatus
+		} else if status == "error" {
+			return fmt.Errorf("Replica clone status returned error")
 		}
 		// We will validate this later
 		c.setReplicaModeNoLock(address, types.RW)

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -430,3 +430,18 @@ func (r *replicator) GetRevisionCounter(address string) (int64, error) {
 
 	return counter, nil
 }
+
+func (r *replicator) GetCloneStatus(address string) (string, error) {
+	backend, ok := r.backends[address]
+	if !ok {
+		return "", fmt.Errorf("Cannot find backend %v", address)
+	}
+
+	status, err := backend.backend.GetCloneStatus()
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Get backend %s clone status", address)
+
+	return status, nil
+}

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -168,6 +168,17 @@ func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	return replica, err
 }
 
+func (c *ReplicaClient) UpdateCloneInfo(snapName string) (rest.Replica, error) {
+	var replica rest.Replica
+
+	input := &rest.CloneUpdateInput{
+		SnapName: snapName,
+	}
+
+	err := c.post(c.address+"/replicas/1?action=updatecloneinfo", input, &replica)
+	return replica, err
+}
+
 func (c *ReplicaClient) LaunchReceiver(toFilePath string) (string, int, error) {
 	var running agent.Process
 	err := c.post(c.syncAgent+"/processes", &agent.Process{

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -325,10 +325,7 @@ func (r *Replica) UpdateCloneInfo(snapName string) error {
 		return err
 	}
 	r.diskData[r.info.Head].Parent = r.info.Parent
-	if err := r.encodeToFile(r.diskData[r.info.Head], r.info.Head+metadataSuffix); err != nil {
-		return err
-	}
-	return nil
+	return r.encodeToFile(r.diskData[r.info.Head], r.info.Head+metadataSuffix)
 }
 
 func (r *Replica) findDisk(name string) int {
@@ -1066,10 +1063,8 @@ func (r *Replica) SetCloneStatus(status string) error {
 	defer r.Unlock()
 	r.cloneStatus = status
 	r.info.CloneStatus = status
-	if err := r.encodeToFile(&r.info, volumeMetaData); err != nil {
-		return err
-	}
-	return nil
+
+	return r.encodeToFile(&r.info, volumeMetaData)
 }
 
 func (r *Replica) getDiskSize(disk string) int64 {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -58,6 +58,10 @@ type Replica struct {
 	peerLock  sync.Mutex
 	peerCache types.PeerDetails
 	peerFile  *sparse.DirectFileIoProcessor
+
+	cloneStatus   string
+	CloneSnapName string
+	Clone         bool
 }
 
 type Info struct {
@@ -68,6 +72,7 @@ type Info struct {
 	Parent          string
 	SectorSize      int64
 	BackingFileName string
+	CloneStatus     string
 	BackingFile     *BackingFile `json:"-"`
 }
 
@@ -211,7 +216,6 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 			return nil, err
 		}
 	}
-
 	r.info.Parent = r.diskData[r.info.Head].Parent
 
 	r.insertBackingFile()
@@ -313,6 +317,18 @@ func (r *Replica) Reload() (*Replica, error) {
 	}
 	newReplica.info.Dirty = r.info.Dirty
 	return newReplica, nil
+}
+
+func (r *Replica) UpdateCloneInfo(snapName string) error {
+	r.info.Parent = "volume-snap-" + snapName + ".img"
+	if err := r.encodeToFile(&r.info, volumeMetaData); err != nil {
+		return err
+	}
+	r.diskData[r.info.Head].Parent = r.info.Parent
+	if err := r.encodeToFile(r.diskData[r.info.Head], r.info.Head+metadataSuffix); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *Replica) findDisk(name string) int {
@@ -856,11 +872,13 @@ func (r *Replica) openLiveChain() error {
 	}
 
 	for i := len(chain) - 1; i >= 0; i-- {
+
 		parent := chain[i]
 		f, err := r.openFile(parent, 0)
 		if err != nil {
 			return err
 		}
+
 		r.volume.files = append(r.volume.files, f)
 		r.activeDiskData = append(r.activeDiskData, r.diskData[parent])
 	}
@@ -900,6 +918,7 @@ func (r *Replica) readMetadata() (bool, error) {
 			}
 		}
 	}
+
 	r.volume.UsedBlocks += 2 // One each for peer.details and revision.counter
 
 	return len(r.diskData) > 0, nil
@@ -992,20 +1011,6 @@ func (r *Replica) WriteAt(buf []byte, offset int64) (int, error) {
 	return c, nil
 }
 
-/*
-func (r *Replica) Update() error {
-	if r.readOnly {
-		return fmt.Errorf("Can not write on read-only replica")
-	}
-
-	r.info.Dirty = true
-	if err := r.increaseRevisionCounter(); err != nil {
-		return err
-	}
-	return nil
-}
-*/
-
 func (r *Replica) ReadAt(buf []byte, offset int64) (int, error) {
 	r.RLock()
 	c, err := r.volume.ReadAt(buf, offset)
@@ -1043,6 +1048,28 @@ func (r *Replica) GetRemainSnapshotCounts() int {
 	defer r.RUnlock()
 
 	return maximumChainLength - len(r.activeDiskData)
+}
+
+func (r *Replica) GetCloneStatus() string {
+	var info Info
+	r.RLock()
+	defer r.RUnlock()
+	if err := r.unmarshalFile(volumeMetaData, &info); err != nil {
+		return ""
+	}
+
+	return info.CloneStatus
+}
+
+func (r *Replica) SetCloneStatus(status string) error {
+	r.Lock()
+	defer r.Unlock()
+	r.cloneStatus = status
+	r.info.CloneStatus = status
+	if err := r.encodeToFile(&r.info, volumeMetaData); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (r *Replica) getDiskSize(disk string) int64 {

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -24,6 +24,7 @@ type Replica struct {
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
+	CloneStatus       string                      `json:"clonestatus"`
 }
 
 type Stats struct {
@@ -53,6 +54,11 @@ type SnapshotInput struct {
 	Name        string `json:"name"`
 	UserCreated bool   `json:"usercreated"`
 	Created     string `json:"created"`
+}
+
+type CloneUpdateInput struct {
+	client.Resource
+	SnapName string `json:"snapname"`
 }
 
 type RemoveDiskInput struct {
@@ -128,6 +134,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["start"] = true
 		actions["create"] = true
 		actions["resize"] = true
+		actions["updatecloneinfo"] = true
 	case replica.Open:
 		actions["start"] = true
 		actions["resize"] = true
@@ -141,6 +148,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["revert"] = true
 		actions["prepareremovedisk"] = true
 		actions["setrevisioncounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["setreplicacounter"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Closed:
@@ -150,6 +158,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["removedisk"] = true
 		actions["replacedisk"] = true
 		actions["revert"] = true
+		actions["updatecloneinfo"] = true
 		actions["prepareremovedisk"] = true
 		actions["setreplicacounter"] = true
 	case replica.Dirty:
@@ -164,6 +173,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["revert"] = true
 		actions["prepareremovedisk"] = true
 		actions["setreplicacounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Rebuilding:
 		actions["start"] = true
@@ -174,6 +184,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["reload"] = true
 		actions["setrevisioncounter"] = true
 		actions["setreplicacounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Error:
 	}
@@ -194,6 +205,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.Disks = rep.ListDisks()
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
+		r.CloneStatus = rep.GetCloneStatus()
 	}
 
 	return r

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -216,6 +216,15 @@ func (s *Server) ReloadReplica(rw http.ResponseWriter, req *http.Request) error 
 	return s.doOp(req, s.s.Reload())
 }
 
+func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) error {
+	var input CloneUpdateInput
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil && err != io.EOF {
+		return err
+	}
+	return s.doOp(req, s.s.UpdateCloneInfo(input.SnapName))
+}
+
 func (s *Server) CloseReplica(rw http.ResponseWriter, req *http.Request) error {
 	return s.doOp(req, s.s.Close())
 }

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -1,12 +1,13 @@
 package rest
 
 import (
+	"net/http"
+	_ "net/http/pprof" /* for profiling */
+
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
-	"net/http"
-	_ "net/http/pprof" /* for profiling */
 )
 
 func HandleError(s *client.Schemas, t func(http.ResponseWriter, *http.Request) error) http.Handler {
@@ -58,6 +59,7 @@ func NewRouter(s *Server) *mux.Router {
 	actions := map[string]func(http.ResponseWriter, *http.Request) error{
 		"start":              s.StartReplica,
 		"reload":             s.ReloadReplica,
+		"updatecloneinfo":    s.UpdateCloneInfo,
 		"snapshot":           s.SnapshotReplica,
 		"open":               s.OpenReplica,
 		"close":              s.CloseReplica,

--- a/replica/server.go
+++ b/replica/server.go
@@ -76,6 +76,7 @@ func (s *Server) Create(size int64) error {
 	state, _ := s.Status()
 
 	if state != Initial {
+		fmt.Println("STATE = ", state)
 		return nil
 	}
 
@@ -130,6 +131,18 @@ func (s *Server) Reload() error {
 	s.r = newReplica
 	oldReplica.Close()
 	return nil
+}
+
+func (s *Server) UpdateCloneInfo(snapName string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.r == nil {
+		return nil
+	}
+
+	logrus.Infof("Update Clone Info")
+	return s.r.UpdateCloneInfo(snapName)
 }
 
 func (s *Server) Status() (State, Info) {
@@ -318,19 +331,6 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
 }
-
-/*
-func (s *Server) Update() error {
-	s.RLock()
-	defer s.RUnlock()
-
-	if s.r == nil {
-		return fmt.Errorf("Volume no longer exist")
-	}
-	err := s.r.Update()
-	return err
-}
-*/
 
 func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	s.RLock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -216,7 +216,7 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 		ControllerClient := client.NewControllerClient(url)
 		reps, err := ControllerClient.ListReplicas()
 		if err != nil {
-			fmt.Errorf("Failed to get replica list from %s, retry after 2s", url)
+			logrus.Errorf("Failed to get replica list from %s, retry after 2s", url)
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -229,7 +229,7 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 		}
 
 		if fromReplica.Mode == "" {
-			fmt.Errorf("No RW replica found at %s, retry after 2s", url)
+			logrus.Errorf("No RW replica found at %s, retry after 2s", url)
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -265,7 +265,7 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 			return fmt.Errorf("Snapshot Not found at source")
 		}
 		if err = t.syncFiles(fromClient, toClient, chain); err != nil {
-			fmt.Errorf("Sync failed, retry after 2s")
+			logrus.Errorf("Sync failed, retry after 2s")
 			time.Sleep(2 * time.Second)
 			continue
 		}

--- a/types/types.go
+++ b/types/types.go
@@ -36,6 +36,7 @@ type Backend interface {
 	SectorSize() (int64, error)
 	RemainSnapshots() (int, error)
 	GetRevisionCounter() (int64, error)
+	GetCloneStatus() (string, error)
 	GetVolUsage() (VolUsage, error)
 	SetRevisionCounter(counter int64) error
 	UpdatePeerDetails(replicaCount int, quorumReplicaCount int) error


### PR DESCRIPTION
Enhance jiva for clone feature  …
1. This PR will add sync and rebuild capabilities in jiva as clone feature.
2. Now clone volume can be created from the running replicas volume and can be further used as RO/RW mode.
3. There is 3 new flags has been added, which has to passed while starting a clone replica with a new jiva-controller, to be clone to a particular snapshot.
- `cloneIP` : This is frontendIP of running controller, which will be used to make a clone request will be passed as a argument while starting clone replica.
- `clone`: Type of replica, now we can pass type as `clone` to trigger the clone API of jiva, which says the new replica is getting added as clone not as usual replica.
- `snapName` : Name of the  snapshot which will be synced to a new volume.