### PR TITLE
Remove iSCSI session from node before starting libiscsi test suite

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -72,6 +72,10 @@ if [ "$x"!="" ]; then
         else
             echo "VDbench Test: FAILED";exit 1
         fi
+	# Remove iSCSI session
+	sudo umount /mnt/store
+	sudo iscsiadm -m node -u
+	sudo iscsiadm -m node -o delete
 
         # TEST#3: Run the libiscsi compliance suite on Jiva Vol
         sudo mkdir /mnt/logs 


### PR DESCRIPTION
This will avoid the use of same iSCSI volume by two initiators.
Signed-off-by: Payes <payes.anand@cloudbyte.com>