### PR TITLE
Jiva replica clone feature

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -15,7 +15,7 @@ ENV TRASH_CACHE ${DAPPER_SOURCE}/.trash-cache
 WORKDIR ${DAPPER_SOURCE}
 
 # Install packages
-RUN apt-get update && \
+RUN apt-get update -o Acquire::CompressionTypes::Order::=gz && apt-get update && \
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
@@ -27,15 +27,11 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.7.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-    DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
-    DOCKER_URL=DOCKER_URL_${ARCH}
-
-RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
+RUN curl -sSL https://get.docker.com | bash && chmod +x /usr/bin/docker
 
 # Build TCMU
 RUN cd /usr/src && \

--- a/app/replica.go
+++ b/app/replica.go
@@ -18,6 +18,7 @@ import (
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/replica/rpc"
+	"github.com/openebs/jiva/sync"
 	"github.com/openebs/jiva/util"
 )
 
@@ -32,6 +33,14 @@ func ReplicaCmd() cli.Command {
 			},
 			cli.StringFlag{
 				Name:  "frontendIP",
+				Value: "",
+			},
+			cli.StringFlag{
+				Name:  "cloneIP",
+				Value: "",
+			},
+			cli.StringFlag{
+				Name:  "snapName",
 				Value: "",
 			},
 			cli.StringFlag{
@@ -92,6 +101,19 @@ checkagain:
 	}
 }
 
+func CloneReplica(s *replica.Server, address string, cloneIP string, snapName string) error {
+	var err error
+	url := "http://" + cloneIP + ":9501"
+	task := sync.NewTask(url)
+	if err = task.CloneReplica(url, address, cloneIP, snapName); err != nil {
+		return err
+	}
+	if s.Replica() != nil {
+		s.Replica().SetCloneStatus("completed")
+	}
+	return err
+}
+
 func startReplica(c *cli.Context) error {
 	if c.NArg() != 1 {
 		return errors.New("directory name is required")
@@ -108,6 +130,8 @@ func startReplica(c *cli.Context) error {
 
 	address := c.String("listen")
 	frontendIP := c.String("frontendIP")
+	cloneIP := c.String("cloneIP")
+	snapName := c.String("snapName")
 	size := c.String("size")
 	if size != "" {
 		//Units bails with an error size is provided with i, like Gi
@@ -189,6 +213,24 @@ func startReplica(c *cli.Context) error {
 			address = "localhost:9502"
 		}
 		go AutoConfigureReplica(s, frontendIP, "tcp://"+address, replicaType)
+	}
+	for s.Replica() == nil {
+		time.Sleep(2 * time.Second)
+	}
+	if replicaType == "clone" && snapName != "" {
+		logrus.Infof("Starting clone process\n")
+		status := s.Replica().GetCloneStatus()
+		if status != "completed" {
+			s.Replica().SetCloneStatus("inProgress")
+			if err = CloneReplica(s, "tcp://"+address, cloneIP, snapName); err != nil {
+				s.Replica().SetCloneStatus("error")
+				return err
+			}
+		}
+		s.Replica().SetCloneStatus("completed")
+		logrus.Infof("Clone process completed successfully\n")
+	} else {
+		s.Replica().SetCloneStatus("NA")
 	}
 
 	return <-resp

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -86,6 +86,10 @@ func (f *Wrapper) GetMonitorChannel() types.MonitorChannel {
 	return nil
 }
 
+func (f *Wrapper) GetCloneStatus() (string, error) {
+	return "", nil
+}
+
 func (f *Wrapper) PingResponse() error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -147,6 +147,14 @@ func (r *Remote) GetRevisionCounter() (int64, error) {
 	return counter, nil
 }
 
+func (r *Remote) GetCloneStatus() (string, error) {
+	replica, err := r.info()
+	if err != nil {
+		return "", err
+	}
+	return replica.CloneStatus, nil
+}
+
 func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	var Details rest.VolUsage
 	var volUsage types.VolUsage

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -5,8 +5,11 @@ JI=$(sudo docker images | grep openebs/jiva | awk '{print $1":"$2}')
 echo "Run CI tests on $JI"
 
 # Prepare environment to run Jiva containers
+sudo rm -rf /tmp/vol*
+sudo rm -rf /mnt/logs
 mkdir /tmp/vol1
 mkdir /tmp/vol2
+mkdir /tmp/vol3
 sudo docker network create --subnet=172.18.0.0/16 stg-net
 
 # Start Jiva controller and replicas in detached mode
@@ -15,75 +18,153 @@ sudo docker run -d -it --net stg-net --ip 172.18.0.3 -P --expose 9502-9504 -v /t
 sudo docker run -d -it --net stg-net --ip 172.18.0.4 -P --expose 9502-9504 -v /tmp/vol2:/vol2 $JI launch replica --frontendIP 172.18.0.2 --listen 172.18.0.4:9502 --size 2g /vol2
 
 # Display running containers
-sudo docker ps 
+sudo docker ps
 
 # Create a local mountpoint
 sudo mkdir -p /mnt/store
+sudo mkdir -p /mnt/store2
 
 # Cleanup existing iSCSI sessions
-sudo iscsiadm -m node -u
-sudo iscsiadm -m node -o delete
+logout_of_volume() {
+	sudo iscsiadm -m node -u
+	sudo iscsiadm -m node -o delete
+}
 
-# Discover Jiva iSCSI target and Login 
-sudo iscsiadm -m discovery -t st -p 172.18.0.2:3260
-sudo iscsiadm -m node -l
+# Discover Jiva iSCSI target and Login
+login_to_volume() {
+	sudo iscsiadm -m discovery -t st -p $1
+	sudo iscsiadm -m node -l
+}
 
-# Wait for iSCSI device node (scsi device) to be created 
-sleep 1
-sudo fdisk -l
-x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-echo $x
+# Wait for iSCSI device node (scsi device) to be created
+get_scsi_disk() {
+	device_name=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+	i=0
+	while [ -z $device_name ]; do
+		sleep 4
+		device_name=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
+		i=`expr $i + 1`
+		if [ $i -eq 10 ]; then
+			echo "scsi disk not found";
+			exit;
+		else
+			continue;
+		fi
+	done
+}
+
+login_to_volume "172.18.0.2:3260"
+sleep 5
+get_scsi_disk
+if [ "$device_name"!="" ]; then
+	# Format disk as ext2 FS
+	sudo mkfs.ext2 -F /dev/$device_name
+
+	# Mount FS onto local mountpoint
+	sudo mount /dev/$device_name /mnt/store
+
+	# TEST#1: Perform simple data-integrity check on Jiva Vol
+	sudo dd if=/dev/urandom of=file1 bs=4k count=10000
+	hash1=$(sudo md5sum file1 | awk '{print $1}')
+	sudo cp file1 /mnt/store
+	hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
+	if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
+	else
+		echo "DI Test: FAILED"; exit 1
+	fi
+
+	cd /mnt/store; sync; sleep 5; sync; sleep 5; cd ~;
+	sudo blockdev --flushbufs /dev/$device_name
+	sudo hdparm -F /dev/$device_name
+	sudo umount /mnt/store
+	logout_of_volume
+	sleep 5
+else
+	echo "Unable to detect iSCSI device, login failed"; exit 1
+fi
+
+#Create a snapshot for testing clone feature
+id=`curl http://172.18.0.2:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
+curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://172.18.0.2:9501/v1/volumes/$id?action=snapshot
+
+# TEST#2: Perform a random I/O workload test on Jiva Vol
+login_to_volume "172.18.0.2:3260"
+sleep 5
+get_scsi_disk
+if [ "$device_name"!="" ]; then
+	sudo mount /dev/$device_name /mnt/store
+	sudo mkdir -p /mnt/store/data
+	sudo chown 777 /mnt/store/data
+	sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
+	if [ $? -eq 0 ]; then echo "VDbench Test: PASSED"
+	else
+		echo "VDbench Test: FAILED";exit 1
+	fi
+	sudo umount /mnt/store
+else
+	echo "Unable to detect iSCSI device, login failed"; exit 1
+fi
+logout_of_volume
+
+# TEST#3: Run the libiscsi compliance suite on Jiva Vol
+echo "Run the libiscsi compliance suite on Jiva Vol"
+sudo mkdir /mnt/logs
+sudo docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip 172.18.0.2"
+tp=$(grep "PASSED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
+tf=$(grep "FAILED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
+if [ $tp -ge 146 ] && [ $tf -le 29 ]; then
+	echo "iSCSI Compliance test: PASSED"
+else
+	echo "iSCSI Compliance test: FAILED"; exit 1
+fi
+
+# TEST#4: Test clone feature
+echo "Test clone feature"
+sudo docker run -d --net stg-net --ip 172.18.0.5 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI launch controller --frontend gotgt --frontendIP 172.18.0.5 store1
+sudo docker run -d -it --net stg-net --ip 172.18.0.6 -P --expose 9502-9504 -v /tmp/vol3:/vol3 $JI launch replica --type clone --snapName snap1 --cloneIP 172.18.0.2 --frontendIP 172.18.0.5 --listen 172.18.0.6:9502 --size 2g /vol3
+
+clonestatus=`curl http://172.18.0.6:9502/v1/replicas/1 | jq '.clonestatus' | tr -d '"'`
 
 i=0
-while x==""; do
-        sleep 4
-        x=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
-        i=i+1
-        if i==5; then
-                break
-        else
-                continue
-        fi
+while [ -z $clonestatus ]; do
+	sleep 3
+	clonestatus=`curl http://172.18.0.6:9502/v1/replicas/1 | jq '.clonestatus' | tr -d '"'`
+	i=`expr $i + 1`
+	if [ $i -eq 20 ]; then
+		echo "Clone process took longer than usual"
+		exit 1;
+	else
+		echo "Waiting for clone process to complete"
+		continue
+	fi
 done
 
-# Start tests once (i)SCSI device is detected
-if [ "$x"!="" ]; then
-        # Format disk as ext2 FS
-        sudo mkfs.ext2 -F /dev/$x
+# Display running containers
+sudo docker ps
 
-        # Mount FS onto local mountpoint
-        sudo mount /dev/$x /mnt/store
+# Display volume info
+curl http://172.18.0.5:9501/v1/volumes
 
-        # TEST#1: Perform simple data-integrity check on Jiva Vol
-        sudo dd if=/dev/urandom of=file1 bs=4k count=10000
-        hash1=$(sudo md5sum file1 | awk '{print $1}')
-        sudo cp file1 /mnt/store
-        hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
-        if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
-        else 
-            echo "DI Test: FAILED"; exit 1
-        fi
+# Discover Jiva iSCSI target and Login
+sleep 5
+login_to_volume "172.18.0.5:3260"
+get_scsi_disk
 
-        # TEST#2: Perform a random I/O workload test on Jiva Vol
-        sudo mkdir -p /mnt/store/data
-        sudo chown 777 /mnt/store/data
-        sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
-        if [ $? -eq 0 ]; then echo "VDbench Test: PASSED"
-        else
-            echo "VDbench Test: FAILED";exit 1
-        fi
+if [ "$device_name"!="" ]; then
+	# Mount FS onto local mountpoint
+	sudo mount /dev/$device_name /mnt/store2
 
-        # TEST#3: Run the libiscsi compliance suite on Jiva Vol
-        sudo mkdir /mnt/logs 
-        sudo docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip 172.18.0.2"
-        tp=$(grep "PASSED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
-        tf=$(grep "FAILED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
-        if [ $tp -ge 146 ] && [ $tf -le 29 ]; then
-            echo "iSCSI Compliance test: PASSED"
-        else 
-            echo "iSCSI Compliance test: FAILED"; exit 1
-        fi
-else 
-        echo "Unable to detect iSCSI device, login failed"; exit 1
-fi 
-
+	# TEST#1: Perform simple data-integrity check on Jiva Vol
+	hash3=$(sudo md5sum /mnt/store2/file1 | awk '{print $1}')
+	if [ $hash1 == $hash3 ]; then
+		sudo umount /mnt/store2
+		logout_of_volume
+		echo "DI Test: PASSED"
+	else
+		sudo umount /mnt/store2
+		logout_of_volume
+		echo "DI Test: FAILED"; exit 1
+	fi
+else
+	echo "Unable to detect iSCSI device, login failed"; exit 1
+fi

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -430,3 +430,18 @@ func (r *replicator) GetRevisionCounter(address string) (int64, error) {
 
 	return counter, nil
 }
+
+func (r *replicator) GetCloneStatus(address string) (string, error) {
+	backend, ok := r.backends[address]
+	if !ok {
+		return "", fmt.Errorf("Cannot find backend %v", address)
+	}
+
+	status, err := backend.backend.GetCloneStatus()
+	if err != nil {
+		return "", err
+	}
+	logrus.Infof("Get backend %s clone status", address)
+
+	return status, nil
+}

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -168,6 +168,17 @@ func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	return replica, err
 }
 
+func (c *ReplicaClient) UpdateCloneInfo(snapName string) (rest.Replica, error) {
+	var replica rest.Replica
+
+	input := &rest.CloneUpdateInput{
+		SnapName: snapName,
+	}
+
+	err := c.post(c.address+"/replicas/1?action=updatecloneinfo", input, &replica)
+	return replica, err
+}
+
 func (c *ReplicaClient) LaunchReceiver(toFilePath string) (string, int, error) {
 	var running agent.Process
 	err := c.post(c.syncAgent+"/processes", &agent.Process{

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -24,6 +24,7 @@ type Replica struct {
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
+	CloneStatus       string                      `json:"clonestatus"`
 }
 
 type Stats struct {
@@ -53,6 +54,11 @@ type SnapshotInput struct {
 	Name        string `json:"name"`
 	UserCreated bool   `json:"usercreated"`
 	Created     string `json:"created"`
+}
+
+type CloneUpdateInput struct {
+	client.Resource
+	SnapName string `json:"snapname"`
 }
 
 type RemoveDiskInput struct {
@@ -128,6 +134,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["start"] = true
 		actions["create"] = true
 		actions["resize"] = true
+		actions["updatecloneinfo"] = true
 	case replica.Open:
 		actions["start"] = true
 		actions["resize"] = true
@@ -141,6 +148,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["revert"] = true
 		actions["prepareremovedisk"] = true
 		actions["setrevisioncounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["setreplicacounter"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Closed:
@@ -150,6 +158,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["removedisk"] = true
 		actions["replacedisk"] = true
 		actions["revert"] = true
+		actions["updatecloneinfo"] = true
 		actions["prepareremovedisk"] = true
 		actions["setreplicacounter"] = true
 	case replica.Dirty:
@@ -164,6 +173,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["revert"] = true
 		actions["prepareremovedisk"] = true
 		actions["setreplicacounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Rebuilding:
 		actions["start"] = true
@@ -174,6 +184,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["reload"] = true
 		actions["setrevisioncounter"] = true
 		actions["setreplicacounter"] = true
+		actions["updatecloneinfo"] = true
 		actions["updatepeerdetails"] = true
 	case replica.Error:
 	}
@@ -194,6 +205,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.Disks = rep.ListDisks()
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
+		r.CloneStatus = rep.GetCloneStatus()
 	}
 
 	return r

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -216,6 +216,15 @@ func (s *Server) ReloadReplica(rw http.ResponseWriter, req *http.Request) error 
 	return s.doOp(req, s.s.Reload())
 }
 
+func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) error {
+	var input CloneUpdateInput
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil && err != io.EOF {
+		return err
+	}
+	return s.doOp(req, s.s.UpdateCloneInfo(input.SnapName))
+}
+
 func (s *Server) CloseReplica(rw http.ResponseWriter, req *http.Request) error {
 	return s.doOp(req, s.s.Close())
 }

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -1,12 +1,13 @@
 package rest
 
 import (
+	"net/http"
+	_ "net/http/pprof" /* for profiling */
+
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
-	"net/http"
-	_ "net/http/pprof" /* for profiling */
 )
 
 func HandleError(s *client.Schemas, t func(http.ResponseWriter, *http.Request) error) http.Handler {
@@ -58,6 +59,7 @@ func NewRouter(s *Server) *mux.Router {
 	actions := map[string]func(http.ResponseWriter, *http.Request) error{
 		"start":              s.StartReplica,
 		"reload":             s.ReloadReplica,
+		"updatecloneinfo":    s.UpdateCloneInfo,
 		"snapshot":           s.SnapshotReplica,
 		"open":               s.OpenReplica,
 		"close":              s.CloseReplica,

--- a/replica/server.go
+++ b/replica/server.go
@@ -76,6 +76,7 @@ func (s *Server) Create(size int64) error {
 	state, _ := s.Status()
 
 	if state != Initial {
+		fmt.Println("STATE = ", state)
 		return nil
 	}
 
@@ -130,6 +131,18 @@ func (s *Server) Reload() error {
 	s.r = newReplica
 	oldReplica.Close()
 	return nil
+}
+
+func (s *Server) UpdateCloneInfo(snapName string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.r == nil {
+		return nil
+	}
+
+	logrus.Infof("Update Clone Info")
+	return s.r.UpdateCloneInfo(snapName)
 }
 
 func (s *Server) Status() (State, Info) {
@@ -318,19 +331,6 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
 }
-
-/*
-func (s *Server) Update() error {
-	s.RLock()
-	defer s.RUnlock()
-
-	if s.r == nil {
-		return fmt.Errorf("Volume no longer exist")
-	}
-	err := s.r.Update()
-	return err
-}
-*/
 
 func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	s.RLock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -207,6 +207,81 @@ Register:
 	return nil
 }
 
+func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName string) error {
+	var (
+		fromReplica rest.Replica
+		snapFound   bool
+	)
+	for {
+		ControllerClient := client.NewControllerClient(url)
+		reps, err := ControllerClient.ListReplicas()
+		if err != nil {
+			logrus.Errorf("Failed to get replica list from %s, retry after 2s", url)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		for _, rep := range reps {
+			if rep.Mode == "RW" {
+				fromReplica = rep
+				break
+			}
+		}
+
+		if fromReplica.Mode == "" {
+			logrus.Errorf("No RW replica found at %s, retry after 2s", url)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+
+		fromClient, err := replicaClient.NewReplicaClient(fromReplica.Address)
+		if err != nil {
+			return fmt.Errorf("Failed to create fromClient %s", err)
+		}
+
+		repl, err := fromClient.GetReplica()
+		if err != nil {
+			return fmt.Errorf("fromClient.GetReplica() failed, %s", err)
+		}
+		chain := repl.Chain
+
+		logrus.Infof("Using replica %s as the source for rebuild ", fromReplica.Address)
+
+		toClient, err := replicaClient.NewReplicaClient(address)
+		if err != nil {
+			return fmt.Errorf("Failed to create toClient %s", err)
+		}
+		if err := toClient.SetRebuilding(true); err != nil {
+			return fmt.Errorf("Failed to setRebuilding = true, %s", err)
+		}
+		for i, name := range chain {
+			if name == "volume-snap-"+snapName+".img" {
+				snapFound = true
+				chain = chain[i:]
+				break
+			}
+		}
+		if snapFound == false {
+			return fmt.Errorf("Snapshot Not found at source")
+		}
+		if err = t.syncFiles(fromClient, toClient, chain); err != nil {
+			logrus.Errorf("Sync failed, retry after 2s")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		toClient.UpdateCloneInfo(snapName)
+
+		_, err = toClient.ReloadReplica()
+		if err != nil {
+			return fmt.Errorf("Failed to reload replica %s", err)
+		}
+		if err := toClient.SetRebuilding(false); err != nil {
+			return fmt.Errorf("Failed to setRebuilding = false")
+		}
+		return err
+	}
+}
+
 func (t *Task) AddReplica(replicaAddress string) error {
 	var action string
 

--- a/types/types.go
+++ b/types/types.go
@@ -36,6 +36,7 @@ type Backend interface {
 	SectorSize() (int64, error)
 	RemainSnapshots() (int, error)
 	GetRevisionCounter() (int64, error)
+	GetCloneStatus() (string, error)
 	GetVolUsage() (VolUsage, error)
 	SetRevisionCounter(counter int64) error
 	UpdatePeerDetails(replicaCount int, quorumReplicaCount int) error


### PR DESCRIPTION
Now cloned volumes can be created from running volumes and can further be used in RO/RW mode.
Two new flags have been added to replica start-script for this feature:
 --cloneIP  : This is the service IP of the controller which exposes the volume to be cloned.
 --snapName : Name of the snapshot which needs to be cloned.
A new replica type "--type clone" has been added.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>