### PR TITLE
Fix typo on rpc client.go

### DIFF
--- a/rpc/client.go
+++ b/rpc/client.go
@@ -142,7 +142,7 @@ func (c *Client) operation(op uint32, buf []byte, offset int64) (int, error) {
 		case <-timeout:
 			switch msg.Type {
 			case TypeRead:
-				logrus.Errorln("Read timeout on replcia", c.TargetID(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
+				logrus.Errorln("Read timeout on replica", c.TargetID(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
 			case TypeWrite:
 				logrus.Errorln("Write timeout on replica", c.TargetID(), "seq=", msg.Seq, "size=", len(msg.Data)/1024, "(kB)")
 			case TypePing:


### PR DESCRIPTION
Fix typo on rpc client.go