### PR TITLE
Delay error response by 1 second when volume is in read only state

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -657,6 +657,7 @@ func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 	if c.ReadOnly == true {
 		err := fmt.Errorf("Mode: ReadOnly")
 		c.RUnlock()
+		time.Sleep(1 * time.Second)
 		return 0, err
 	}
 	if off < 0 || off+int64(len(b)) > c.size {

--- a/controller/control.go
+++ b/controller/control.go
@@ -652,6 +652,9 @@ func (c *Controller) Start(addresses ...string) error {
 	return nil
 }
 
+//Delaying error response by 1 second when volume is in read only state
+//This will avoid the iscsi disk at client side to go in read only mode even when IOs are not being served.
+//Above approach can hold the the app only for small amount of time based on the app.
 func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 	c.RLock()
 	if c.ReadOnly == true {

--- a/controller/control.go
+++ b/controller/control.go
@@ -654,7 +654,7 @@ func (c *Controller) Start(addresses ...string) error {
 
 // WriteAt is the interface which can be used to write data to jiva volumes
 // Delaying error response by 1 second when volume is in read only state, this will avoid
-// avoid the iscsi disk at client side to go in read only mode even when IOs
+// the iscsi disk at client side to go in read only mode even when IOs
 // are not being served.
 // Above approach can hold the the app only for small amount of time based
 // on the app.

--- a/controller/control.go
+++ b/controller/control.go
@@ -652,9 +652,12 @@ func (c *Controller) Start(addresses ...string) error {
 	return nil
 }
 
-//Delaying error response by 1 second when volume is in read only state
-//This will avoid the iscsi disk at client side to go in read only mode even when IOs are not being served.
-//Above approach can hold the the app only for small amount of time based on the app.
+// WriteAt is the interface which can be used to write data to jiva volumes
+// Delaying error response by 1 second when volume is in read only state, this will avoid
+// avoid the iscsi disk at client side to go in read only mode even when IOs
+// are not being served.
+// Above approach can hold the the app only for small amount of time based
+// on the app.
 func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 	c.RLock()
 	if c.ReadOnly == true {


### PR DESCRIPTION
This will avoid the iscsi disk at client side to go in read only mode even when IOs are not being served.
This can hold the the app only for small amount of time based on the app.
Signed-off-by: Payes <payes.anand@cloudbyte.com>