### PR TITLE
Improve logging to detect replica failures

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -236,12 +236,11 @@ func startReplica(c *cli.Context) error {
 	}
 	select {
 	case resp = <-controlResp:
-		logrus.Infof("Rest API exited: %v", resp)
+		logrus.Fatalf("Rest API exited: %v", resp)
 	case resp = <-rpcResp:
-		logrus.Infof("RPC listen exited: %v", resp)
+		logrus.Fatalf("RPC listen exited: %v", resp)
 	case resp = <-syncResp:
-		logrus.Infof("Sync process exited: %v", resp)
+		logrus.Fatalf("Sync process exited: %v", resp)
 	}
 	return resp
-
 }

--- a/controller/multi_writer_at.go
+++ b/controller/multi_writer_at.go
@@ -43,7 +43,7 @@ func (m *MultiWriterError) Error() string {
 }
 
 func (m *MultiWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
-	quorumErrs := make([]error, len(m.writers))
+	quorumErrs := make([]error, len(m.updaters))
 	replicaErrs := make([]error, len(m.writers))
 	replicaErrCount := 0
 	quorumErrCount := 0


### PR DESCRIPTION
This PR adds enhanced logging in the following scenarios:
1) When a replica registers at the controller
2) When a replica goes down because of the exit of one of its critical goroutines.
3) When the state of the volume is switched between R/W and R/O
Signed-off-by: Payes <payes.anand@cloudbyte.com>