### PR TITLE
rpc: Eliminate empty data transfer between client/server

### DIFF
--- a/rpc/server.go
+++ b/rpc/server.go
@@ -123,7 +123,9 @@ func (s *Server) createResponse(count int, msg *Message, err error) {
 	msg.Type = TypeResponse
 	if err == io.EOF {
 		msg.Type = TypeEOF
-		msg.Data = msg.Data[:count]
+		if msg.Data != nil {
+			msg.Data = msg.Data[:count]
+		}
 		msg.Size = uint32(len(msg.Data))
 	} else if err != nil {
 		msg.Type = TypeError

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -92,6 +92,7 @@ func (s *Server) Stop() {
 }
 
 func (s *Server) handleRead(msg *Message) {
+	msg.Data = make([]byte, msg.Size)
 	c, err := s.data.ReadAt(msg.Data, msg.Offset)
 	s.createResponse(c, msg, err)
 }
@@ -115,13 +116,19 @@ func (s *Server) handleUpdate(msg *Message) {
 
 func (s *Server) createResponse(count int, msg *Message, err error) {
 	msg.MagicVersion = MagicVersion
+	msg.Size = uint32(len(msg.Data))
+	if msg.Type == TypeWrite {
+		msg.Data = nil
+	}
 	msg.Type = TypeResponse
 	if err == io.EOF {
-		msg.Data = msg.Data[:count]
 		msg.Type = TypeEOF
+		msg.Data = msg.Data[:count]
+		msg.Size = uint32(len(msg.Data))
 	} else if err != nil {
 		msg.Type = TypeError
 		msg.Data = []byte(err.Error())
+		msg.Size = uint32(len(msg.Data))
 	}
 }
 

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -29,6 +29,7 @@ type Message struct {
 	Type         uint32
 	Offset       int64
 	Data         []byte
+	Size         uint32
 	transportErr error
 
 	ID journal.OpID //Seq and ID can apparently be collapsed into one (ID)

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -35,6 +35,9 @@ func (w *Wire) Write(msg *Message) error {
 	if err := binary.Write(w.writer, binary.LittleEndian, msg.Offset); err != nil {
 		return err
 	}
+	if err := binary.Write(w.writer, binary.LittleEndian, msg.Size); err != nil {
+		return err
+	}
 	if err := binary.Write(w.writer, binary.LittleEndian, uint32(len(msg.Data))); err != nil {
 		return err
 	}
@@ -67,6 +70,9 @@ func (w *Wire) Read() (*Message, error) {
 	}
 
 	if err := binary.Read(w.reader, binary.LittleEndian, &msg.Offset); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(w.reader, binary.LittleEndian, &msg.Size); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
We don't need data buffer for read request or write response, because they're
empty. For this purpose, we introduced `Size` in message struct. It will be the
intended size of read or write.

This PR has been picked from upstream.
https://github.com/rancher/longhorn-engine/commit/feb9f4b63e22702318a1bedd0912939fa9661e4a

Signed-off-by: Payes <payes.anand@cloudbyte.com>