### PR TITLE
Remove lock before signaling replica close

### DIFF
--- a/replica/server.go
+++ b/replica/server.go
@@ -310,18 +310,20 @@ func (s *Server) Delete() error {
 func (s *Server) Close(signalMonitor bool) error {
 	logrus.Infof("Closing replica")
 	s.Lock()
-	defer s.Unlock()
 
 	if s.r == nil {
 		logrus.Infof("Close replica failed, s.r not set")
+		s.Unlock()
 		return nil
 	}
 
 	if err := s.r.Close(); err != nil {
+		s.Unlock()
 		return err
 	}
 
 	s.r = nil
+	s.Unlock()
 	if signalMonitor {
 		s.MonitorChannel <- struct{}{}
 	}


### PR DESCRIPTION
This will avoid a deadlock, if the connection establishment process breaks in between, and the controller sends a close for the replica. It will be a deadlock since there will be no listener for the channel until the connection process is complete, and the connection will not complete until it gets this lock.
Signed-off-by: Payes <payes.anand@cloudbyte.com>