### PR TITLE
Fix quorum related issues and a race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ _run_ci:
 	@echo ""
 	@echo "INFO:\t..... run ci over jiva image"
 	@echo ""
-	./ci/start_init_test.sh
+	sudo ./ci/start_init_test.sh
 
 _push_image:
 	cd $(GOPATH)/src/github.com/openebs/jiva && ./scripts/push

--- a/app/replica.go
+++ b/app/replica.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -144,6 +145,21 @@ func startReplica(c *cli.Context) error {
 	}
 
 	resp := make(chan error)
+
+	signalChan := make(chan os.Signal, 5)
+	signal.Notify(signalChan, syscall.SIGUSR1, syscall.SIGUSR2)
+	go func() {
+		for {
+			s := <-signalChan
+			switch s {
+			case syscall.SIGUSR1:
+				replica.Delay += 2
+			case syscall.SIGUSR2:
+				replica.Delay -= 2
+			}
+			logrus.Infof("replica Delay for testing changed to: %d\n", replica.Delay)
+		}
+	}()
 
 	go func() {
 		server := rest.NewServer(s)

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1,19 +1,22 @@
 #!/bin/bash
+#SIGUSR1 increases the delay by 2 seconds at certain places in controller/replica
+#SIGUSR2 decreases the delay by 2 seconds at certain places in controller/replica
 
 CONTROLLER_IP="172.18.0.2"
 REPLICA_IP1="172.18.0.3"
 REPLICA_IP2="172.18.0.4"
-CLONED_CONTROLLER_IP="172.18.0.5"
-CLONED_REPLICA_IP="172.18.0.6"
+REPLICA_IP3="172.18.0.5"
+CLONED_CONTROLLER_IP="172.18.0.6"
+CLONED_REPLICA_IP="172.18.0.7"
 
 prepare_test_env() {
-	sudo rm -rf /tmp/vol*
-	sudo rm -rf /mnt/logs
-	sudo mkdir -p /tmp/vol1 /tmp/vol2 /tmp/vol3
-	sudo mkdir -p /mnt/store /mnt/store2
+	rm -rf /tmp/vol*
+	rm -rf /mnt/logs
+	mkdir -p /tmp/vol1 /tmp/vol2 /tmp/vol3 /tmp/vol4
+	mkdir -p /mnt/store /mnt/store2
 
-	sudo docker network create --subnet=172.18.0.0/16 stg-net
-	JI=$(sudo docker images | grep openebs/jiva | awk '{print $1":"$2}')
+	docker network create --subnet=172.18.0.0/16 stg-net
+	JI=$(docker images | grep openebs/jiva | awk '{print $1":"$2}')
 	echo "Run CI tests on $JI"
 }
 
@@ -31,7 +34,7 @@ verify_rw_status() {
 			rw_status="RW"
 		fi
 		i=`expr $i + 1`
-		if [ i == 10 ]; then
+		if [ "$i" == 10 ]; then
 			echo "1"
 		fi
 	done
@@ -40,21 +43,21 @@ verify_rw_status() {
 
 # start_controller CONTROLLER_IP
 start_controller() {
-	controller_id=$(sudo docker run -d --net stg-net --ip "$1" -P --expose 3260 --expose 9501 --expose 9502-9504 $JI \
+	controller_id=$(docker run -d --net stg-net --ip "$1" -P --expose 3260 --expose 9501 --expose 9502-9504 $JI \
 		launch controller --frontend gotgt --frontendIP "$1" "$2")
 	echo "$controller_id"
 }
 
 # start_replica CONTROLLER_IP REPLICA_IP folder_name
 start_replica() {
-	replica_id=$(sudo docker run -d -it --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI \
+	replica_id=$(docker run -d -it --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI \
 		launch replica --frontendIP "$1" --listen "$2":9502 --size 2g /"$3")
 	echo "$replica_id"
 }
 
 # start_cloned_replica CONTROLLER_IP  CLONED_CONTROLLER_IP CLONED_REPLICA_IP folder_name
 start_cloned_replica() {
-	cloned_replica_id=$(sudo docker run -d -it --net stg-net --ip "$3" -P --expose 9502-9504 -v /tmp/"$4":/"$4" $JI \
+	cloned_replica_id=$(docker run -d -it --net stg-net --ip "$3" -P --expose 9502-9504 -v /tmp/"$4":/"$4" $JI \
 		launch replica --type clone --snapName snap1 --cloneIP "$1" --frontendIP "$2" --listen "$3":9502 --size 2g /"$4")
 	echo "$cloned_replica_id"
 }
@@ -62,13 +65,13 @@ start_cloned_replica() {
 # get_replica_count CONTROLLER_IP
 get_replica_count() {
 	replicaCount=`curl http://"$1":9501/v1/volumes | jq '.data[0].replicaCount'`
-	return $replicaCount
+	echo "$replicaCount"
 }
 
 test_single_replica_stop_start() {
-	sudo docker stop $replica1_id
+	docker stop $replica1_id
 	sleep 5
-	sudo docker start $replica1_id
+	docker start $replica1_id
 	if [ $(verify_rw_status "RW") == "0" ]; then
 		echo "Single replica stop/start test passed"
 	else
@@ -78,7 +81,7 @@ test_single_replica_stop_start() {
 }
 
 test_two_replica_stop_start() {
-	sudo docker stop $replica1_id
+	docker stop $replica1_id
 	if [ $(verify_rw_status "RO") == 0 ]; then
 		echo "stop/start test passed when there are 2 replicas and one is stopped"
 	else
@@ -86,7 +89,7 @@ test_two_replica_stop_start() {
 		exit 1
 	fi
 
-	sudo docker start $replica1_id
+	docker start $replica1_id
 	if [ $(verify_rw_status "RW") == 0 ]; then
 		echo "stop/start test passed when there are 2 replicas and one is restarted"
 	else
@@ -94,8 +97,8 @@ test_two_replica_stop_start() {
 		exit 1
 	fi
 
-	sudo docker stop $replica1_id
-	sudo docker stop $replica2_id
+	docker stop $replica1_id
+	docker stop $replica2_id
 	if [ $(verify_rw_status "RO") == 0 ]; then
 		echo "stop/start test passed when there are 2 replicas and both are stopped"
 	else
@@ -103,7 +106,7 @@ test_two_replica_stop_start() {
 		exit 1
 	fi
 
-	sudo docker start $replica1_id
+	docker start $replica1_id
 	if [ $(verify_rw_status "RO") == 0 ]; then
 		echo "stop/start test passed when there are 2 replicas and one is restarted"
 	else
@@ -111,7 +114,7 @@ test_two_replica_stop_start() {
 		exit 1
 	fi
 
-	sudo docker start $replica2_id
+	docker start $replica2_id
 	if [ $(verify_rw_status "RW") == 0 ]; then
 		echo "Dual replica stop/start test passed"
 	else
@@ -120,34 +123,127 @@ test_two_replica_stop_start() {
 	fi
 
 }
+run_ios_to_test_stop_start() {
+	login_to_volume "$CONTROLLER_IP:3260"
+	sleep 2
+	get_scsi_disk
+	if [ "$device_name"!="" ]; then
+		# Add 4 sec delay in serving IOs from replica1, start IOs, and then close replica1
+		# This will trigger the quorum condition which checks if the IOs are
+		# written to more than 50% of the replicas
+		docker kill --signal=SIGUSR1 $replica1_id
+		docker kill --signal=SIGUSR1 $replica1_id
+
+		dd if=/dev/urandom of=/dev/$device_name bs=4k count=1000
+		if [ $? -eq 0 ]; then echo "IOs were written successfully while running 3 replicas stop/start test"
+		else
+			echo "IOs errored out while running 3 replicas stop/start test"; exit 1
+		fi
+		logout_of_volume
+		sleep 5
+	else
+		echo "Unable to detect iSCSI device, login failed"; exit 1
+	fi
+}
+
+test_three_replica_stop_start() {
+	run_ios_to_test_stop_start &
+	sleep 8
+	docker stop $replica1_id
+	if [ $(verify_rw_status "RW") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and one is stopped"
+	else
+		echo "stop/start test failed when there are 3 replicas and one is stopped"
+		exit 1
+	fi
+	docker stop $replica2_id
+	if [ $(verify_rw_status "RO") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and two are stopped"
+	else
+		echo "stop/start test failed when there are 3 replicas and two are stopped"
+		exit 1
+	fi
+
+	docker stop $replica3_id
+	if [ $(verify_rw_status "RO") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and all are stopped"
+	else
+		echo "stop/start test failed when there are 3 replicas and all are stopped"
+		exit 1
+	fi
+
+	docker start $replica1_id
+	if [ $(verify_rw_status "RO") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and one is restarted"
+	else
+		echo "stop/start test failed when there are 3 replicas and one is restarted"
+		exit 1
+	fi
+	# Sending SIGUSR1 to controller twice adds delay of 4 seconds in the controller code at some places
+	# It has been introduced just before starting 2nd and 3rd replica.
+	# Path being tested here is the race condition which should be hit as both the replicas 
+	# are added at the same time at the controller. So that both the replicas are opened but 
+	# only one is attached successfully and the other is left in open state.
+	docker kill --signal=SIGUSR1 $controller_id
+	docker kill --signal=SIGUSR1 $controller_id
+
+	docker start $replica2_id
+	if [ $(verify_rw_status "RW") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and two are restarted"
+	else
+		echo "stop/start test failed when there are 3 replicas and two are restarted"
+		exit 1
+	fi
+
+	docker start $replica3_id
+	if [ $(verify_rw_status "RW") == 0 ]; then
+		echo "stop/start test passed when there are 3 replicas and all are restarted"
+	else
+		echo "stop/start test failed when there are 3 replicas and all are restarted"
+		exit 1
+	fi
+
+	replica_count=$(get_replica_count $CONTROLLER_IP)
+	while [ "$replica_count" != 3 ]; do
+		i=`expr $i + 1`
+		if [ $i -eq 10 ]; then
+			echo "Closed replica failed to attach back to controller"
+			exit;
+		fi
+		echo "Wait for the closed replica to connect back to controller, replicaCount: "$replica_count
+		sleep 5;
+		replica_count=$(get_replica_count $CONTROLLER_IP)
+	done
+
+}
 
 test_replica_reregitration() {
 	i=0
-	get_replica_count $CONTROLLER_IP
-	while [ $? != 2 ]; do
+	replica_count=$(get_replica_count $CONTROLLER_IP)
+	while [ "$replica_count" != 3 ]; do
 		i=`expr $i + 1`
 		if [ $i -eq 10 ]; then
 			echo "Replicas failed to attach to controller"
 			exit;
 		fi
-		echo "Wait for both replicas to attach to controller"
+		echo "Wait for the closed replica to connect back to controller, replicaCount: "$replica_count
 		sleep 5;
-		get_replica_count $CONTROLLER_IP
+		replica_count=$(get_replica_count $CONTROLLER_IP)
 	done
 
 	curl -H "Content-Type: application/json" -X POST http://172.18.0.3:9502/v1/replicas/1?action=close
 
 	i=0
-	get_replica_count $CONTROLLER_IP
-	while [ $? != 2 ]; do
-		i=`expr $i+1`
+	replica_count=$(get_replica_count $CONTROLLER_IP)
+	while [ "$replica_count" != 3 ]; do
+		i=`expr $i + 1`
 		if [ $i -eq 10 ]; then
 			echo "Closed replica failed to attach back to controller"
 			exit;
 		fi
-		echo "Wait for the closed replica to connect back to controller"
+		echo "Wait for the closed replica to connect back to controller, replicaCount: "$replica_count
 		sleep 5;
-		get_replica_count $CONTROLLER_IP
+		replica_count=$(get_replica_count $CONTROLLER_IP)
 	done
 }
 
@@ -158,15 +254,15 @@ run_vdbench_test_on_volume() {
 	sleep 5
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
-		sudo mount /dev/$device_name /mnt/store
-		sudo mkdir -p /mnt/store/data
-		sudo chown 777 /mnt/store/data
-		sudo docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
+		mount /dev/$device_name /mnt/store
+		mkdir -p /mnt/store/data
+		chown 777 /mnt/store/data
+		docker run -v /mnt/store/data:/datadir1 openebs/tests-vdbench:latest
 		if [ $? -eq 0 ]; then echo "VDbench Test: PASSED"
 		else
 			echo "VDbench Test: FAILED";exit 1
 		fi
-		sudo umount /mnt/store
+		umount /mnt/store
 	else
 		echo "Unable to detect iSCSI device, login failed"; exit 1
 	fi
@@ -175,8 +271,8 @@ run_vdbench_test_on_volume() {
 
 run_libiscsi_test_suite() {
 	echo "Run the libiscsi compliance suite on Jiva Vol"
-	sudo mkdir /mnt/logs
-	sudo docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip $CONTROLLER_IP"
+	mkdir /mnt/logs
+	docker run -v /mnt/logs:/mnt/logs --net host openebs/tests-libiscsi /bin/bash -c "./testiscsi.sh --ctrl-svc-ip $CONTROLLER_IP"
 	tp=$(grep "PASSED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
 	tf=$(grep "FAILED" $(find /mnt/logs -name SUMMARY.log) | wc -l)
 	if [ $tp -ge 146 ] && [ $tf -le 29 ]; then
@@ -187,8 +283,8 @@ run_libiscsi_test_suite() {
 }
 
 logout_of_volume() {
-	sudo iscsiadm -m node -u
-	sudo iscsiadm -m node -o delete
+	iscsiadm -m node -u
+	iscsiadm -m node -o delete
 }
 
 # Discover Jiva iSCSI target and Login
@@ -214,28 +310,28 @@ get_scsi_disk() {
 	done
 }
 
-run_data_integrity_test(){
+run_data_integrity_test() {
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 5
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
-		sudo mkfs.ext2 -F /dev/$device_name
+		mkfs.ext2 -F /dev/$device_name
 
-		sudo mount /dev/$device_name /mnt/store
+		mount /dev/$device_name /mnt/store
 
-		sudo dd if=/dev/urandom of=file1 bs=4k count=10000
-		hash1=$(sudo md5sum file1 | awk '{print $1}')
-		sudo cp file1 /mnt/store
-		hash2=$(sudo md5sum /mnt/store/file1 | awk '{print $1}')
+		dd if=/dev/urandom of=file1 bs=4k count=10000
+		hash1=$(md5sum file1 | awk '{print $1}')
+		cp file1 /mnt/store
+		hash2=$(md5sum /mnt/store/file1 | awk '{print $1}')
 		if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
 		else
 			echo "DI Test: FAILED"; exit 1
 		fi
 
 		cd /mnt/store; sync; sleep 5; sync; sleep 5; cd ~;
-		sudo blockdev --flushbufs /dev/$device_name
-		sudo hdparm -F /dev/$device_name
-		sudo umount /mnt/store
+		blockdev --flushbufs /dev/$device_name
+		hdparm -F /dev/$device_name
+		umount /mnt/store
 		logout_of_volume
 		sleep 5
 	else
@@ -243,15 +339,73 @@ run_data_integrity_test(){
 	fi
 }
 
+create_snapshot() {
+	id=`curl http://$1:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
+	curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://$CONTROLLER_IP:9501/v1/volumes/$id?action=snapshot
+}
+
+test_clone_feature() {
+	start_controller "$CLONED_CONTROLLER_IP" "store2"
+	start_cloned_replica "$CONTROLLER_IP"  "$CLONED_CONTROLLER_IP" "$CLONED_REPLICA_IP" "vol4"
+
+	if [ $(verify_clone_status "completed") == "0" ]; then
+		echo "clone created successfully"
+	else
+		echo "Clone creation failed"
+		exit 1
+	fi
+
+	login_to_volume "$CLONED_CONTROLLER_IP:3260"
+	get_scsi_disk
+
+	if [ "$device_name"!="" ]; then
+		mount /dev/$device_name /mnt/store2
+
+		hash3=$(md5sum /mnt/store2/file1 | awk '{print $1}')
+		if [ $hash1 == $hash3 ]; then
+			umount /mnt/store2
+			logout_of_volume
+			echo "DI Test: PASSED"
+		else
+			umount /mnt/store2
+			logout_of_volume
+			echo "DI Test: FAILED"; exit 1
+		fi
+	else
+		echo "Unable to detect iSCSI device, login failed"; exit 1
+	fi
+}
+
+verify_clone_status() {
+	i=0
+	clonestatus=""
+	while [ "$clonestatus" != "$1" ]; do
+		sleep 5
+		clonestatus=`curl http://$CLONED_REPLICA_IP:9502/v1/replicas/1 | jq '.clonestatus' | tr -d '"'`
+		i=`expr $i + 1`
+		if [ $i -eq 20 ]; then
+			echo "1"
+			return
+		else
+			continue
+		fi
+	done
+	echo "0"
+}
+
 prepare_test_env
 controller_id=$(start_controller "$CONTROLLER_IP" "store1")
 replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 sleep 5
 test_single_replica_stop_start
-
+sleep 5
 replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
 sleep 5
 test_two_replica_stop_start
+sleep 5
+replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3")
+sleep 5
+test_three_replica_stop_start
 sleep 5
 test_replica_reregitration
 sleep 5

--- a/controller/control.go
+++ b/controller/control.go
@@ -152,6 +152,7 @@ func (c *Controller) addQuorumReplica(address string, snapshot bool) error {
 	}
 
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Marking volume RW")
 		c.ReadOnly = false
 	}
 
@@ -195,6 +196,7 @@ func (c *Controller) addReplica(address string, snapshot bool) error {
 
 	err = c.addReplicaNoLock(newBackend, address, snapshot)
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Marking volume RW")
 		c.ReadOnly = false
 	}
 	return err
@@ -479,6 +481,7 @@ func (c *Controller) RemoveReplica(address string) error {
 	}
 
 	if len(c.replicas)+len(c.quorumReplicas) <= (c.replicaCount+c.quorumReplicaCount)/2 {
+		logrus.Infof("Marking volume RO")
 		c.ReadOnly = true
 	}
 	return nil
@@ -645,6 +648,7 @@ func (c *Controller) Start(addresses ...string) error {
 		}
 	}
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Marking volume RW")
 		c.ReadOnly = false
 	}
 
@@ -654,6 +658,7 @@ func (c *Controller) Start(addresses ...string) error {
 func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 	c.RLock()
 	if c.ReadOnly == true {
+		logrus.Infof("Marking volume RO")
 		err := fmt.Errorf("Mode: ReadOnly")
 		c.RUnlock()
 		return 0, err

--- a/controller/multi_writer_at.go
+++ b/controller/multi_writer_at.go
@@ -45,6 +45,8 @@ func (m *MultiWriterError) Error() string {
 func (m *MultiWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
 	quorumErrs := make([]error, len(m.writers))
 	replicaErrs := make([]error, len(m.writers))
+	replicaErrCount := 0
+	quorumErrCount := 0
 	quorumErrored := false
 	replicaErrored := false
 	wg := sync.WaitGroup{}
@@ -80,8 +82,25 @@ func (m *MultiWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
 		errors.Updaters = m.updaters
 		errors.QuorumErrors = quorumErrs
 	}
-
+	//Below code is introduced to make sure that the IO has been written to more
+	//than 50% of the replica.
+	//If any replica has errored, return with the length of data written and the
+	//erroed replica details so that it can be closed.
 	if replicaErrored || quorumErrored {
+		for _, err1 := range replicaErrs {
+			if err1 != nil {
+				replicaErrCount++
+			}
+		}
+		for _, err1 := range quorumErrs {
+			if err1 != nil {
+				quorumErrCount++
+			}
+		}
+		if (len(m.writers)-replicaErrCount > len(m.writers)/2) &&
+			(len(m.writers)+len(m.updaters)-replicaErrCount-quorumErrCount > (len(m.writers)+len(m.updaters))/2) {
+			return len(p), &errors
+		}
 		return 0, &errors
 	}
 	return len(p), nil

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -35,6 +35,7 @@ const (
 	maximumChainLength = 250
 )
 
+var Delay time.Duration
 var (
 	diskPattern = regexp.MustCompile(`volume-head-(\d)+.img`)
 )
@@ -976,6 +977,9 @@ func (r *Replica) WriteAt(buf []byte, offset int64) (int, error) {
 	if r.readOnly {
 		return 0, fmt.Errorf("Can not write on read-only replica")
 	}
+	if Delay != 0 {
+		time.Sleep(time.Second * Delay)
+	}
 
 	if r.ReplicaType != "quorum" {
 		r.RLock()
@@ -1007,6 +1011,9 @@ func (r *Replica) Update() error {
 */
 
 func (r *Replica) ReadAt(buf []byte, offset int64) (int, error) {
+	if Delay != 0 {
+		time.Sleep(time.Second * Delay)
+	}
 	r.RLock()
 	c, err := r.volume.ReadAt(buf, offset)
 	r.RUnlock()

--- a/replica/server.go
+++ b/replica/server.go
@@ -102,7 +102,6 @@ func (s *Server) Open() error {
 	_, info := s.Status()
 	size := s.getSize(info.Size)
 	sectorSize := s.getSectorSize()
-
 	logrus.Infof("Opening volume %s, size %d/%d", s.dir, size, sectorSize)
 	r, err := New(size, sectorSize, s.dir, s.backing, s.ServerType)
 	if err != nil {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -212,6 +212,13 @@ func (t *Task) AddReplica(replicaAddress string) error {
 
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	currentReplicaClient, err := replicaClient.NewReplicaClient(replicaAddress)
+	if err != nil {
+		return err
+	}
+	//Attempt replica close before trying to connect to controller.
+	//Replica can only connect to controller in closed state.
+	currentReplicaClient.Close()
 Register:
 	volume, err := t.client.GetVolume()
 	if err != nil {

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,4 +20,4 @@ github.com/jmespath/go-jmespath         c01cf91b011868172fdcd9f41838e80c9d716264
 github.com/yasker/go-iscsi-helper       9910689ad7c88f650262e01557b16bdc0d5b6a94
 github.com/yasker/nsfilelock            90eff0ebb9e2e0ee2f22519cfb8404f9fdd9c008
 github.com/yasker/backupstore           39c822e19eb3d54eca4dc5f75205e426c8357ac1
-github.com/openebs/gotgt		91c16f7d235739ffc7994e02ae51d4a063febc6d	
+github.com/openebs/gotgt		51112f40b6636b524cf8d5abf3a852dd63abd910


### PR DESCRIPTION
This commit is cherry-picked from https://github.com/openebs/jiva/commit/59b33519b68a85ee573a094d1056367d4bc87130
* Fix quorum related issues and a race condition
1)Reply with success when IOs are written to atleast 51% of replicas.
  Add delays in through signals in read/write code to simulate the above case.
2)Attempt replica close before trying to connect to controller.
  Replica can only connect to controller in closed state.
3)Add delays through signals in replica addition path to simulate race condition.
* Add test case for 3 replicas and reduce R/W timeout and retry values

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>