### PR TITLE
Add logs when volume changes mode and remove signaling monitorChan

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -150,6 +150,7 @@ func (c *Controller) addQuorumReplica(address string, snapshot bool) error {
 	}
 
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Mark volume as r/w")
 		c.ReadOnly = false
 	}
 
@@ -181,6 +182,7 @@ func (c *Controller) addReplica(address string, snapshot bool) error {
 
 	err = c.addReplicaNoLock(newBackend, address, snapshot)
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Mark volume as r/w")
 		c.ReadOnly = false
 	}
 	return err
@@ -465,6 +467,7 @@ func (c *Controller) RemoveReplica(address string) error {
 	}
 
 	if len(c.replicas)+len(c.quorumReplicas) <= (c.replicaCount+c.quorumReplicaCount)/2 {
+		logrus.Infof("Mark volume as r/o")
 		c.ReadOnly = true
 	}
 	return nil
@@ -631,6 +634,7 @@ func (c *Controller) Start(addresses ...string) error {
 		}
 	}
 	if (len(c.replicas)+len(c.quorumReplicas) > (c.replicaCount+c.quorumReplicaCount)/2) && (c.ReadOnly == true) {
+		logrus.Infof("Mark volume as r/w")
 		c.ReadOnly = false
 	}
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -305,7 +305,7 @@ func (s *Server) Close() error {
 	}
 
 	s.r = nil
-	s.MonitorChannel <- struct{}{}
+	//s.MonitorChannel <- struct{}{}
 	return nil
 }
 


### PR DESCRIPTION
Adding logs at the suspecting places where we are changing the volume state from read/write state.
Also removing writing to the MonitorChannel which ends up closing the monitoring channel and triggers the registration to the controller, suspecting it might be causing/triggering registering code path which might be causing the controller panic.


Signed-off-by: Payes <payes.anand@cloudbyte.com>