### PR TITLE
Replace the image tag in DockerFile from 16.04 to xenial-20180228

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:xenial-20180228
 # FROM arm=armhf/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH=amd64


### PR DESCRIPTION
This commit replaces the image tag in Dockerfile.
Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>