### PR TITLE
Changing Ubuntu image version to match 0.5.4

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:xenial-20180412
 # FROM arm=armhf/ubuntu:16.04
 
 ARG DAPPER_HOST_ARCH=amd64


### PR DESCRIPTION
docker hub keeps updating the images. Update in image will bring in changes to compilation and build environment.
This PR is to change the ubuntu version from 16.04 to match that of 0.5.4 release.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>