### PR TITLE
Rectify string comparision while removing replica from registered list and add logs

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -427,7 +427,12 @@ func (c *Controller) hasReplica(address string) bool {
 }
 
 func (c *Controller) RemoveReplicaNoLock(address string) error {
+	var foundregrep int
+	var prev bool
+
+	logrus.Infof("RemoveReplica %v ReplicasAdded:%v FrontendState:%v", address, len(c.replicas), c.frontend.State())
 	if !c.hasReplica(address) {
+		logrus.Infof("RemoveReplica %v not found", address)
 		return nil
 	}
 	for i, r := range c.replicas {
@@ -443,32 +448,49 @@ func (c *Controller) RemoveReplicaNoLock(address string) error {
 					return fmt.Errorf("Cannot remove last replica if volume is up")
 				}
 			}
+			foundregrep = 0
 			for regrep := range c.RegisteredReplicas {
-				if strings.Contains(address, regrep) {
+				logrus.Infof("RemoveReplica ToRemove: %v Found: %v", address, regrep)
+				if address == "tcp://"+regrep+":9502" {
 					delete(c.RegisteredReplicas, regrep)
+					foundregrep = 1
+					break
 				}
+			}
+			if foundregrep == 0 {
+				logrus.Infof("RemoveReplica %v not found in registered replicas", address)
 			}
 			c.replicas = append(c.replicas[:i], c.replicas[i+1:]...)
 			c.backend.RemoveBackend(r.Address)
+			break
 		}
 	}
 
 	for i, r := range c.quorumReplicas {
+		foundregrep = 0
 		if r.Address == address {
 			for regrep := range c.RegisteredQuorumReplicas {
-				if strings.Contains(address, regrep) {
+				logrus.Infof("RemoveReplica quorum ToRemove: %v Found: %v", address, regrep)
+				if address == "tcp://"+regrep+":9502" {
 					delete(c.RegisteredQuorumReplicas, regrep)
+					foundregrep = 1
+					break
 				}
+			}
+			if foundregrep == 0 {
+				logrus.Infof("RemoveReplica %v not found in registered quorum replicas", address)
 			}
 			c.quorumReplicas = append(c.quorumReplicas[:i], c.quorumReplicas[i+1:]...)
 			c.backend.RemoveBackend(r.Address)
+			break
 		}
 	}
-
+	prev = c.ReadOnly
 	if len(c.replicas)+len(c.quorumReplicas) <= (c.replicaCount+c.quorumReplicaCount)/2 {
 		logrus.Infof("Marking volume as R/O")
 		c.ReadOnly = true
 	}
+	logrus.Infof("controller readonly p:%v c:%v", prev, c.ReadOnly)
 	return nil
 }
 

--- a/controller/control.go
+++ b/controller/control.go
@@ -458,6 +458,11 @@ func (c *Controller) RemoveReplicaNoLock(address string) error {
 				}
 			}
 			if foundregrep == 0 {
+				//We should not break if the replica is not found in registered
+				//list, since all replicas are not registered.
+				//if there is already one replica in RW mode then, the replica
+				//registration process is avoided and same is true for quorum
+				//replicas
 				logrus.Infof("RemoveReplica %v not found in registered replicas", address)
 			}
 			c.replicas = append(c.replicas[:i], c.replicas[i+1:]...)


### PR DESCRIPTION
There was a problem while clearing replica details from controller when replica goes down.
The address passed in RemoveReplica function contains the strings "tcp://" and ":9502".

But the registered replica list contains only ip addresses and we were checking for this ip substring in the passed address which is tcp://<ip str>:<port>.
So in case of two replica having IPs 10.10.10.10 and 10.10.10.1, the substring comparison of 10.10.10.1 will also be true for the replica with address tcp://10.10.10.10:9502 and we will remove wrong (or both) the replica in this case.

Signed-off-by: Payes <payes.anand@cloudbyte.com>