### PR TITLE
Initialize volume mode as read only when controller starts

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -48,6 +48,7 @@ func NewController(name string, frontendIP string, clusterIP string, factory typ
 		RegisteredReplicas:       map[string]types.RegReplica{},
 		RegisteredQuorumReplicas: map[string]types.RegReplica{},
 		StartTime:                time.Now(),
+		ReadOnly:                 true,
 	}
 	c.reset()
 	return c


### PR DESCRIPTION
When the controller comes up the status of the volume should be read only.
The default for boolean variables in golang is false, so we need to set it explicitly.
Signed-off-by: Payes <payes.anand@cloudbyte.com>