### PR TITLE
remove the last replica if it is in WO mode.

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -472,6 +472,33 @@ func (c *Controller) RemoveReplicaNoLock(address string) error {
 		}
 	}
 
+	if len(c.replicas) == 1 {
+		r := c.replicas[0]
+		/*
+		 * there can be only one replica in WO mode, we don't
+		 * allow any other replica to connect. So, if the last
+		 * replica remaining is in WO, we should disconnect it
+		 * so that other can connect and proceed.
+		 */
+		if r.Mode == "WO" {
+			if c.frontend.State() == types.StateUp {
+				if c.frontend != nil {
+					c.StartSignalled = false
+					c.MaxRevReplica = ""
+					c.frontend.Shutdown()
+				}
+			}
+			for regrep := range c.RegisteredReplicas {
+				if r.Address == regrep {
+					delete(c.RegisteredReplicas, regrep)
+				}
+			}
+			c.replicas = nil
+			logrus.Infof("last replica (%v) is in WO mode, removing it!!!", r.Address)
+			c.backend.RemoveBackend(r.Address)
+		}
+	}
+
 	for i, r := range c.quorumReplicas {
 		foundregrep = 0
 		if r.Address == address {
@@ -734,6 +761,16 @@ func (c *Controller) ReadAt(b []byte, off int64) (int, error) {
 		err := fmt.Errorf("EOF: Read of %v bytes at offset %v is beyond volume size %v", len(b), off, c.size)
 		return 0, err
 	}
+	if len(c.replicas) == 0 {
+		return 0, fmt.Errorf("No backends available")
+	}
+	if len(c.replicas) == 1 {
+		r := c.replicas[0]
+		if r.Mode == "WO" {
+			return 0, fmt.Errorf("only WO replica available")
+		}
+	}
+
 	n, err := c.backend.ReadAt(b, off)
 	if err != nil {
 		errh := c.handleErrorNoLock(err)


### PR DESCRIPTION
Currently there can be only one replica in WO mode, we don't
allow any other replica to connect. So, if the last
replica remaining is in WO, we should disconnect it
so that other can connect and proceed.