### PR TITLE
Fetch Replication factor from env and make volume R/W only when >50% replicas are in R/W mode

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -43,6 +43,7 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 			err = task.AddReplica(replica)
 		}
 		if err != nil {
+			logrus.Errorf("Error adding replica, err: %v, will retry", err)
 			time.Sleep(2 * time.Second)
 			s.Close(false)
 			continue

--- a/app/controller.go
+++ b/app/controller.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -66,6 +67,12 @@ func startController(c *cli.Context) error {
 		return errors.New("volume name is required")
 	}
 	name := c.Args()[0]
+	replicationFactor, _ := strconv.ParseInt(os.Getenv("REPLICATION_FACTOR"), 10, 32)
+	if replicationFactor == 0 {
+		logrus.Infof("REPLICATION_FACTOR env not set")
+	} else {
+		logrus.Infof("REPLICATION_FACTOR: %v", replicationFactor)
+	}
 
 	if !util.ValidVolumeName(name) {
 		return errors.New("invalid target name")
@@ -100,7 +107,7 @@ func startController(c *cli.Context) error {
 		frontend = f
 	}
 
-	control := controller.NewController(name, frontendIP, clusterIP, dynamic.New(factories), frontend)
+	control := controller.NewController(name, frontendIP, clusterIP, dynamic.New(factories), frontend, int(replicationFactor))
 	server := rest.NewServer(control)
 	router := http.Handler(rest.NewRouter(server))
 

--- a/app/replica.go
+++ b/app/replica.go
@@ -85,7 +85,9 @@ func CheckReplicaState(frontendIP string, replicaIP string) (string, error) {
 
 func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, replicaType string) {
 checkagain:
+	logrus.Infof("Get replica state")
 	state, err := CheckReplicaState(frontendIP, address)
+	logrus.Infof("checkreplicastate %v %v", state, err)
 	if err == nil && (state == "" || state == "ERR") {
 		s.Close(false)
 	} else {
@@ -96,6 +98,7 @@ checkagain:
 	AutoAddReplica(s, frontendIP, address, replicaType)
 	select {
 	case <-s.MonitorChannel:
+		logrus.Infof("Restart AutoConfigure Process")
 		goto checkagain
 	}
 }

--- a/app/replica.go
+++ b/app/replica.go
@@ -85,7 +85,6 @@ func CheckReplicaState(frontendIP string, replicaIP string) (string, error) {
 
 func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, replicaType string) {
 checkagain:
-	logrus.Infof("Get replica state")
 	state, err := CheckReplicaState(frontendIP, address)
 	logrus.Infof("checkreplicastate %v %v", state, err)
 	if err == nil && (state == "" || state == "ERR") {

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -197,7 +197,8 @@ verify_controller_rep_state() {
 
 # start_controller CONTROLLER_IP
 start_controller() {
-	controller_id=$(docker run -d --net stg-net --ip $1 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI env REPLICATION_FACTOR="$3" launch controller --frontend gotgt --frontendIP "$1" "$2")
+	controller_id=$(docker run -d --net stg-net --ip $1 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI \
+			env REPLICATION_FACTOR="$3" launch controller --frontend gotgt --frontendIP "$1" "$2")
 	echo "$controller_id"
 }
 

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -178,10 +178,12 @@ func (c *ControllerClient) GetVolume() (*rest.Volume, error) {
 
 	err := c.get("/volumes", &volumes)
 	if err != nil {
+		logrus.Errorf("GetVolume failed, %v", err)
 		return nil, err
 	}
 
 	if len(volumes.Data) == 0 {
+		logrus.Errorf("volume not found")
 		return nil, errors.New("No volume found")
 	}
 

--- a/controller/control.go
+++ b/controller/control.go
@@ -76,7 +76,12 @@ func (c *Controller) UpdateVolStatus() {
 			rwReplicaCount++
 		}
 	}
-	if rwReplicaCount >= ((c.replicaCount+c.quorumReplicaCount)/2)+1 {
+	for _, replica := range c.quorumReplicas {
+		if replica.Mode == "RW" {
+			rwReplicaCount++
+		}
+	}
+	if rwReplicaCount >= (((c.replicaCount + c.quorumReplicaCount) / 2) + 1) {
 		c.ReadOnly = false
 	} else {
 		c.ReadOnly = true
@@ -267,8 +272,8 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 		c.MaxRevReplica = register.Address
 	}
 
-	if (len(c.RegisteredReplicas) >= (c.replicaCount/2)+1) &&
-		((len(c.RegisteredReplicas) + len(c.RegisteredQuorumReplicas)) >= ((c.quorumReplicaCount+c.replicaCount)/2)+1) {
+	if (len(c.RegisteredReplicas) >= ((c.replicaCount / 2) + 1)) &&
+		((len(c.RegisteredReplicas) + len(c.RegisteredQuorumReplicas)) >= (((c.quorumReplicaCount + c.replicaCount) / 2) + 1)) {
 		c.signalToAdd()
 		c.StartSignalled = true
 		logrus.Infof("Replica %v signalled to start volume", register.Address)

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -100,6 +100,7 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 		c.quorumReplicaCount = len(c.quorumReplicas)
 	}
 	c.backend.UpdatePeerDetails(c.replicaCount, c.quorumReplicaCount)
+	c.UpdateVolStatus()
 	return nil
 }
 

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -96,11 +96,12 @@ func (r *replicator) RemoveBackend(address string) {
 	if !ok {
 		backend, ok = r.quorumBackends[address]
 		if !ok {
+			logrus.Infof("RemoveBackend %v not found", address)
 			return
 		}
 	}
 
-	logrus.Infof("Removing backend: %s", address)
+	logrus.Infof("Remove backend: %s mode: %v", address, backend.mode)
 
 	// We cannot wait for it's return because peer may not exists anymore
 	go backend.backend.Close()

--- a/replica/peer_details.go
+++ b/replica/peer_details.go
@@ -51,17 +51,21 @@ func (r *Replica) initPeerDetails() error {
 		}
 		// file doesn't exist yet
 		if err := r.openPeerFile(true); err != nil {
+			logrus.Errorf("openPeerFile failed %v", err)
 			return err
 		}
 		if err := r.writePeerDetails(peerDetails); err != nil {
+			logrus.Errorf("writePeerDetails failed %v", err)
 			return err
 		}
 	} else if err := r.openPeerFile(false); err != nil {
+		logrus.Errorf("OpenPeerFile failed when file already exists %v", err)
 		return err
 	}
 
 	peerDetails, err := r.readPeerDetails()
 	if err != nil {
+		logrus.Errorf("readPeerDetails failed %v", err)
 		return err
 	}
 	// Don't use r.peerCache directly

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -123,9 +123,11 @@ func CreateTempReplica() (*Replica, error) {
 		ReplicaStartTime: StartTime,
 	}
 	if err := r.initRevisionCounter(); err != nil {
+		logrus.Errorf("Error in initRevisionCounter, err:%v", err)
 		return nil, err
 	}
 	if err := r.initPeerDetails(); err != nil {
+		logrus.Errorf("Error in initPeerDetails, err:%v", err)
 		return nil, err
 	}
 	return r, nil

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -64,17 +64,21 @@ func (r *Replica) initRevisionCounter() error {
 		}
 		// file doesn't exist yet
 		if err := r.openRevisionFile(true); err != nil {
+			logrus.Errorf("openRevisionFile failed, %v", err)
 			return err
 		}
 		if err := r.writeRevisionCounter(0); err != nil {
+			logrus.Errorf("writeRevisionCounter failed, %v", err)
 			return err
 		}
 	} else if err := r.openRevisionFile(false); err != nil {
+		logrus.Errorf("open existing revision counter file failed, %v", err)
 		return err
 	}
 
 	counter, err := r.readRevisionCounter()
 	if err != nil {
+		logrus.Errorf("readRevisionCounter failed, %v", err)
 		return err
 	}
 	// Don't use r.revisionCache directly

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -282,61 +282,89 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 func (t *Task) AddReplica(replicaAddress string) error {
 	var action string
 
+	logrus.Infof("Addreplica %v", replicaAddress)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
+	Replica, err := replica.CreateTempReplica()
+	if err != nil {
+		logrus.Errorf("CreateTempReplica failed, err: %v", err)
+		return err
+	}
+	server, err := replica.CreateTempServer()
+	if err != nil {
+		logrus.Errorf("CreateTempServer failed, err: %v", err)
+		return err
+	}
 Register:
+	logrus.Infof("Get Volume info from controller")
 	volume, err := t.client.GetVolume()
 	if err != nil {
+		logrus.Errorf("Get volume info failed, err: %v", err)
 		return err
 	}
 	addr := strings.Split(replicaAddress, "://")
 	parts := strings.Split(addr[1], ":")
-	Replica, _ := replica.CreateTempReplica()
-	server, _ := replica.CreateTempServer()
 	if volume.ReplicaCount == 0 {
 		revisionCount := Replica.GetRevisionCounter()
 		peerDetails, _ := Replica.GetPeerDetails()
 		replicaType := "Backend"
 		upTime := time.Since(Replica.ReplicaStartTime)
 		state, _ := server.PrevStatus()
-		t.client.Register(parts[0], revisionCount, peerDetails, replicaType, upTime, string(state))
+		logrus.Infof("Register replica at controller")
+		err := t.client.Register(parts[0], revisionCount, peerDetails, replicaType, upTime, string(state))
+		if err != nil {
+			logrus.Errorf("Error in sending register command, err: %v", err)
+		}
 		select {
 		case <-ticker.C:
+			logrus.Infof("TimedOut waiting for response from controller")
 			goto Register
 		case action = <-replica.ActionChannel:
 		}
 	}
 	if action == "start" {
+		logrus.Infof("Received start from controller")
 		return t.client.Start(replicaAddress)
 	}
+	logrus.Infof("CheckAndResetFailedRebuild %v", replicaAddress)
 	if err := t.checkAndResetFailedRebuild(replicaAddress); err != nil {
+		logrus.Errorf("CheckAndResetFailedRebuild failed, err:%v", err)
 		return err
 	}
 
 	logrus.Infof("Adding replica %s in WO mode", replicaAddress)
 	_, err = t.client.CreateReplica(replicaAddress)
 	if err != nil {
+		logrus.Errorf("CreateReplica failed, err:%v", err)
 		return err
 	}
 
+	logrus.Infof("getTransferClients %v", replicaAddress)
 	fromClient, toClient, err := t.getTransferClients(replicaAddress)
 	if err != nil {
+		logrus.Errorf("getTransferClients failed, err:%v", err)
 		return err
 	}
 
+	logrus.Infof("SetRebuilding %v", replicaAddress)
 	if err := toClient.SetRebuilding(true); err != nil {
+		logrus.Errorf("SetRebuilding failed, err:%v", err)
 		return err
 	}
 
+	logrus.Infof("PrepareRebuild %v", replicaAddress)
 	output, err := t.client.PrepareRebuild(rest.EncodeID(replicaAddress))
 	if err != nil {
+		logrus.Errorf("PrepareRebuild failed, err:%v", err)
 		return err
 	}
 
+	logrus.Infof("syncFiles from:%v to:%v", fromClient, toClient)
 	if err = t.syncFiles(fromClient, toClient, output.Disks); err != nil {
 		return err
 	}
 
+	logrus.Infof("reloadAndVerify %v", replicaAddress)
 	return t.reloadAndVerify(replicaAddress, toClient)
 
 }


### PR DESCRIPTION
If replication factor is received from control plane, data corruption can be avoided.
Scenario:
2 Replicas are present.
1) Replica_1 is connected to controller and IOs have been started, but replica 2 did not connect till now.
2) Controller restarts and replica 2 connects before replica 1. Revision counter and peerCount at Replica_2 are 0, so controller thinks that it is a new deployment and starts the IOs on this replica.
3) Replica_1 now connects back to controller and its data is synced, assuming Replica_1 as source.
Now the data which was written earlier at Replica_1 is lost.  

Other fixes:
- There is unnecessary creation of TempServer and TempReplica during repeated registration. Removed the unnecessary creation.

Signed-off-by: Payes <payes.anand@cloudbyte.com>