### PR TITLE
Timestamp in replica logs, goroutines leak fix

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -116,6 +116,12 @@ func CloneReplica(s *replica.Server, address string, cloneIP string, snapName st
 }
 
 func startReplica(c *cli.Context) error {
+
+	formatter := &logrus.TextFormatter {
+		FullTimestamp: true,
+	}
+	logrus.SetFormatter(formatter)
+
 	if c.NArg() != 1 {
 		return errors.New("directory name is required")
 	}

--- a/app/replica.go
+++ b/app/replica.go
@@ -117,7 +117,7 @@ func CloneReplica(s *replica.Server, address string, cloneIP string, snapName st
 
 func startReplica(c *cli.Context) error {
 
-	formatter := &logrus.TextFormatter {
+	formatter := &logrus.TextFormatter{
 		FullTimestamp: true,
 	}
 	logrus.SetFormatter(formatter)

--- a/controller/control.go
+++ b/controller/control.go
@@ -115,7 +115,7 @@ func (c *Controller) canAdd(address string) (bool, error) {
 		return false, nil
 	}
 	if c.hasWOReplica() {
-		return false, fmt.Errorf("Can only have one WO replica at a time")
+		return false, fmt.Errorf("Can only have one WO replica at a time %v", address)
 	}
 	return true, nil
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -189,6 +189,10 @@ func (c *Client) loop() {
 			c.handleRequest(req)
 		case resp := <-c.responses:
 			c.handleResponse(resp)
+			if c.err != nil {
+				logrus.Infof("Exiting rpc loop for %v with err %v", c.TargetID, c.err)
+				return
+			}
 		}
 	}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -190,7 +190,7 @@ func (c *Client) loop() {
 		case resp := <-c.responses:
 			c.handleResponse(resp)
 			if c.err != nil {
-				logrus.Infof("Exiting rpc loop for %v with err %v", c.TargetID, c.err)
+				logrus.Infof("Exiting rpc loop for %v with err %v", c.peerAddr, c.err)
 				return
 			}
 		}


### PR DESCRIPTION
In jiva, replica logs are not having timestamp details. This PR addresses it by adding a formatter to logrus to print timestamp in replica logs

When replica disconnects with controller, there are goroutines which doesn't get freed. This PR address by checking for error and returns to fix goroutines leak.

Added test cases for verifying quorum, and to goroutines leak fix

Also, reduced few iterations in ci script to reduce build time

Signed-off-by: Vishnu Itta <vitta@mayadata.io>