### PR TITLE
Creating tagged images from non-master branch

### DIFF
--- a/scripts/push
+++ b/scripts/push
@@ -15,14 +15,14 @@ then
   if [ ! -z "${TRAVIS_TAG}" ] || [ ! -z "${RELEASE_TAG}" ];
   then
     #Push the release tag image to jiva docker hub repository
-    #When a git hub is tagged with a release, the travis will 
+    #When a git hub is tagged with a release, the travis will
     #hold the release tag in env TRAVIS_TAG
     if [ ! -z "${TRAVIS_TAG}" ];
     then
       RELEASE_TAG=${TRAVIS_TAG}
     fi
     docker tag ${IMAGEID} openebs/jiva:${RELEASE_TAG}
-    docker push openebs/jiva:${RELEASE_TAG}; 
+    docker push openebs/jiva:${RELEASE_TAG};
     docker tag ${IMAGEID} openebs/jiva:latest
     docker push openebs/jiva:latest;
   fi;

--- a/scripts/push
+++ b/scripts/push
@@ -12,10 +12,17 @@ then
   docker push openebs/jiva-ci:${VERSION};
   docker tag ${IMAGEID} openebs/jiva:ci
   docker push openebs/jiva:ci;
-  if [ ! -z "${TRAVIS_TAG}" ] && [ "${TRAVIS_BRANCH}" == "master" ];
+  if [ ! -z "${TRAVIS_TAG}" ] || [ ! -z "${RELEASE_TAG}" ];
   then
-    docker tag ${IMAGEID} openebs/jiva:${TRAVIS_TAG}
-    docker push openebs/jiva:${TRAVIS_TAG};
+    #Push the release tag image to jiva docker hub repository
+    #When a git hub is tagged with a release, the travis will 
+    #hold the release tag in env TRAVIS_TAG
+    if [ ! -z "${TRAVIS_TAG}" ];
+    then
+      RELEASE_TAG=${TRAVIS_TAG}
+    fi
+    docker tag ${IMAGEID} openebs/jiva:${RELEASE_TAG}
+    docker push openebs/jiva:${RELEASE_TAG}; 
     docker tag ${IMAGEID} openebs/jiva:latest
     docker push openebs/jiva:latest;
   fi;


### PR DESCRIPTION
There is need to create tagged images from non-master branches.
This PR is to revert PR#74 which limits the creation of tagged images to master branch.

However, creating images with latest tag need to be looked in holistic way when there are images built from multiple branches.

Signed-off-by: Vishnu Itta vitta@mayadata.io