### PR TITLE
Reverse the current order of sync to avoid corrupting the snapshot chain

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -30,7 +30,7 @@ func addReplica(c *cli.Context) error {
 
 	url := c.GlobalString("url")
 	task := sync.NewTask(url)
-	return task.AddReplica(replica)
+	return task.AddReplica(replica, nil)
 }
 func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replicaType string) error {
 	var err error
@@ -38,9 +38,9 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	task := sync.NewTask(url)
 	for {
 		if replicaType == "quorum" {
-			err = task.AddQuorumReplica(replica)
+			err = task.AddQuorumReplica(replica, s)
 		} else {
-			err = task.AddReplica(replica)
+			err = task.AddReplica(replica, s)
 		}
 		if err != nil {
 			logrus.Errorf("Error adding replica, err: %v, will retry", err)

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -126,7 +126,7 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 		return err
 	}
 
-	logrus.Infof("Synchronizing %s to %s@%s:%d", from, to, host, port)
+	logrus.Infof("Synchronizing %s@%s to %s@%s:%d", from, fromReplica.Address, to, host, port)
 	err = fromClient.SendFile(from, host, port)
 	if err != nil {
 		logrus.Infof("Failed synchronizing %s to %s@%s:%d: %v", from, to, host, port, err)


### PR DESCRIPTION
This PR addresses the situation when the sync process breaks in between.
Logs seen after this issue is hit are as follows:
```
ERRO[0m[2018-07-13T06:55:17Z] Error adding replica, err: Bad response: 500 500 Internal Server Error: {"actions":{},"code":"Server Error","detail":"","links":{"self":"http://172.18.0.5:9502/v1/replicas/1"},"message":"Failed to find metadata for volume-snap-aec261ba-1f93-4b49-b671-257dac8f2789.img","status":500,"type":"error"}, will retry 
172.18.0.2 - - [13/Jul/2018:06:55:17 +0000] "POST /v1/replicas/1?action=close HTTP/1.1" 404 0
INFO[0m[2018-07-13T06:55:19Z] Closing replica                              
INFO[0m[2018-07-13T06:55:19Z] Close replica failed, s.r not set            
INFO[0m[2018-07-13T06:55:19Z] Addreplica tcp://172.18.0.5:9502             
INFO[0m[2018-07-13T06:55:19Z] Get Volume info from controller              
INFO[0m[2018-07-13T06:55:19Z] CheckAndResetFailedRebuild tcp://172.18.0.5:9502 
INFO[0m[2018-07-13T06:55:19Z] Opening volume /vol3, size 2147483648/512    
ERRO[0m[2018-07-13T06:55:19Z] Error in request: Failed to find metadata for volume-snap-aec261ba-1f93-4b49-b671-257dac8f2789.img 
172.18.0.5 - - [13/Jul/2018:06:55:19 +0000] "POST /v1/replicas/1?action=open HTTP/1.1" 500 226
ERRO[0m[2018-07-13T06:55:19Z] CheckAndResetFailedRebuild failed, err:Bad response: 500 500 Internal Server Error: {"actions":{},"code":"Server Error","detail":"","links":{"self":"http://172.18.0.5:9502/v1/replicas/1"},"message":"Failed to find metadata for volume-snap-aec261ba-1f93-4b49-b671-257dac8f2789.img","status":500,"type":"error"}

 ERRO[0m[2018-07-13T06:55:19Z] Error adding replica, err: Bad response: 500 500 Internal Server Error: {"actions":{},"code":"Server Error","detail":"","links":{"self":"http://172.18.0.5:9502/v1/replicas/1"},"message":"Failed to find metadata for volume-snap-aec261ba-1f93-4b49-b671-257dac8f2789.img","status":500,"type":"error"}, will retry 
INFO[0m[2018-07-13T06:55:21Z] Closing replica                              
INFO[0m[2018-07-13T06:55:21Z] Close replica failed, s.r not set            
INFO[0m[2018-07-13T06:55:21Z] Addreplica tcp://172.18.0.5:9502  
```

Signed-off-by: Payes <payes.anand@cloudbyte.com>