### PR TITLE
[TA1842] Set a fixed ubuntu image as base image

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM openebs/jiva:base
+FROM openebs/jiva:base-xenial-20180417
 # FROM ubuntu:16.04
 # FROM arm=armhf/ubuntu:16.04
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM openebs/jiva:base
+FROM openebs/jiva:base-xenial-20180417
 RUN apt-get update && apt-get install -y kmod curl nfs-common fuse \
         libibverbs1 librdmacm1 libconfig-general-perl libaio1 \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Signed-off-by: kmova <kiran.mova@openebs.io>

Related to #89

jiva:base is derived by stripping the content from the jiva:0.5.4, which created additional layers. 

```
docker image inspect openebs/jiva:base

            "Layers": [
                "sha256:c8aa3ff3c3d351787cc5f84d960870fad16c9615aab7aa47ab343906fc8cfc24",
                "sha256:82718dbf791d95622b5edeedbfbc6d0f01d406d4035a30a416d51d2c7e193486",
                "sha256:3a0404adc8bdbcf7cfc28ca3a3e703d6db86f4e11853664085f00add69ccb3d7",
                "sha256:cd7b4cc1c2dd51a75939212a7b5c278eb899ac4330b9482038f72f7e6feba975",
                "sha256:bf3d982208f5bad81239ff690e81ad90e28c3cd81634b079cb938757d2435902",
                "sha256:0660c6278c9758a333dcc7267d2eac07ef2fdcf98a88b287fb2ee29e64d05b3d",
                "sha256:992b95a03a4fae2d37a1349f66b39dddcb575c02db1b640b0bd61214f5623901",
                "sha256:168ebc11d62380444d7c637c409c802572345a8b3a361b530526ccd14006a98c",
                "sha256:c08cc48b57cdbab78b303e063135b5ed1bef5e73f2eeae620413068479b3fd8b"
            ]
```

Since only the first 5 layers are related to ubuntu, created a new jiva:base with only the required ubuntu layers. (The image was derived from ubuntu:xenial-20180417)

```
docker image inspect openebs/jiva:base-xenial-20180417 
< snipped >
            "Layers": [
                "sha256:c8aa3ff3c3d351787cc5f84d960870fad16c9615aab7aa47ab343906fc8cfc24",
                "sha256:82718dbf791d95622b5edeedbfbc6d0f01d406d4035a30a416d51d2c7e193486",
                "sha256:3a0404adc8bdbcf7cfc28ca3a3e703d6db86f4e11853664085f00add69ccb3d7",
                "sha256:cd7b4cc1c2dd51a75939212a7b5c278eb899ac4330b9482038f72f7e6feba975",
                "sha256:bf3d982208f5bad81239ff690e81ad90e28c3cd81634b079cb938757d2435902"
            ]
```

The above base layers are same as the ones found on jiva:0.5.4

```
sudo docker image inspect openebs/jiva:0.5.4
            "Layers": [
                "sha256:c8aa3ff3c3d351787cc5f84d960870fad16c9615aab7aa47ab343906fc8cfc24",
                "sha256:82718dbf791d95622b5edeedbfbc6d0f01d406d4035a30a416d51d2c7e193486",
                "sha256:3a0404adc8bdbcf7cfc28ca3a3e703d6db86f4e11853664085f00add69ccb3d7",
                "sha256:cd7b4cc1c2dd51a75939212a7b5c278eb899ac4330b9482038f72f7e6feba975",
                "sha256:bf3d982208f5bad81239ff690e81ad90e28c3cd81634b079cb938757d2435902",
                "sha256:0660c6278c9758a333dcc7267d2eac07ef2fdcf98a88b287fb2ee29e64d05b3d",
                "sha256:992b95a03a4fae2d37a1349f66b39dddcb575c02db1b640b0bd61214f5623901",
                "sha256:168ebc11d62380444d7c637c409c802572345a8b3a361b530526ccd14006a98c",
                "sha256:c08cc48b57cdbab78b303e063135b5ed1bef5e73f2eeae620413068479b3fd8b"
            ]
```