### PR TITLE
Update versions for docker and go

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -27,11 +27,15 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.9.2.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
-RUN curl -sSL https://get.docker.com | bash && chmod +x /usr/bin/docker
+ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
+DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+DOCKER_URL=DOCKER_URL_${ARCH}
+
+RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
 
 # Build TCMU
 RUN cd /usr/src && \


### PR DESCRIPTION
This PR reverts the docker version update in https://github.com/openebs/jiva/commit/30883ee513559c57f0624b08940596b18a34e987
Go version has also been updated to get the following fix: https://github.com/golang/go/commit/a158382b1c9c0b95a7d41865a405736be6bc585f
Signed-off-by: Payes <payes.anand@cloudbyte.com>