### PR TITLE
[TA328] add error logs if clone is not completed.

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -234,23 +233,29 @@ func startReplica(c *cli.Context) error {
 		status := s.Replica().GetCloneStatus()
 		if status != "completed" {
 			logrus.Infof("Set clone status as inProgress")
-			if err := s.Replica().SetCloneStatus("inProgress"); err != nil {
+			if err = s.Replica().SetCloneStatus("inProgress"); err != nil {
+				logrus.Error("Error in setting the clone status as 'inProgress'")
 				return err
 			}
 			if err = CloneReplica(s, "tcp://"+address, cloneIP, snapName); err != nil {
-				logrus.Error("Error in cloning replica, found error ", err.Error())
-				logrus.Info("Setting the status of clone as error")
-				return s.Replica().SetCloneStatus("error")
+				logrus.Info("Error in cloning replica, setting clone status as 'error'")
+				if err := s.Replica().SetCloneStatus("error"); err != nil {
+					logrus.Error("Error in setting the clone status as 'error'")
+					return err
+				}
+				return err
 			}
 		}
 		logrus.Infof("Set clone status as Completed")
 		if err := s.Replica().SetCloneStatus("completed"); err != nil {
-			return fmt.Errorf("Error in setting the status of clone as complete, found error %s", err.Error())
+			logrus.Error("Error in setting the clone status as 'completed'")
+			return err
 		}
 		logrus.Infof("Clone process completed successfully\n")
 	} else {
 		logrus.Infof("Set clone status as NA")
 		if err := s.Replica().SetCloneStatus("NA"); err != nil {
+			logrus.Error("Error in setting the clone status as 'NA'")
 			return err
 		}
 	}

--- a/app/replica.go
+++ b/app/replica.go
@@ -238,9 +238,9 @@ func startReplica(c *cli.Context) error {
 				return err
 			}
 			if err = CloneReplica(s, "tcp://"+address, cloneIP, snapName); err != nil {
-				logrus.Info("Error in cloning replica, setting clone status as 'error'")
-				if err := s.Replica().SetCloneStatus("error"); err != nil {
-					logrus.Error("Error in setting the clone status as 'error'")
+				logrus.Error("Error in cloning replica, setting clone status as 'error'")
+				if statusErr := s.Replica().SetCloneStatus("error"); err != nil {
+					logrus.Errorf("Error in setting the clone status as 'error', found error:%v", statusErr)
 					return err
 				}
 				return err


### PR DESCRIPTION
On branch fix-clone-logs
Changes to be committed:
	modified:   ../../../app/replica.go

1. Why is this change necessary?
-  Error was ignored while setting the status of cloned replcas.

2. How does it address the issue?
-  Added the logs and err var to catch those errors.

3. What side effects does this change have?
-  None

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>