### PR TITLE
[TA2052] Add details of replicaStart and controllerStart in logs

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -84,6 +84,7 @@ func startController(c *cli.Context) error {
 	if frontendName == "gotgt" {
 		frontendIP = c.String("frontendIP")
 		clusterIP = c.String("clusterIP")
+		logrus.Infof("Starting controller with frontendIP: %v, and clusterIP: %v", frontendIP, clusterIP)
 	}
 	controlListener = c.String("listen")
 	factories := map[string]types.BackendFactory{}

--- a/app/replica.go
+++ b/app/replica.go
@@ -174,6 +174,9 @@ func startReplica(c *cli.Context) error {
 		return err
 	}
 
+	logrus.Infof("Starting replica having replicaType: %v, frontendIP: %v, size: %v, dir: %v", replicaType, frontendIP, size, dir)
+	logrus.Infof("Setting replicaAddr: %v, controlAddr: %v, dataAddr: %v, syncAddr: %v", address, controlAddress, dataAddress, syncAddress)
+
 	var resp error
 	controlResp := make(chan error)
 	syncResp := make(chan error)


### PR DESCRIPTION
On branch fix-controller-logs
 Changes to be committed:
	modified:   app/controller.go
	modified:   app/replica.go

1. Why is this change necessary?
-  We were not getting the details such as controllerIP, clusterIP in the
   startController logs
-  We were not getting the details such as replicaType, dir, size, address
   sync address etc in startReplica etc.

2. How does it address the issue?
-  This commit add these logs.

3. What side effects does this change have?
-  None

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>