### PR TITLE
Update jiva version

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -18,7 +18,7 @@ const (
 )
 
 const (
-	MagicVersion = uint16(0x1b01) // LongHorn01
+	MagicVersion = uint16(0x1b02) // Jiva02
 )
 
 type Message struct {


### PR DESCRIPTION
This PR was required because of the recent changes in the structure of data packets exchanged between controller and replica https://github.com/openebs/jiva/commit/24f78f39f9d35dce81a6e916ad0f6d8f7e0b9349.
It will resolve the issues arising because of the time gap between the upgrade of controller and replicas.
Signed-off-by: Payes <payes.anand@cloudbyte.com>