### PR TITLE
Avoid sending a close signal from controller to replica

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -86,7 +86,7 @@ func CheckReplicaState(frontendIP string, replicaIP string) (string, error) {
 func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, replicaType string) {
 checkagain:
 	state, err := CheckReplicaState(frontendIP, address)
-	logrus.Infof("checkreplicastate %v %v", state, err)
+	logrus.Infof("Replicastate: %v err:%v", state, err)
 	if err == nil && (state == "" || state == "ERR") {
 		s.Close(false)
 	} else {
@@ -95,6 +95,7 @@ checkagain:
 	}
 	AutoRmReplica(frontendIP, address)
 	AutoAddReplica(s, frontendIP, address, replicaType)
+	logrus.Infof("Waiting on MonitorChannel")
 	select {
 	case <-s.MonitorChannel:
 		logrus.Infof("Restart AutoConfigure Process")

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -43,7 +43,7 @@ type Remote struct {
 func (r *Remote) Close() error {
 	logrus.Infof("Closing: %s", r.Name)
 	r.StopMonitoring()
-	return r.doAction("close", nil)
+	return nil
 }
 
 func (r *Remote) open() error {

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -96,6 +96,21 @@ verify_rw_status() {
 	echo "0"
 }
 
+verify_rw_rep_count() {
+       i=0
+       count=""
+       while [ "$count" != "$1" ]; do
+               count=`get_rw_rep_count`
+               i=`expr $i + 1`
+               if [ "$i" == 50 ]; then
+                       echo "1"
+                       return
+               fi
+               sleep 2
+       done
+       echo "0"
+}
+
 #returns number of replicas connected to controller in RW mode
 get_rw_rep_count() {
 	rep_index=0
@@ -489,6 +504,29 @@ test_three_replica_stop_start() {
 	cleanup
 }
 
+test_ctrl_stop_start() {
+       echo "-----------------Test_three_replica_stop_start---------------"
+       orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3")
+       replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+       replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+       replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3")
+
+       if [ $(verify_rw_rep_count "3") != 0 ]; then
+               echo "test_ctrl_stop_start() Verify_rw_rep_count failed"
+               collect_logs_and_exit
+       fi
+
+       docker stop $orig_controller_id
+       docker start $orig_controller_id
+
+       if [ $(verify_rw_rep_count "3") != 0 ]; then
+               echo "test_ctrl_stop_start() Verify_rw_rep_count failed"
+               collect_logs_and_exit
+       fi
+
+       cleanup
+}
+
 test_replica_reregistration() {
 	echo "----------------Test_replica_reregistration------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3")
@@ -702,6 +740,7 @@ prepare_test_env
 test_single_replica_stop_start
 test_two_replica_stop_start
 test_three_replica_stop_start
+test_ctrl_stop_start
 test_replica_reregistration
 run_data_integrity_test
 create_snapshot "$CONTROLLER_IP"

--- a/controller/control.go
+++ b/controller/control.go
@@ -911,10 +911,8 @@ func (c *Controller) monitoring(address string, backend types.Backend) {
 	err := <-monitorChan
 	c.Lock()
 	defer c.Unlock()
-	if err != nil {
-		logrus.Errorf("Backend %v monitoring failed, mark as ERR: %v", address, err)
-		c.setReplicaModeNoLock(address, types.ERR)
-	}
+	logrus.Errorf("Backend %v monitoring failed, mark as ERR: %v", address, err)
+	c.setReplicaModeNoLock(address, types.ERR)
 	logrus.Infof("Monitoring stopped %v", address)
 	c.RemoveReplicaNoLock(address)
 }

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -105,8 +105,7 @@ func (r *replicator) RemoveBackend(address string) {
 
 	logrus.Infof("Remove backend: %s mode: %v", address, backend.mode)
 
-	// We cannot wait for it's return because peer may not exists anymore
-	go backend.backend.Close()
+	backend.backend.Close()
 	delete(r.backends, address)
 	r.buildReadWriters()
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -325,6 +325,7 @@ func (s *Server) Close(signalMonitor bool) error {
 	s.r = nil
 	s.Unlock()
 	if signalMonitor {
+		logrus.Infof("Signal MonitorChannel")
 		s.MonitorChannel <- struct{}{}
 	}
 	return nil


### PR DESCRIPTION
This PR addresses the issue of multiple close sent to replica after an error.
When the controller is stopped it sends a close to the replica, and when the replica's read thread errors out due to the connection break, it again sends a close to itself. 
Whenever the replica receives a close, it sends to signal to its monitor channel to restart the replica registration and addition process to controller. Multiple closes trigger multiple signals on monitorchannel which retriggers the addition process. 
Signed-off-by: Payes <payes.anand@cloudbyte.com>