### PR TITLE
lock protection in API code of controller

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -519,8 +519,6 @@ func (c *Controller) RemoveReplica(address string) error {
 }
 
 func (c *Controller) ListReplicas() []types.Replica {
-	c.Lock()
-	defer c.Unlock()
 	return c.replicas
 }
 

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"sync"
@@ -51,9 +52,11 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 	logrus.Infof("List Replicas")
 	apiContext := api.GetApiContext(req)
 	resp := client.GenericCollection{}
+	s.c.Lock()
 	for _, r := range s.c.ListReplicas() {
 		resp.Data = append(resp.Data, NewReplica(apiContext, r.Address, r.Mode))
 	}
+	s.c.Unlock()
 
 	resp.ResourceType = "replica"
 	resp.CreateTypes = map[string]string{
@@ -65,21 +68,28 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 }
 
 func (s *Server) GetReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Get Replica")
 	apiContext := api.GetApiContext(req)
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Get Replica decodeid %v failed %v", id, err)
+		rw.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+	logrus.Infof("Get Replica for id %v", id)
+
+	r := s.getReplica(apiContext, id)
+	if r == nil {
+		logrus.Errorf("Get Replica failed for id %v", id)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
 
-	apiContext.Write(s.getReplica(apiContext, id))
+	apiContext.Write(r)
 	return nil
 }
 
 func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Register Replica")
 	var (
 		regReplica      RegReplica
 		localRevCount   int64
@@ -91,8 +101,10 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 	apiContext := api.GetApiContext(req)
 
 	if err := apiContext.Read(&regReplica); err != nil {
+		logrus.Errorf("read in RegReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Register Replica for address %v", regReplica.Address)
 
 	localRevCount, _ = strconv.ParseInt(regReplica.RevCount, 10, 64)
 	local := types.RegReplica{
@@ -125,38 +137,56 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 }
 
 func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Create Replica")
 	var replica Replica
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&replica); err != nil {
+		logrus.Errorf("read in createReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Create Replica for address %v", replica.Address)
 
 	if err := s.c.AddReplica(replica.Address); err != nil {
 		return err
 	}
 
-	apiContext.Write(s.getReplica(apiContext, replica.Address))
+	r := s.getReplica(apiContext, replica.Address)
+	if r == nil {
+		logrus.Errorf("createReplica failed for id %v", replica.Address)
+		return fmt.Errorf("createReplica failed while getting it")
+	}
+
+	apiContext.Write(r)
+
 	return nil
 }
 
 func (s *Server) CreateQuorumReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Create QuorumReplica")
 	var replica Replica
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&replica); err != nil {
+		logrus.Errorf("read in createQuorumReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Create QuorumReplica for address %v", replica.Address)
 
 	if err := s.c.AddQuorumReplica(replica.Address); err != nil {
 		return err
 	}
 
-	apiContext.Write(s.getQuorumReplica(apiContext, replica.Address))
+	r := s.getQuorumReplica(apiContext, replica.Address)
+	if r == nil {
+		logrus.Errorf("createQuorumReplica failed for id %v", replica.Address)
+		return fmt.Errorf("createQuorumReplica failed while getting it")
+	}
+
+	apiContext.Write(r)
+
 	return nil
 }
 
 func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
+	s.c.Lock()
+	defer s.c.Unlock()
 	for _, r := range s.c.ListReplicas() {
 		if r.Address == id {
 			return NewReplica(context, r.Address, r.Mode)
@@ -166,6 +196,8 @@ func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
 }
 
 func (s *Server) getQuorumReplica(context *api.ApiContext, id string) *Replica {
+	s.c.Lock()
+	defer s.c.Unlock()
 	for _, r := range s.c.ListQuorumReplicas() {
 		if r.Address == id {
 			return NewReplica(context, r.Address, r.Mode)
@@ -175,25 +207,27 @@ func (s *Server) getQuorumReplica(context *api.ApiContext, id string) *Replica {
 }
 
 func (s *Server) DeleteReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Delete Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in DeleteReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Delete Replica for id %v", id)
 
 	return s.c.RemoveReplica(id)
 }
 
 func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Update Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in UpdateReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Update Replica for id %v", id)
 
 	var replica Replica
 	apiContext := api.GetApiContext(req)
@@ -207,16 +241,18 @@ func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error 
 }
 
 func (s *Server) PrepareRebuildReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Prepare Rebuild Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in PrepareRebuildReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Prepare Rebuild Replica for id %v", id)
 
 	disks, err := s.c.PrepareRebuildReplica(id)
 	if err != nil {
+		logrus.Errorf("Prepare Rebuild Replica failed %v for id %v", err, id)
 		return err
 	}
 
@@ -234,7 +270,6 @@ func (s *Server) PrepareRebuildReplica(rw http.ResponseWriter, req *http.Request
 }
 
 func (s *Server) VerifyRebuildReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Verify Rebuild Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
@@ -242,9 +277,10 @@ func (s *Server) VerifyRebuildReplica(rw http.ResponseWriter, req *http.Request)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Verify Rebuild Replica for id %v", id)
 
 	if err := s.c.VerifyRebuildReplica(id); err != nil {
-		logrus.Errorf("Err %v in verifyrebuildreplica", err)
+		logrus.Errorf("Err %v in verifyrebuildreplica for id %v", err, id)
 		return err
 	}
 

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -92,6 +92,7 @@ func (s *Server) GetVolUsage(rw http.ResponseWriter, req *http.Request) error {
 
 func (s *Server) doOp(req *http.Request, err error) error {
 	if err != nil {
+		logrus.Errorf("Error in doOp %v", err)
 		return err
 	}
 


### PR DESCRIPTION
REST API code in controller uses controller related data structures with out any lock protection.
This causes Go routine crash as below trace:
```
2018/07/25 12:20:33 http: panic serving 172.18.0.4:49932: Passed type is not a struct got: invalid
goroutine 173 [running]:
net/http.(*conn).serve.func1(0xc4200a9680)
	/usr/local/go/src/net/http/server.go:1726 +0xd0
panic(0xa886c0, 0xc420415740)
	/usr/local/go/src/runtime/panic.go:502 +0x229
github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api.getEmbedded(0xa69b00, 0x0, 0xbfda00, 0xb48c00, 0x9, 0x4112d9)
	/go/src/github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api/api.go:30 +0x4bc
github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api.getCollection(0xa69b00, 0x0, 0x2)
	/go/src/github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api/api.go:47 +0xd6
github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api.(*ApiContext).Write(0xc42047b7c0, 0xa69b00, 0x0)
	/go/src/github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api/writer.go:34 +0x39
github.com/openebs/jiva/controller/rest.(*Server).GetReplica(0xc420158070, 0x7fdcfce61400, 0xc4202770b0, 0xc42034b200, 0xbea798, 0x0)
	/go/src/github.com/openebs/jiva/controller/rest/replica.go:75 +0xfb
github.com/openebs/jiva/controller/rest.(*Server).GetReplica-fm(0x7fdcfce61400, 0xc4202770b0, 0xc42034b200, 0xa87800, 0xbea798)
	/go/src/github.com/openebs/jiva/controller/rest/router.go:35 +0x48
github.com/openebs/jiva/replica/rest.HandleError.func1(0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/go/src/github.com/openebs/jiva/replica/rest/router.go:15 +0x47
net/http.HandlerFunc.ServeHTTP(0xc420157e70, 0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/usr/local/go/src/net/http/server.go:1947 +0x44
github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api.ApiHandler.func1(0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/go/src/github.com/openebs/jiva/vendor/github.com/rancher/go-rancher/api/handler.go:26 +0x127
net/http.HandlerFunc.ServeHTTP(0xc4202c2aa0, 0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/usr/local/go/src/net/http/server.go:1947 +0x44
github.com/openebs/jiva/vendor/github.com/gorilla/context.ClearHandler.func1(0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/go/src/github.com/openebs/jiva/vendor/github.com/gorilla/context/context.go:141 +0x8b
net/http.HandlerFunc.ServeHTTP(0xc4202c2ac0, 0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/usr/local/go/src/net/http/server.go:1947 +0x44
github.com/openebs/jiva/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc420152a00, 0x7fdcfce61400, 0xc4202770b0, 0xc42034b200)
	/go/src/github.com/openebs/jiva/vendor/github.com/gorilla/mux/mux.go:103 +0x226
github.com/openebs/jiva/vendor/github.com/gorilla/handlers.loggingHandler.ServeHTTP(0xbef800, 0xc42000e018, 0xbef160, 0xc420152a00, 0xbf5160, 0xc4202307e0, 0xc42034b200)
	/go/src/github.com/openebs/jiva/vendor/github.com/gorilla/handlers/handlers.go:69 +0x123
github.com/openebs/jiva/util.filteredLoggingHandler.ServeHTTP(0xc4202c76e0, 0xbef160, 0xc420152a00, 0xbefe40, 0xc4202c3640, 0xbf5160, 0xc4202307e0, 0xc42034b200)
```

This PR is to provide lock protection for controller's data structures while accessing them in REST API handlers.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>