### PR TITLE
Lock protection for replica data structures during REST API handling

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -519,8 +519,6 @@ func (c *Controller) RemoveReplica(address string) error {
 }
 
 func (c *Controller) ListReplicas() []types.Replica {
-	c.Lock()
-	defer c.Unlock()
 	return c.replicas
 }
 

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"sync"
@@ -51,9 +52,11 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 	logrus.Infof("List Replicas")
 	apiContext := api.GetApiContext(req)
 	resp := client.GenericCollection{}
+	s.c.Lock()
 	for _, r := range s.c.ListReplicas() {
 		resp.Data = append(resp.Data, NewReplica(apiContext, r.Address, r.Mode))
 	}
+	s.c.Unlock()
 
 	resp.ResourceType = "replica"
 	resp.CreateTypes = map[string]string{
@@ -65,21 +68,28 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 }
 
 func (s *Server) GetReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Get Replica")
 	apiContext := api.GetApiContext(req)
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Get Replica decodeid %v failed %v", id, err)
+		rw.WriteHeader(http.StatusNotFound)
+		return nil
+	}
+	logrus.Infof("Get Replica for id %v", id)
+
+	r := s.getReplica(apiContext, id)
+	if r == nil {
+		logrus.Errorf("Get Replica failed for id %v", id)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
 
-	apiContext.Write(s.getReplica(apiContext, id))
+	apiContext.Write(r)
 	return nil
 }
 
 func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Register Replica")
 	var (
 		regReplica      RegReplica
 		localRevCount   int64
@@ -91,8 +101,10 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 	apiContext := api.GetApiContext(req)
 
 	if err := apiContext.Read(&regReplica); err != nil {
+		logrus.Errorf("read in RegReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Register Replica for address %v", regReplica.Address)
 
 	localRevCount, _ = strconv.ParseInt(regReplica.RevCount, 10, 64)
 	local := types.RegReplica{
@@ -125,38 +137,56 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 }
 
 func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Create Replica")
 	var replica Replica
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&replica); err != nil {
+		logrus.Errorf("read in createReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Create Replica for address %v", replica.Address)
 
 	if err := s.c.AddReplica(replica.Address); err != nil {
 		return err
 	}
 
-	apiContext.Write(s.getReplica(apiContext, replica.Address))
+	r := s.getReplica(apiContext, replica.Address)
+	if r == nil {
+		logrus.Errorf("createReplica failed for id %v", replica.Address)
+		return fmt.Errorf("createReplica failed while getting it")
+	}
+
+	apiContext.Write(r)
+
 	return nil
 }
 
 func (s *Server) CreateQuorumReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Create QuorumReplica")
 	var replica Replica
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&replica); err != nil {
+		logrus.Errorf("read in createQuorumReplica failed %v", err)
 		return err
 	}
+	logrus.Infof("Create QuorumReplica for address %v", replica.Address)
 
 	if err := s.c.AddQuorumReplica(replica.Address); err != nil {
 		return err
 	}
 
-	apiContext.Write(s.getQuorumReplica(apiContext, replica.Address))
+	r := s.getQuorumReplica(apiContext, replica.Address)
+	if r == nil {
+		logrus.Errorf("createQuorumReplica failed for id %v", replica.Address)
+		return fmt.Errorf("createQuorumReplica failed while getting it")
+	}
+
+	apiContext.Write(r)
+
 	return nil
 }
 
 func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
+	s.c.Lock()
+	defer s.c.Unlock()
 	for _, r := range s.c.ListReplicas() {
 		if r.Address == id {
 			return NewReplica(context, r.Address, r.Mode)
@@ -166,6 +196,8 @@ func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
 }
 
 func (s *Server) getQuorumReplica(context *api.ApiContext, id string) *Replica {
+	s.c.Lock()
+	defer s.c.Unlock()
 	for _, r := range s.c.ListQuorumReplicas() {
 		if r.Address == id {
 			return NewReplica(context, r.Address, r.Mode)
@@ -175,25 +207,27 @@ func (s *Server) getQuorumReplica(context *api.ApiContext, id string) *Replica {
 }
 
 func (s *Server) DeleteReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Delete Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in DeleteReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Delete Replica for id %v", id)
 
 	return s.c.RemoveReplica(id)
 }
 
 func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Update Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in UpdateReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Update Replica for id %v", id)
 
 	var replica Replica
 	apiContext := api.GetApiContext(req)
@@ -207,16 +241,18 @@ func (s *Server) UpdateReplica(rw http.ResponseWriter, req *http.Request) error 
 }
 
 func (s *Server) PrepareRebuildReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Prepare Rebuild Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
+		logrus.Errorf("Getting ID in PrepareRebuildReplica failed %v", err)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Prepare Rebuild Replica for id %v", id)
 
 	disks, err := s.c.PrepareRebuildReplica(id)
 	if err != nil {
+		logrus.Errorf("Prepare Rebuild Replica failed %v for id %v", err, id)
 		return err
 	}
 
@@ -234,7 +270,6 @@ func (s *Server) PrepareRebuildReplica(rw http.ResponseWriter, req *http.Request
 }
 
 func (s *Server) VerifyRebuildReplica(rw http.ResponseWriter, req *http.Request) error {
-	logrus.Infof("Verify Rebuild Replica")
 	vars := mux.Vars(req)
 	id, err := DencodeID(vars["id"])
 	if err != nil {
@@ -242,9 +277,10 @@ func (s *Server) VerifyRebuildReplica(rw http.ResponseWriter, req *http.Request)
 		rw.WriteHeader(http.StatusNotFound)
 		return nil
 	}
+	logrus.Infof("Verify Rebuild Replica for id %v", id)
 
 	if err := s.c.VerifyRebuildReplica(id); err != nil {
-		logrus.Errorf("Err %v in verifyrebuildreplica", err)
+		logrus.Errorf("Err %v in verifyrebuildreplica for id %v", err, id)
 		return err
 	}
 

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -92,6 +92,7 @@ func (s *Server) GetVolUsage(rw http.ResponseWriter, req *http.Request) error {
 
 func (s *Server) doOp(req *http.Request, err error) error {
 	if err != nil {
+		logrus.Errorf("Error in doOp %v", err)
 		return err
 	}
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -187,10 +187,8 @@ func (s *Server) PrevStatus() (State, Info) {
 	return Closed, info
 }
 
-/*
-* Stats() returns the revisionCache and Peerdetails
-* TODO: What to return in Stats and GetUsage if s.r is nil?
- */
+// Stats returns the revisionCache and Peerdetails
+// TODO: What to return in Stats and GetUsage if s.r is nil?
 func (s *Server) Stats() *types.Stats {
 	r := s.r
 	var revisionCache int64

--- a/replica/server.go
+++ b/replica/server.go
@@ -187,6 +187,10 @@ func (s *Server) PrevStatus() (State, Info) {
 	return Closed, info
 }
 
+/*
+* Stats() returns the revisionCache and Peerdetails
+* TODO: What to return in Stats and GetUsage if s.r is nil?
+ */
 func (s *Server) Stats() *types.Stats {
 	r := s.r
 	var revisionCache int64

--- a/replica/server.go
+++ b/replica/server.go
@@ -121,6 +121,7 @@ func (s *Server) Reload() error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("returning as s.r is nil in reloading volume")
 		return nil
 	}
 
@@ -188,14 +189,32 @@ func (s *Server) PrevStatus() (State, Info) {
 
 func (s *Server) Stats() *types.Stats {
 	r := s.r
-	return &types.Stats{
-		RevisionCounter: r.revisionCache,
-		ReplicaCounter:  int64(r.peerCache.ReplicaCount),
+	var revisionCache int64
+	var replicaCount int64
+
+	revisionCache = 0
+	replicaCount = 0
+	if r != nil {
+		revisionCache = r.revisionCache
+		replicaCount = int64(r.peerCache.ReplicaCount)
 	}
+
+	stats1 := &types.Stats{
+		RevisionCounter: revisionCache,
+		ReplicaCounter:  replicaCount,
+	}
+	return stats1
 }
 
 func (s *Server) GetUsage() (*types.VolUsage, error) {
-	return s.r.GetUsage()
+	if s.r != nil {
+		return s.r.GetUsage()
+	}
+	return &types.VolUsage{
+		UsedLogicalBlocks: 0,
+		UsedBlocks:        0,
+		SectorSize:        0,
+	}, nil
 }
 
 func (s *Server) SetRebuilding(rebuilding bool) error {
@@ -227,6 +246,7 @@ func (s *Server) Revert(name, created string) error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("Revert is not performed as s.r is nil")
 		return nil
 	}
 
@@ -245,6 +265,7 @@ func (s *Server) Snapshot(name string, userCreated bool, createdTime string) err
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("snapshot is not performed as s.r is nil")
 		return nil
 	}
 
@@ -258,6 +279,7 @@ func (s *Server) RemoveDiffDisk(name string) error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("RemoveDiffDisk is not performed as s.r is nil")
 		return nil
 	}
 
@@ -270,6 +292,7 @@ func (s *Server) ReplaceDisk(target, source string) error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("ReplicaDisk is not performed as s.r is nil")
 		return nil
 	}
 
@@ -282,6 +305,7 @@ func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("PrepareRemoveDisk is not performed as s.r is nil")
 		return nil, nil
 	}
 
@@ -294,6 +318,7 @@ func (s *Server) Delete() error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("Delete is not performed as s.r is nil")
 		return nil
 	}
 
@@ -358,6 +383,7 @@ func (s *Server) SetRevisionCounter(counter int64) error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("s.r is nil during setRevisionCounter")
 		return nil
 	}
 	return s.r.SetRevisionCounter(counter)
@@ -369,6 +395,7 @@ func (s *Server) UpdatePeerDetails(peerDetails types.PeerDetails) error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Infof("s.r is nil during updatePeerDetails")
 		return nil
 	}
 	return s.r.UpdatePeerDetails(peerDetails)


### PR DESCRIPTION
In replicas of jiva volumes, during REST API handling, replica related data structures are used without any lock protection.
This leads to data race between reader and writer of those structures.

This PR is to lock protect of those structures during REST API handling.

This PR also adds logs to track REST APIs and its errors.