### PR TITLE
[TA2117][TA2118] Issues in sync process due to breakages

### DIFF
--- a/app/sync_agent.go
+++ b/app/sync_agent.go
@@ -54,7 +54,7 @@ func startSyncAgent(c *cli.Context) error {
 
 	server := agent.NewServer(start, end)
 	router := agent.NewRouter(server)
-	logrus.Infof("Listening on sync %s", listen)
+	logrus.Infof("Listening on sync %s start: %d end: %d", listen, start, end)
 
 	return http.ListenAndServe(listen, router)
 }

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -463,11 +463,9 @@ test_three_replica_stop_start() {
 	replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3")
 
 	sleep 5
-	#run_ios_to_test_stop_start &
-	#sleep 8
 
 	count=0
-	while [ "$count" != 100 ]; do
+	while [ "$count" != 5 ]; do
 		docker stop $orig_controller_id &
 		docker stop $replica1_id &
 		wait
@@ -479,9 +477,8 @@ test_three_replica_stop_start() {
 		count=`expr $count + 1`
 	done
 
-	wait
-	cleanup
-	exit 0
+	run_ios_to_test_stop_start &
+	sleep 8
 
 	docker stop $replica1_id
 	if [ $(verify_rw_status "RW") == 0 ]; then
@@ -779,8 +776,8 @@ verify_clone_status() {
 }
 
 prepare_test_env
-#test_single_replica_stop_start
-#test_two_replica_stop_start
+test_single_replica_stop_start
+test_two_replica_stop_start
 test_three_replica_stop_start
 test_ctrl_stop_start
 test_replica_reregistration

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -158,6 +158,7 @@ func (c *ControllerClient) GetReplica(address string) (*rest.Replica, error) {
 func (c *ControllerClient) VerifyRebuildReplica(address string) error {
 	replica, err := c.GetReplica(address)
 	if err != nil {
+		logrus.Errorf("getReplica in verifyRebuildReplica failed %s", address)
 		return err
 	}
 	return c.post(replica.Actions["verifyrebuild"], &replica, nil)
@@ -167,6 +168,7 @@ func (c *ControllerClient) PrepareRebuild(address string) (*rest.PrepareRebuildO
 	var output rest.PrepareRebuildOutput
 	replica, err := c.GetReplica(address)
 	if err != nil {
+		logrus.Errorf("getReplica in prepareRebuild failed %s", address)
 		return nil, err
 	}
 	err = c.post(replica.Actions["preparerebuild"], &replica, &output)

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -92,6 +92,7 @@ func (c *ReplicaClient) Revert(name, created string) error {
 func (c *ReplicaClient) Close() error {
 	r, err := c.GetReplica()
 	if err != nil {
+		logrus.Errorf("getReplica in close failed")
 		return err
 	}
 
@@ -101,6 +102,7 @@ func (c *ReplicaClient) Close() error {
 func (c *ReplicaClient) SetRebuilding(rebuilding bool) error {
 	r, err := c.GetReplica()
 	if err != nil {
+		logrus.Errorf("getReplica in setrebuilding failed %v", rebuilding)
 		return err
 	}
 
@@ -112,6 +114,7 @@ func (c *ReplicaClient) SetRebuilding(rebuilding bool) error {
 func (c *ReplicaClient) RemoveDisk(disk string) error {
 	r, err := c.GetReplica()
 	if err != nil {
+		logrus.Errorf("getReplica in removeDisk failed")
 		return err
 	}
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -542,7 +542,15 @@ func (r *Replica) DisplayChain() ([]string, error) {
 	for cur != "" {
 		disk, ok := r.diskData[cur]
 		if !ok {
-			return nil, fmt.Errorf("Failed to find metadata for %s", cur)
+			cur1 := r.info.Head
+			for cur1 != "" {
+				logrus.Errorf("cur1: %s", cur1)
+				if _, ok1 := r.diskData[cur1]; !ok1 {
+					break
+				}
+				cur1 = r.diskData[cur1].Parent
+			}
+			return nil, fmt.Errorf("Failed to find metadata for %s in DisplayChain", cur)
 		}
 		if !disk.Removed {
 			result = append(result, cur)
@@ -563,6 +571,14 @@ func (r *Replica) Chain() ([]string, error) {
 	for cur != "" {
 		result = append(result, cur)
 		if _, ok := r.diskData[cur]; !ok {
+			cur1 := r.info.Head
+			for cur1 != "" {
+				logrus.Errorf("cur1: %s", cur1)
+				if _, ok1 := r.diskData[cur1]; !ok1 {
+					break
+				}
+				cur1 = r.diskData[cur1].Parent
+			}
 			return nil, fmt.Errorf("Failed to find metadata for %s", cur)
 		}
 		cur = r.diskData[cur].Parent

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -160,6 +160,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	}
 
 	if err := os.Mkdir(dir, 0700); err != nil && !os.IsExist(err) {
+		logrus.Errorf("Error %v in mkdir %v", err, dir)
 		return nil, err
 	}
 
@@ -601,15 +602,18 @@ func (r *Replica) encodeToFile(obj interface{}, file string) error {
 
 	f, err := os.Create(r.diskPath(file + ".tmp"))
 	if err != nil {
+		logrus.Errorf("Error %v in creating tmp file %s", err, file)
 		return err
 	}
 	defer f.Close()
 
 	if err := json.NewEncoder(f).Encode(&obj); err != nil {
+		logrus.Errorf("Error %v in encoder to file %s", err, file)
 		return err
 	}
 
 	if err := f.Close(); err != nil {
+		logrus.Errorf("Error %v in encoder while closing file %s", err, file)
 		return err
 	}
 
@@ -875,6 +879,7 @@ func (r *Replica) openLiveChain() error {
 		parent := chain[i]
 		f, err := r.openFile(parent, 0)
 		if err != nil {
+			logrus.Errorf("error %v in openFile %s", err, parent)
 			return err
 		}
 
@@ -898,6 +903,7 @@ func (r *Replica) readMetadata() (bool, error) {
 	for _, file := range files {
 		if file.Name() == volumeMetaData {
 			if err := r.unmarshalFile(file.Name(), &r.info); err != nil {
+				logrus.Errorf("Error %v in unmarshalFile %s", err, file.Name())
 				return false, err
 			}
 			r.volume.sectorSize = defaultSectorSize
@@ -926,6 +932,7 @@ func (r *Replica) readMetadata() (bool, error) {
 func (r *Replica) readDiskData(file string) error {
 	var data disk
 	if err := r.unmarshalFile(file, &data); err != nil {
+		logrus.Errorf("Error %v in unmarshalFile %s during readDisk", err, file)
 		return err
 	}
 

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -207,7 +207,6 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
 		r.CloneStatus = rep.GetCloneStatus()
 	}
-
 	return r
 }
 

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
 	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
@@ -85,6 +86,7 @@ func (s *Server) GetVolUsage(rw http.ResponseWriter, req *http.Request) error {
 
 func (s *Server) doOp(req *http.Request, err error) error {
 	if err != nil {
+		logrus.Errorf("Error %v in doOp: %v", err, req.RequestURI)
 		return err
 	}
 
@@ -213,7 +215,12 @@ func (s *Server) RevertReplica(rw http.ResponseWriter, req *http.Request) error 
 }
 
 func (s *Server) ReloadReplica(rw http.ResponseWriter, req *http.Request) error {
-	return s.doOp(req, s.s.Reload())
+	var err error
+	if err = s.doOp(req, s.s.Reload()); err != nil {
+		logrus.Errorf("error in reloadReplica %v", err)
+	}
+	return err
+
 }
 
 func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/server.go
+++ b/replica/server.go
@@ -110,6 +110,7 @@ func (s *Server) Open() error {
 	logrus.Infof("Opening volume %s, size %d/%d", s.dir, size, sectorSize)
 	r, err := New(size, sectorSize, s.dir, s.backing, s.ServerType)
 	if err != nil {
+		logrus.Errorf("Error %v during open", err)
 		return err
 	}
 	s.r = r
@@ -121,12 +122,14 @@ func (s *Server) Reload() error {
 	defer s.Unlock()
 
 	if s.r == nil {
+		logrus.Errorf("s.r is NULL in reload")
 		return nil
 	}
 
 	logrus.Infof("Reloading volume")
 	newReplica, err := s.r.Reload()
 	if err != nil {
+		logrus.Errorf("error in Reload")
 		return err
 	}
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -61,6 +61,7 @@ func (s *Server) readWrite(ret chan<- error) {
 	for {
 		msg, err := s.wire.Read()
 		if err == io.EOF {
+			logrus.Errorf("Received EOF: %v", err)
 			ret <- err
 			break
 		} else if err != nil {

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -203,6 +203,8 @@ func (s *Server) launchSync(p *Process) error {
 	} else {
 		args = append(args, p.SrcFile)
 	}
+	//Overwriting default of 2 mins to 7 seconds for ssync client in retrying
+	//to open file on ssync server.
 	args = append(args, "-timeout", strconv.Itoa(7))
 
 	cmd := reexec.Command(args...)

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -205,6 +205,9 @@ func (s *Server) launchSync(p *Process) error {
 	}
 	//Overwriting default of 2 mins to 7 seconds for ssync client in retrying
 	//to open file on ssync server.
+	//When the ssync server restarts and opens listener on same port that
+	//ssync client is trying to connect for 120 seconds, it can cause corruption
+	//as ssync client and server are looking at different files.
 	args = append(args, "-timeout", strconv.Itoa(7))
 
 	cmd := reexec.Command(args...)

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -192,6 +192,14 @@ func (s *Server) launchSync(p *Process) error {
 	if p.Host != "" {
 		args = append(args, "-host", p.Host)
 	}
+
+	//Overwriting default of 2 mins to 7 seconds for ssync client in retrying
+	//to open file on ssync server.
+	//When the ssync server restarts and opens listener on same port that
+	//ssync client is trying to connect for 120 seconds, it can cause corruption
+	//as ssync client and server are looking at different files.
+	args = append(args, "-timeout", strconv.Itoa(7))
+
 	if p.Port != 0 {
 		args = append(args, "-port", strconv.Itoa(p.Port))
 	}
@@ -203,12 +211,6 @@ func (s *Server) launchSync(p *Process) error {
 	} else {
 		args = append(args, p.SrcFile)
 	}
-	//Overwriting default of 2 mins to 7 seconds for ssync client in retrying
-	//to open file on ssync server.
-	//When the ssync server restarts and opens listener on same port that
-	//ssync client is trying to connect for 120 seconds, it can cause corruption
-	//as ssync client and server are looking at different files.
-	args = append(args, "-timeout", strconv.Itoa(7))
 
 	cmd := reexec.Command(args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -193,7 +193,7 @@ func (s *Server) launchSync(p *Process) error {
 	} else {
 		args = append(args, p.SrcFile)
 	}
-	args = append(args, "-timeout", strconv.Itoa(5))
+	args = append(args, "-timeout", strconv.Itoa(7))
 
 	cmd := reexec.Command(args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -443,11 +443,6 @@ func (t *Task) syncFile(from, to string, fromClient *replicaClient.ReplicaClient
 	logrus.Infof("Synchronizing %s to %s@%s:%d", from, to, host, port)
 	err = fromClient.SendFile(from, host, port)
 	if err != nil {
-		//		if err1 := os.Remove(to); err1 != nil {
-		//			logrus.Errorf("Remove %s failed with err %v", to, err1)
-		//		} else {
-		//			logrus.Infof("Removed %s due to err in sync", to)
-		//		}
 		logrus.Infof("Failed synchronizing %s to %s@%s:%d: %v", from, to, host, port, err)
 	} else {
 		logrus.Infof("Done synchronizing %s to %s@%s:%d", from, to, host, port)


### PR DESCRIPTION
This PR addresses the below issues when there are any breakages during sync process:

==> A port map has been maintained in sync-agent. This is supposed to be only for ssync servers that are created in that replica. But, it is getting updated even for ssync clients created in that replica. This can cause problem as below:
Consider ssync server is created on port 9759, and, this updated the port map. Due to reason that ssync client is crashed, that ssync server process still stays, and so, listener also exists.
During this time, if another replica have listener on 9759 and asked this replica to help in rebuilding, current code adds entry related to 9759 port to map, and deletes the entry from map once the file is synced.
Later, this port 9759 again can get alloted and cause 'bind port failed', as ssync server still exists.
This PR addresses this by adding only the ssync server details to the map.

==> Currently, ssync client keeps retrying for 120 seconds to open the file 'file1' in ssync server on a particular port. Once it succeeds, it starts sending the file content.
Now, consider the case where ssync server is restarted and starts rebuilding from different replica. If ssync server opens same port for different file 'file2' to sync from different ssync client, first ssync client can gets succeeded in opening the file and starts sending data of 'file1', when second ssync client also will be sending the content.
This PR handles this by setting the timeout value as 7 seconds instead of 120 seconds. Another fix can be attempted by re-designing the sync process completely.

==>Added logs to registration process of replica on replica side.