### PR TITLE
[TA2189]Verifying for success response from healthy replica during sy…

### DIFF
--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -256,6 +256,11 @@ func (c *ReplicaClient) SendFile(from, host string, port int) error {
 				start = 1 * time.Second
 			}
 		case 0:
+			/*
+			* During sync process, degraded replica receives exitCode as success
+			* in cases like restart of healthy replica.
+			* Below changes verifies the exitCode once again - PR101
+			 */
 			successCount++
 			if successCount == 2 {
 				return nil

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -240,6 +240,7 @@ func (c *ReplicaClient) SendFile(from, host string, port int) error {
 		return err
 	}
 
+	successCount := 0
 	start := 250 * time.Millisecond
 	for {
 		err := c.get(running.Links["self"], &running)
@@ -255,7 +256,11 @@ func (c *ReplicaClient) SendFile(from, host string, port int) error {
 				start = 1 * time.Second
 			}
 		case 0:
-			return nil
+			successCount++
+			if successCount == 2 {
+				return nil
+			}
+			time.Sleep(start)
 		default:
 			return fmt.Errorf("ExitCode: %d", running.ExitCode)
 		}


### PR DESCRIPTION
…nc process

In Jiva, due to cases like restart of healthy replica during sync process, there are scenarios where degraded replica receives it as success as shown below:

Healthy replica logs during its down time:
```
[34mINFO [0m[0005] Running ssync [ssync -host 172.18.0.5 -port 9702 volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta -timeout 7]

[34mINFO [0m[0000] Syncing volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta to 172.18.0.5:9702...



[34mINFO [0m[0000] source file size: 112, setting up directIo: false

[33mWARN [0m[0000] Failed to open server: 172.18.0.5:9702, Retrying...

[33mWARN [0m[0000] Failed to open server: 172.18.0.5:9702, Retrying...

STATE =  closed
```

Degraded replica logs:
```
[34mINFO [0m[2018-07-28T21:19:41Z] Synchronizing volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta to volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta@172.18.0.5:9702

[34mINFO [0m[0004] Running ssync [ssync -port 9702 -daemon volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta -timeout 7]

[34mINFO [0m[0000] Creating Ssync service

[31mERRO [0m[2018-07-28T21:19:42Z] Read msg.Version failed, Error: EOF

[31mERRO [0m[2018-07-28T21:19:42Z] Received EOF: EOF

[31mERRO [0m[2018-07-28T21:19:42Z] Read msg.Version failed, Error: EOF

[31mERRO [0m[2018-07-28T21:19:42Z] Received EOF: EOF

[34mINFO [0m[2018-07-28T21:19:50Z] Done synchronizing volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta to volume-snap-00103065-6f23-4da5-9d4b-d1168d5e9559.img.meta@172.18.0.5:9702
```
In this state, even if entire data is not synced to degraded replica, it will be marked as rebuilding done.

This PR makes degraded replica to verify from healthy replica that sync process for given file is completed.

Signed-off-by: Vishnu Itta <vitta@mayadata.io>