### PR TITLE
[TA2437] Fix goroutine leaks in jiva

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -214,7 +214,7 @@ verify_go_routine_leak() {
     passed=0
     req_cnt=0
     while [ "$i" != 30 ]; do
-            curl http://$2:9503
+            curl http://$2:9503 &
             i=`expr $i + 1`
             sleep 2
     done

--- a/replica/rpc/server.go
+++ b/replica/rpc/server.go
@@ -38,7 +38,6 @@ func (s *Server) ListenAndServe() error {
 			logrus.Errorf("failed to accept connection %v", err)
 			continue
 		}
-
 		err = conn.SetKeepAlive(true)
 		if err != nil {
 			logrus.Errorf("failed to accept connection %v", err)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -35,7 +35,10 @@ func (s *Server) Handle() error {
 		err error
 	)
 	defer func() {
-		s.monitorChan <- struct{}{}
+		select {
+		case s.monitorChan <- struct{}{}:
+		default:
+		}
 	}()
 	ret := make(chan error)
 	go s.readWrite(ret)
@@ -51,6 +54,7 @@ func (s *Server) Handle() error {
 			return nil
 		case err = <-ret:
 			if err != nil {
+				s.wire.conn.Close()
 				return err
 			}
 		}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -54,7 +54,6 @@ func (s *Server) Handle() error {
 			return nil
 		case err = <-ret:
 			if err != nil {
-				s.wire.conn.Close()
 				return err
 			}
 		}


### PR DESCRIPTION
 On branch US2634-fix-goroutine-leaks
 Changes to be committed:
	modified:   replica/rest/router.go
	modified:   replica/rpc/server.go
	modified:   replica/server.go
1. Why is this change necessary?
-  To fix the goroutine leaks in jiva.

2. How does it address the issue?
-  Added an additional check before handling client requests for verification
   of the expected rpc client from controller.
-  Added an additional field `ClientAddr` in the `replica.Server` which can be
   used for verifying the clients and hence avoid goroutine leak.

3. What side effects does this change have?
-  None

4. How to verify this change?
-  Make request to replica by `curl replicaIP:9503` and open the debug/pprof UI
   and you should not see the increase in the goroutines.

5. Any specific message for reviewer ?
-  None

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>