### PR TITLE
[TA2491, TA2515] Purge replica files when replicas are deleted

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -361,10 +361,19 @@ test_two_replica_delete() {
 	# This will delay sync between replicas
 	run_ios_to_test_stop_start
 	verify_delete_replica "Delete replicas test2"
-	sleep 5
 
 	docker stop $replica1_id
 	docker stop $replica2_id
+    sleep 5
+
+    docker start $replica1_id
+	docker start $replica2_id
+    sleep 5
+
+	docker stop $replica1_id
+    verify_delete_replica "Delete replicas test2"
+
+    docker stop $replica2_id
 	docker stop $orig_controller_id
 	cleanup
 }
@@ -804,14 +813,14 @@ verify_clone_status() {
 }
 
 prepare_test_env
-test_single_replica_stop_start
-test_two_replica_stop_start
+#test_single_replica_stop_start
+#test_two_replica_stop_start
 test_two_replica_delete
-test_three_replica_stop_start
-test_ctrl_stop_start
-test_replica_reregistration
-run_data_integrity_test
-create_snapshot "$CONTROLLER_IP"
-test_clone_feature
-run_vdbench_test_on_volume
-run_libiscsi_test_suite
+#test_three_replica_stop_start
+#test_ctrl_stop_start
+#test_replica_reregistration
+#run_data_integrity_test
+#create_snapshot "$CONTROLLER_IP"
+#test_clone_feature
+#run_vdbench_test_on_volume
+#run_libiscsi_test_suite

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -383,15 +383,15 @@ verify_delete_replica_unsuccess() {
                echo $2"  --failed"
         collect_logs_and_exit
     fi
-    #verify whether no of replicas are still the same as it was sent or nor.
+    #verify whether number of replicas are still the same as it was sent or nor.
     verify_replica_cnt "$1" "$2"
     echo $2"  --passed"
     return
 }
 
 #verify_delete_replica verifies that if the replication factor condition
-#is met then it will delete the replicas.So before calling this function
-#ensure that no of replicas should be equal to the RF.
+#is met then it will delete the replicas. So before calling this function
+#ensure that number of replicas should be equal to the RF.
 verify_delete_replica() {
     old_replica_count=$(get_replica_count $CONTROLLER_IP)
     echo "$old_replica_count"

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -414,18 +414,18 @@ test_two_replica_delete() {
 
 	docker stop $replica1_id
 	docker stop $replica2_id
-        sleep 5
+	sleep 5
 
-        docker start $replica1_id
+	docker start $replica1_id
 	docker start $replica2_id
-        sleep 5
-        verify_replica_cnt "2" "Two replica count test3"
+	sleep 5
+	verify_replica_cnt "2" "Two replica count test3"
 
 	docker stop $replica1_id
-        verify_replica_cnt "1" "One replica count test4"
-        verify_delete_replica_unsuccess "1" "Delete replicas with RF=2 and 1 registered replica test5"
+	verify_replica_cnt "1" "One replica count test4"
+	verify_delete_replica_unsuccess "1" "Delete replicas with RF=2 and 1 registered replica test5"
 
-        docker stop $replica2_id
+	docker stop $replica2_id
 	docker stop $orig_controller_id
 	cleanup
 }

--- a/controller/rest/delete.go
+++ b/controller/rest/delete.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	zeroReplica     = "No of replicas are zero"
+	zeroReplica     = "No replicas registered with this controller instance"
 	repClientErr    = "Error in creating replica client"
 	deletionSuccess = "Replica deleted successfully"
 	deletionErr     = "Error deleting replica"

--- a/controller/rest/delete.go
+++ b/controller/rest/delete.go
@@ -1,0 +1,77 @@
+package rest
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	replicaClient "github.com/openebs/jiva/replica/client"
+	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
+)
+
+const (
+	zeroReplica     = "No of replicas are zero"
+	repClientErr    = "Error in creating replica client"
+	deletionSuccess = "Replica deleted successfully"
+	deletionErr     = "Error in making 'Delete' request to replica"
+)
+
+type DeletedReplica struct {
+	Replica string `json:"replica"`
+	Error   error  `json:"error"`
+	Msg     string `json:"msg"`
+}
+
+type DeletedReplicas struct {
+	DeletedReplicasInfo []DeletedReplica `json:"replicas"`
+}
+
+func (r *DeletedReplicas) appendReplicas(err error, addr, msg string) {
+	deletedReplica := DeletedReplica{
+		Replica: addr,
+		Error:   err,
+		Msg:     msg,
+	}
+	r.DeletedReplicasInfo = append(r.DeletedReplicasInfo, deletedReplica)
+}
+
+func SetDeleteReplicaOutput(deletedReplicas DeletedReplicas) *DeleteReplicaOutput {
+	return &DeleteReplicaOutput{
+		client.Resource{
+			Type: "delete",
+		},
+		deletedReplicas,
+	}
+}
+
+func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
+	var (
+		volumeNotFound  = errors.New("Volume not found")
+		deletedReplicas DeletedReplicas
+	)
+	apiContext := api.GetApiContext(req)
+
+	if len(s.c.ListReplicas()) == 0 {
+		deletedReplicas.appendReplicas(volumeNotFound, "", zeroReplica)
+		apiContext.Write(SetDeleteReplicaOutput(deletedReplicas))
+		return nil
+	}
+	for _, replica := range s.c.ListReplicas() {
+		repClient, err := replicaClient.NewReplicaClient(replica.Address)
+		if err != nil {
+			logrus.Infof("Error in delete operation of replica %v , found error %v", replica.Address, err)
+			deletedReplicas.appendReplicas(err, replica.Address, repClientErr)
+			continue
+		}
+		logrus.Info("Sending delete request to replica : ", replica.Address)
+		if err := repClient.Delete("/delete"); err != nil {
+			logrus.Infof("Error in delete operation of replica %v , found error %v", replica.Address, err)
+			deletedReplicas.appendReplicas(err, replica.Address, deletionErr)
+			continue
+		}
+		deletedReplicas.appendReplicas(nil, replica.Address, deletionSuccess)
+	}
+	apiContext.Write(SetDeleteReplicaOutput(deletedReplicas))
+	return nil
+}

--- a/controller/rest/delete.go
+++ b/controller/rest/delete.go
@@ -59,13 +59,13 @@ func (s *Server) delete(replicas *DeletedReplicas, wg *sync.WaitGroup) {
 			defer wg.Done()
 			repClient, err := replicaClient.NewReplicaClient(addr)
 			if err != nil {
-				logrus.Infof("Error in delete operation of replica %v , found error %v", addr, err)
+				logrus.Infof("Error in delete operation of replica %v , error %v", addr, err)
 				replicas.appendDeletedReplicas(err.Error(), addr, repClientErr)
 				return
 			}
 			logrus.Info("Sending delete request to replica : ", addr)
 			if err := repClient.Delete("/delete"); err != nil {
-				logrus.Infof("Error in delete operation of replica %v , found error %v", addr, err)
+				logrus.Infof("Error in delete operation of replica %v , error %v", addr, err)
 				replicas.appendDeletedReplicas(err.Error(), addr, deletionErr)
 				return
 			}
@@ -74,11 +74,11 @@ func (s *Server) delete(replicas *DeletedReplicas, wg *sync.WaitGroup) {
 	}
 }
 
-// DeleteVolume handle the delete req call from controller's client.
-// it checks for the replication factor before deleting the replicas
-// if the replica count equal to the replication factor then it will
-// proceed to delete, otherwise return a response explaining the cause
-// of error in response.
+// DeleteVolume handles the delete request call from the controller's
+// client. It checks for the replication factor before deleting the
+// replicas. If the replica count is equal to the replication factor
+// then it will proceed to delete. If not, it returns a response
+// explaining the cause of error in response.
 func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
 	var (
 		replicas DeletedReplicas

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -10,6 +10,10 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
+type DeleteReplicaOutput struct {
+	client.Resource
+	DeletedReplicas
+}
 type Replica struct {
 	client.Resource
 	Address string `json:"address"`
@@ -213,6 +217,8 @@ func NewSchema() *client.Schemas {
 			Output: "snapshotOutput",
 		},
 	}
+	deleteReplica := schemas.AddType("delete", DeleteReplicaOutput{})
+	deleteReplica.ResourceMethods = []string{"POST"}
 
 	return schemas
 }

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -1,12 +1,13 @@
 package rest
 
 import (
+	"net/http"
+	_ "net/http/pprof" /* for profiling */
+
 	"github.com/gorilla/mux"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rancher/go-rancher/api"
-	"net/http"
-	_ "net/http/pprof" /* for profiling */
 )
 
 func NewRouter(s *Server) *mux.Router {
@@ -44,6 +45,8 @@ func NewRouter(s *Server) *mux.Router {
 
 	// Journal
 	router.Methods("POST").Path("/v1/journal").Handler(f(schemas, s.ListJournal))
+	// Delete
+	router.Methods("POST").Path("/v1/delete").Handler(f(schemas, s.DeleteVolume))
 
 	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -39,6 +39,7 @@ func NewReplicaClient(address string) (*ReplicaClient, error) {
 	u, err := url.Parse(address)
 	if err != nil {
 		return nil, err
+
 	}
 
 	parts := strings.Split(u.Host, ":")
@@ -75,6 +76,23 @@ func (c *ReplicaClient) Create(size string) error {
 	return c.post(r.Actions["create"], rest.CreateInput{
 		Size: size,
 	}, nil)
+}
+
+func (c *ReplicaClient) Delete(path string) error {
+	_, err := c.GetReplica()
+	if err != nil {
+		return err
+	}
+	deleteAPI := c.address + path
+	req, err := http.NewRequest("DELETE", deleteAPI, nil)
+	if err != nil {
+		return err
+	}
+	_, err = c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *ReplicaClient) Revert(name, created string) error {

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -39,7 +39,6 @@ func NewReplicaClient(address string) (*ReplicaClient, error) {
 	u, err := url.Parse(address)
 	if err != nil {
 		return nil, err
-
 	}
 
 	parts := strings.Split(u.Host, ":")

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -987,7 +987,7 @@ func (r *Replica) Delete() error {
 	for name := range r.diskData {
 		if name != r.info.BackingFileName {
 			if err := r.rmDisk(name); err != nil {
-				logrus.Error("Error in removing disk data, found error : ", err.Error())
+				logrus.Error("Error in removing disk data, error : ", err.Error())
 				return err
 			}
 		}
@@ -995,12 +995,12 @@ func (r *Replica) Delete() error {
 
 	err := os.Remove(r.diskPath(volumeMetaData))
 	if err != nil {
-		logrus.Error("Error in removing volume meta data, found error : ", err.Error())
+		logrus.Error("Error in removing volume meta data, error : ", err.Error())
 		return err
 	}
 	err = os.Remove(r.diskPath(revisionCounterFile))
 	if err != nil {
-		logrus.Error("Error in removing volume meta data, found error : ", err.Error())
+		logrus.Error("Error in removing revision counter file, error : ", err.Error())
 		return err
 	}
 	return nil

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -995,7 +995,7 @@ func (r *Replica) Delete() error {
 
 	err := os.Remove(r.diskPath(volumeMetaData))
 	if err != nil {
-		logrus.Error("Error in removing volume meta data, error : ", err.Error())
+		logrus.Error("Error in removing volume metadata, error : ", err.Error())
 		return err
 	}
 	err = os.Remove(r.diskPath(revisionCounterFile))
@@ -1011,7 +1011,7 @@ func (r *Replica) DeleteAll() error {
 	defer r.Unlock()
 
 	if err := os.RemoveAll(r.dir); err != nil {
-		logrus.Error("Error in deleting the dir contents, found error : ", err.Error())
+		logrus.Error("Error in deleting the directory contents, error : ", err.Error())
 		return err
 	}
 	return nil

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -995,6 +995,20 @@ func (r *Replica) Delete() error {
 	return nil
 }
 
+func (r *Replica) DeleteAll() error {
+	r.Lock()
+	defer r.Unlock()
+
+	for name := range r.diskData {
+		if name != r.info.BackingFileName {
+			r.rmDisk(name)
+		}
+	}
+
+	os.RemoveAll(r.dir)
+	return nil
+}
+
 func (r *Replica) Snapshot(name string, userCreated bool, created string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1010,15 +1010,6 @@ func (r *Replica) DeleteAll() error {
 	r.Lock()
 	defer r.Unlock()
 
-	for name := range r.diskData {
-		if name != r.info.BackingFileName {
-			if err := r.rmDisk(name); err != nil {
-				logrus.Error("Error in removing disk data, found error : ", err.Error())
-				return err
-			}
-		}
-	}
-
 	if err := os.RemoveAll(r.dir); err != nil {
 		logrus.Error("Error in deleting the dir contents, found error : ", err.Error())
 		return err

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -986,12 +986,23 @@ func (r *Replica) Delete() error {
 
 	for name := range r.diskData {
 		if name != r.info.BackingFileName {
-			r.rmDisk(name)
+			if err := r.rmDisk(name); err != nil {
+				logrus.Error("Error in removing disk data, found error : ", err.Error())
+				return err
+			}
 		}
 	}
 
-	os.Remove(r.diskPath(volumeMetaData))
-	os.Remove(r.diskPath(revisionCounterFile))
+	err := os.Remove(r.diskPath(volumeMetaData))
+	if err != nil {
+		logrus.Error("Error in removing volume meta data, found error : ", err.Error())
+		return err
+	}
+	err = os.Remove(r.diskPath(revisionCounterFile))
+	if err != nil {
+		logrus.Error("Error in removing volume meta data, found error : ", err.Error())
+		return err
+	}
 	return nil
 }
 
@@ -1001,11 +1012,17 @@ func (r *Replica) DeleteAll() error {
 
 	for name := range r.diskData {
 		if name != r.info.BackingFileName {
-			r.rmDisk(name)
+			if err := r.rmDisk(name); err != nil {
+				logrus.Error("Error in removing disk data, found error : ", err.Error())
+				return err
+			}
 		}
 	}
 
-	os.RemoveAll(r.dir)
+	if err := os.RemoveAll(r.dir); err != nil {
+		logrus.Error("Error in deleting the dir contents, found error : ", err.Error())
+		return err
+	}
 	return nil
 }
 

--- a/replica/rest/delete.go
+++ b/replica/rest/delete.go
@@ -8,14 +8,14 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
-// DeleteVolume delete all the contents of the volume. It purges all the replica
+// DeleteVolume deletes all the contents of the volume. It purges all the replica
 // files.
 func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
 	logrus.Infof("DeleteVolume")
 	apiContext := api.GetApiContext(req)
 	err := s.s.DeleteAll()
 	if err != nil {
-		logrus.Errorf("Error in deleting the volume, found error: %v", err)
+		logrus.Errorf("Error in deleting the volume, error: %v", err)
 		return err
 	}
 	apiContext.Write(&DeleteReplicaOutput{

--- a/replica/rest/delete.go
+++ b/replica/rest/delete.go
@@ -1,0 +1,27 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
+)
+
+// DeleteVolume delete all the contents of the volume. It purges all the replica
+// files.
+func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
+	logrus.Infof("DeleteVolume")
+	apiContext := api.GetApiContext(req)
+	err := s.s.DeleteAll()
+	if err != nil {
+		logrus.Errorf("Error %v in doOp: %v", err, req.RequestURI)
+		return err
+	}
+	apiContext.Write(&DeleteReplicaOutput{
+		client.Resource{
+			Type: "delete",
+		},
+	})
+	return nil
+}

--- a/replica/rest/delete.go
+++ b/replica/rest/delete.go
@@ -15,7 +15,7 @@ func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 	err := s.s.DeleteAll()
 	if err != nil {
-		logrus.Errorf("Error %v in doOp: %v", err, req.RequestURI)
+		logrus.Errorf("Error in deleting the volume, found error: %v", err)
 		return err
 	}
 	apiContext.Write(&DeleteReplicaOutput{

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -27,6 +27,10 @@ type Replica struct {
 	CloneStatus       string                      `json:"clonestatus"`
 }
 
+type DeleteReplicaOutput struct {
+	client.Resource
+}
+
 type Stats struct {
 	client.Resource
 	ReplicaCounter  int64  `json:"replicacounter"`
@@ -210,25 +214,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 	return r
 }
 
-func NewSchema() *client.Schemas {
-	schemas := &client.Schemas{}
-
-	schemas.AddType("error", client.ServerApiError{})
-	schemas.AddType("apiVersion", client.Resource{})
-	schemas.AddType("schema", client.Schema{})
-	schemas.AddType("createInput", CreateInput{})
-	schemas.AddType("rebuildingInput", RebuildingInput{})
-	schemas.AddType("snapshotInput", SnapshotInput{})
-	schemas.AddType("removediskInput", RemoveDiskInput{})
-	schemas.AddType("revertInput", RevertInput{})
-	schemas.AddType("prepareRemoveDiskInput", PrepareRemoveDiskInput{})
-	schemas.AddType("prepareRemoveDiskOutput", PrepareRemoveDiskOutput{})
-	schemas.AddType("revisionCounter", RevisionCounter{})
-	schemas.AddType("replicaCounter", ReplicaCounter{})
-	schemas.AddType("replacediskInput", ReplaceDiskInput{})
-	replica := schemas.AddType("replica", Replica{})
-
-	replica.ResourceMethods = []string{"GET", "DELETE"}
+func setReplicaResourceActions(replica *client.Schema) {
 	replica.ResourceActions = map[string]client.Action{
 		"close": {
 			Output: "replica",
@@ -274,6 +260,32 @@ func NewSchema() *client.Schemas {
 			Output: "replica",
 		},
 	}
+}
+
+func NewSchema() *client.Schemas {
+	schemas := &client.Schemas{}
+
+	schemas.AddType("error", client.ServerApiError{})
+	schemas.AddType("apiVersion", client.Resource{})
+	schemas.AddType("schema", client.Schema{})
+	schemas.AddType("createInput", CreateInput{})
+	schemas.AddType("rebuildingInput", RebuildingInput{})
+	schemas.AddType("snapshotInput", SnapshotInput{})
+	schemas.AddType("removediskInput", RemoveDiskInput{})
+	schemas.AddType("revertInput", RevertInput{})
+	schemas.AddType("prepareRemoveDiskInput", PrepareRemoveDiskInput{})
+	schemas.AddType("prepareRemoveDiskOutput", PrepareRemoveDiskOutput{})
+	schemas.AddType("revisionCounter", RevisionCounter{})
+	schemas.AddType("replicaCounter", ReplicaCounter{})
+	schemas.AddType("replacediskInput", ReplaceDiskInput{})
+
+	delete := schemas.AddType("delete", DeleteReplicaOutput{})
+	delete.ResourceMethods = []string{"DELETE"}
+
+	replica := schemas.AddType("replica", Replica{})
+
+	replica.ResourceMethods = []string{"GET", "DELETE"}
+	setReplicaResourceActions(replica)
 
 	return schemas
 }

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -53,6 +53,8 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))
 	router.Methods("GET").Path("/v1/replicas/{id}/volusage").Handler(f(schemas, s.GetVolUsage))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
+
+	router.Methods("DELETE").Path("/v1/delete").Handler(f(schemas, s.DeleteVolume))
 	router.Handle("/metrics", promhttp.Handler())
 
 	// Actions

--- a/replica/server.go
+++ b/replica/server.go
@@ -317,10 +317,10 @@ func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 	return s.r.PrepareRemoveDisk(name)
 }
 
+// CheckPreDeleteConditions checks whether any replica exists or not,
+// in case if it exists, it closes all the connections with the replica
+// and delete the entry from the controller.
 func (s *Server) CheckPreDeleteConditions() error {
-	s.Lock()
-	defer s.Unlock()
-
 	if s.r == nil {
 		logrus.Infof("Delete is not performed as s.r is nil")
 		return nil
@@ -333,7 +333,11 @@ func (s *Server) CheckPreDeleteConditions() error {
 	return nil
 }
 
+// Delete deletes the volume metadata and revision counter file.
 func (s *Server) Delete() error {
+	s.Lock()
+	defer s.Unlock()
+
 	err := s.CheckPreDeleteConditions()
 	if err != nil {
 		return err
@@ -345,7 +349,11 @@ func (s *Server) Delete() error {
 	return err
 }
 
+// DeleteAll deletes all the contents of the mounted directory.
 func (s *Server) DeleteAll() error {
+	s.Lock()
+	defer s.Unlock()
+
 	err := s.CheckPreDeleteConditions()
 	if err != nil {
 		return err

--- a/replica/server.go
+++ b/replica/server.go
@@ -1,6 +1,7 @@
 package replica
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
@@ -322,8 +323,7 @@ func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 // and delete the entry from the controller.
 func (s *Server) CheckPreDeleteConditions() error {
 	if s.r == nil {
-		logrus.Infof("Delete is not performed as s.r is nil")
-		return nil
+		return errors.New("s.r is nil")
 	}
 
 	logrus.Infof("Closing volume")

--- a/replica/server.go
+++ b/replica/server.go
@@ -318,9 +318,9 @@ func (s *Server) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) {
 	return s.r.PrepareRemoveDisk(name)
 }
 
-// CheckPreDeleteConditions checks whether any replica exists or not,
-// in case if it exists, it closes all the connections with the replica
-// and delete the entry from the controller.
+// CheckPreDeleteConditions checks if any replica exists.
+// If it exists, it closes all the connections with the replica
+// and deletes the entry from the controller.
 func (s *Server) CheckPreDeleteConditions() error {
 	if s.r == nil {
 		return errors.New("s.r is nil")

--- a/util/util.go
+++ b/util/util.go
@@ -164,7 +164,7 @@ func GetFileActualSize(file string) int64 {
 }
 
 // CheckReplicationFactor returns the value of env var REPLICATION_FACTOR
-// if it's not been set then it returns 0.
+// if it has not been set, then it returns 0.
 func CheckReplicationFactor() int {
 	replicationFactor, _ := strconv.ParseInt(os.Getenv("REPLICATION_FACTOR"), 10, 32)
 	if replicationFactor == 0 {

--- a/util/util.go
+++ b/util/util.go
@@ -162,3 +162,14 @@ func GetFileActualSize(file string) int64 {
 	}
 	return st.Blocks * BlockSizeLinux
 }
+
+// CheckReplicationFactor returns the value of env var REPLICATION_FACTOR
+// if it's not been set then it returns 0.
+func CheckReplicationFactor() int {
+	replicationFactor, _ := strconv.ParseInt(os.Getenv("REPLICATION_FACTOR"), 10, 32)
+	if replicationFactor == 0 {
+		logrus.Infof("REPLICATION_FACTOR env not set")
+		return int(replicationFactor)
+	}
+	return int(replicationFactor)
+}


### PR DESCRIPTION
On branch US2635-volume-deletion
 Changes to be committed:
	modified:   ci/start_init_test.sh
	modified:   controller/rest/model.go
	modified:   controller/rest/router.go
	modified:   controller/rest/volume.go
	modified:   replica/client/client.go
	modified:   replica/replica.go

1. Why is this change necessary?
-  Delete api from controller is not there in the controller.
-  Delete api does not delete all the contents of the directory.

2. How does it address the issue?
-  Added an api `v1/delete` with method `DELETE` in replica to make delete request to all
   the replicas to delete all the contents under mounted directory.(e.g,
   `/var/openebs`)
-  Added an api `v1/delete` with method `POST` in controller to make delete request to all
   the replicas to delete all the contents.
-  Made changes in existing delete api handler under replica to delete the whole
   volume dir.(e.g, `var/openebs/*`)

3. What side effects does this change have?
-  None

4. How to verify this change?
-  make a request on controller `curl -X "POST"
   http://CONTROLLER_IP:9501/v1/delete` and you will be able to see following
   response.
```
{
  "actions": {},
  "links": {
    "self": "http://172.18.0.2:9501/v1/delete"
  },
  "replicas": [
    {
      "msg": "Replica deleted successfully",
      "replica": "tcp://172.18.0.3:9502"
    },
    {
      "msg": "Replica deleted successfully",
      "replica": "tcp://172.18.0.4:9502"
    }
  ],
  "type": "delete"
}
 ```
Result of negative test-case when 1 of the replica goes down out of two replicas and deleting the replicas instantly.
```
{
  "actions": {},
  "links": {
    "self": "http://172.18.0.2:9501/v1/delete"
  },
  "replicas": [
    {
      "msg": "Replica deleted successfully",
      "replica": "tcp://172.18.0.4:9502"
    },
    {
      "error": {
        "Err": {},
        "Op": "Get",
        "URL": "http://172.18.0.3:9502/v1/replicas/1"
      },
      "msg": "Error deleting replica",
      "replica": "tcp://172.18.0.3:9502"
    }
  ],
  "type": "delete"
}
```
Result of negative test-case when 1 of the replica goes down out of two replicas and deleting the replicas after sometime when the state of that replica (down) is updated.
```
{
  "actions": {},
  "links": {
    "self": "http://172.18.0.2:9501/v1/delete"
  },
  "replicas": [
    {
      "error": "Replication factor: 2 is not equal to replica count: 1",
      "msg": "Error deleting replica",
      "replica": ""
    }
  ],
  "type": "delete"
}
```

5. Any specific message for reviewer ?
-  Added the ci for the changes for two replicas.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>