### PR TITLE
[US2662] check if underlying filesystem supports extents mapping.

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -917,10 +917,10 @@ test_extent_support_file_system() {
 
 	verify_replica_cnt "0" "Zero replica count test1"
 
-	docker logs $replica1_id 2>&1 | cat > errorlog.txt 
-	error=$(cat errorlog.txt | grep -w "underlying file system does not support extent mapping" | wc -l)
+	error=$(docker logs $replica1_id 2>&1 | grep -w "underlying file system does not support extent mapping")
+	count=$(echo $error | wc -l)
 
-	if [ "$error" -eq 0  ]; then
+	if [ "$count" -eq 0  ]; then
 		echo "extent supported file system test failed"
 		umount /tmp/vol1
 		losetup -d $device

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -224,7 +224,11 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
 
-	PreloadLunMap(&r.volume)
+	if err := PreloadLunMap(&r.volume); err != nil {
+		logrus.Error("underlying file system does not support extent mapping")
+		return r, err
+	}
+
 	return r, r.writeVolumeMetaData(true, r.info.Rebuilding)
 }
 


### PR DESCRIPTION
 On branch US2662-verify-file-extents-mapping
 Changes to be committed:
	modified:   ci/start_init_test.sh
	modified:   replica/replica.go

1. Why is this change necessary?
-  To verify whether the underlying filesystem supports extents mapping.

2. How does it address the issue?
-  In the earlier code we were ignoring the error which verifies if the
   filesystem supports extents mapping. So now we will catch the error
   and error out the replica.

3. What side effects does this change have?
-  None.

4. How to verify this change?
-  ci is already added to verify the changes.

5. Any specific message for reviewer ?
-  No

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>