### PR TITLE
[TA2653] Fix the travis timeout issue while registration

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -281,7 +281,7 @@ func (rf *Factory) SignalToAdd(address string, action string) error {
 			Timeout: timeout,
 		},
 	}
-	time.Sleep(inject.SignalToAddTimeout)
+	inject.AddTimeout()
 	return r.doAction("start", &map[string]string{"Action": action})
 }
 

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -10,6 +10,11 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
+type Timeout struct {
+	client.Resource
+	Timeout string `json:"timeout"`
+}
+
 type DeleteReplicaOutput struct {
 	client.Resource
 	DeletedReplicas
@@ -219,6 +224,8 @@ func NewSchema() *client.Schemas {
 	}
 	deleteReplica := schemas.AddType("delete", DeleteReplicaOutput{})
 	deleteReplica.ResourceMethods = []string{"POST"}
+	timeout := schemas.AddType("timeout", Timeout{})
+	timeout.ResourceMethods = []string{"POST"}
 
 	return schemas
 }

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -47,6 +47,8 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/journal").Handler(f(schemas, s.ListJournal))
 	// Delete
 	router.Methods("POST").Path("/v1/delete").Handler(f(schemas, s.DeleteVolume))
+	// Debug
+	router.Methods("POST").Path("/timeout").Handler(f(schemas, s.AddTimeout))
 
 	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 

--- a/controller/rest/timeout.go
+++ b/controller/rest/timeout.go
@@ -1,0 +1,20 @@
+package rest
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher/api"
+)
+
+func (s *Server) AddTimeout(rw http.ResponseWriter, req *http.Request) error {
+	var timeout Timeout
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&timeout); err != nil {
+		logrus.Error("failed to read the request body, error: %v", err)
+		return err
+	}
+	logrus.Infof("Added a timeout of %vs", timeout.Timeout)
+	return os.Setenv("DEBUG_TIMEOUT", timeout.Timeout)
+}

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,8 +2,5 @@
 
 package inject
 
-import "time"
-
-const (
-	SignalToAddTimeout = 0 * time.Second
-)
+func AddTimeout() {
+}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -2,8 +2,16 @@
 
 package inject
 
-import "time"
+import (
+	"os"
+	"strconv"
+	"time"
 
-const (
-	SignalToAddTimeout = 5 * time.Second
+	"github.com/Sirupsen/logrus"
 )
+
+func AddTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("DEBUG_TIMEOUT"))
+	logrus.Infof("Add timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
+}


### PR DESCRIPTION
On branch fix-timeout-issue-while-registration
    Changes to be committed:
        modified:   backend/remote/remote.go
        modified:   ci/start_init_test.sh
        modified:   controller/rest/model.go
        modified:   controller/rest/router.go
        new file:   controller/rest/timeout.go
        modified:   error-inject/default.go
        modified:   error-inject/inject.go

1. Why is this change necessary?
-  To fix the bug related to timeout issues
   while registration of replica.

2. How does it address the issue?
-  Added an endpoint `timeout` in controller to set the timeout
   of registration at the run time.

3. What side effects does this change have?
-  None

4. How to verify this change?
-  Run ci, it should work fine.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>