### PR TITLE
[TA2643, TA2644] fix(snapshot): verify if snapshot already exist

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -837,10 +837,31 @@ run_data_integrity_test() {
 	#Cleanup is not being performed here because this data will be used to test clone feature in the next test
 }
 
-create_snapshot() {
-	echo "--------------create_snapshot-------------"
-	id=`curl http://$1:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
-	curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://$CONTROLLER_IP:9501/v1/volumes/$id?action=snapshot
+# create_and_verify_snapshot first creates a snapshot and verifies if it
+# is of type snapshotOutput in case of failure it returns type:error which
+# is success case that the snapshot snap1 does not exists.
+# As a part of negative test we are trying to create the snapshot with the
+# same name which returns snapshot_exists.
+create_and_verify_snapshot() {
+	echo "--------------create_and_verify_snapshot-------------"
+       snapshot_exists="Snapshot: snap1 already exists"
+       id=`curl http://$CONTROLLER_IP:9501/v1/volumes | jq '.data[0].id' |  tr -d '"'`
+       type=`curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://$CONTROLLER_IP:9501/v1/volumes/$id?action=snapshot | jq '.type' | tr -d '"'`
+       if [ "$type" != "snapshotOutput" ];
+       then
+              echo "create and verify snapshot test1 failed"
+              collect_logs_and_exit
+       else
+              echo "create and verify snapshot test1 passed"
+       fi;
+       message=`curl -H "Content-Type: application/json" -X POST -d '{"name":"snap1"}' http://$CONTROLLER_IP:9501/v1/volumes/$id?action=snapshot | jq '      .message' | tr -d '"'`
+       if [ "$message" == "$snapshot_exists" ];
+       then
+              echo "create and verify snapshot test2 passed"
+       else
+              echo "create and verify snapshot test2 failed"
+              collect_logs_and_exit
+       fi;
 }
 
 test_clone_feature() {
@@ -969,7 +990,7 @@ test_three_replica_stop_start
 test_ctrl_stop_start
 test_replica_reregistration
 run_data_integrity_test
-create_snapshot "$CONTROLLER_IP"
+create_and_verify_snapshot
 test_clone_feature
 test_extent_support_file_system
 run_vdbench_test_on_volume

--- a/controller/control.go
+++ b/controller/control.go
@@ -353,16 +353,19 @@ func (c *Controller) Snapshot(name string) (string, error) {
 		return "", fmt.Errorf("Too many snapshots created")
 	}
 
-	for _, replica := range c.ListReplicas() {
-		ok, err := IsSnapShotExist(name, replica.Address)
-		if err != nil {
-			return name, fmt.Errorf("Failed to create snapshot, error: %v", err)
-		}
-		if ok {
-			return name, fmt.Errorf("Snapshot: %s already exists", name)
-		}
+	replica, err := c.getRWReplica()
+	if err != nil {
+		return name, err
 	}
 
+	ok, err := IsSnapShotExist(name, replica.Address)
+	if err != nil {
+		return name, fmt.Errorf("Failed to create snapshot, error: %v", err)
+	}
+
+	if ok {
+		return name, fmt.Errorf("Snapshot: %s already exists", name)
+	}
 	created := util.Now()
 	return name, c.handleErrorNoLock(c.backend.Snapshot(name, true, created))
 }

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -54,6 +54,7 @@ type StartInput struct {
 
 type SnapshotOutput struct {
 	client.Resource
+	Message string `json:"message"`
 }
 
 type VolumeStats struct {

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -142,12 +143,13 @@ func (s *Server) SnapshotVolume(rw http.ResponseWriter, req *http.Request) error
 	if err != nil {
 		return err
 	}
-
+	msg := fmt.Sprintf("Snapshot: %s created successfully", name)
 	apiContext.Write(&SnapshotOutput{
 		client.Resource{
 			Id:   name,
 			Type: "snapshotOutput",
 		},
+		msg,
 	})
 	return nil
 }


### PR DESCRIPTION
On branch US3005-verify-snapshot-name
Changes to be committed:
    modified:   ci/start_init_test.sh
    modified:   controller/control.go

1. Why is this change necessary?
-  To fix the problem when snapshot with the given name already
   exist.

2. How does it address the issue?
-  verify if snapshot already exist in the chain list and then
   proceed to create snapshot if snapshot with the given name
   does not exist.

3. What side effects does this change have?
-  None

4. How to verify this change?
-  Add ci for the same, it should run fine.

5. Any specific msg for the reviewer?
-  Refer to US3005
-  Snapshots are created in the linear order, need to optimize it in better way.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>