### PR TITLE
[TA2880, TA2881] fix(jiva): extents mapping bug

### DIFF
--- a/replica/extents.go
+++ b/replica/extents.go
@@ -1,6 +1,10 @@
 package replica
 
 import (
+	"fmt"
+	"os"
+
+	"github.com/Sirupsen/logrus"
 	"github.com/frostschutz/go-fibmap"
 	"github.com/openebs/jiva/types"
 )
@@ -61,4 +65,43 @@ func (u *UsedGenerator) findExtents(c chan<- int64) {
 			}
 		}
 	}
+}
+
+func createTempFile(path string) error {
+	var file *os.File
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			file, err = os.Create(path)
+			if err != nil {
+				logrus.Errorf("failed to create tmp file %s, error: %v", path, err.Error())
+				return err
+			}
+		}
+	}
+	if _, err := file.WriteString("This is temp file\n"); err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func findExtents(dir string) error {
+	path := dir + "/tmpFile.tmp"
+	if err := createTempFile(path); err != nil {
+		return err
+	}
+	defer os.Remove(path)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	fiemapFile := fibmap.NewFibmapFile(file)
+	if _, err := fiemapFile.Fiemap(uint32(fileInfo.Size())); err != 0 {
+		return fmt.Errorf("failed to find extents, error: %v", err.Error())
+	}
+	return nil
 }

--- a/replica/extents.go
+++ b/replica/extents.go
@@ -86,7 +86,7 @@ func createTempFile(path string) error {
 	return file.Sync()
 }
 
-func findExtents(dir string) error {
+func isExtentSupported(dir string) error {
 	path := dir + "/tmpFile.tmp"
 	if err := createTempFile(path); err != nil {
 		return err

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -163,9 +163,6 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 		logrus.Errorf("failed to create directory: %s", dir)
 		return nil, err
 	}
-	if err := findExtents(dir); err != nil {
-		return nil, err
-	}
 
 	r := &Replica{
 		dir:             dir,
@@ -228,7 +225,6 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	r.ReplicaType = replicaType
 
 	if err := PreloadLunMap(&r.volume); err != nil {
-		r.Delete()
 		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
 	}
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -77,7 +77,6 @@ func (s *Server) getSize(size int64) int64 {
 func (s *Server) Create(size int64) error {
 	s.Lock()
 	defer s.Unlock()
-
 	state, _ := s.Status()
 
 	if state != Initial {

--- a/replica/server.go
+++ b/replica/server.go
@@ -77,6 +77,13 @@ func (s *Server) getSize(size int64) int64 {
 func (s *Server) Create(size int64) error {
 	s.Lock()
 	defer s.Unlock()
+	if err := os.Mkdir(s.dir, 0700); err != nil && !os.IsExist(err) {
+		logrus.Errorf("failed to create directory: %s", s.dir)
+		return err
+	}
+	if err := isExtentSupported(s.dir); err != nil {
+		return err
+	}
 	state, _ := s.Status()
 
 	if state != Initial {


### PR DESCRIPTION
On branch US3116-extent-mapping-bug
Changes to be committed:
	modified:   ci/start_init_test.sh
	modified:   replica/replica.go
	modified:   replica/server.go

This commit fixes the bug which was not fataling the replicas
if they are restarted due to unsupported underlying file system
where replicas store the data.

Add ci to verify the fix.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>