### PR TITLE
[TA3086] fix(replica): don't add replica if RF is met

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -430,6 +430,33 @@ test_two_replica_delete() {
 	cleanup
 }
 
+test_replication_factor() {
+	echo "----------------Test_replication_factor--------------"
+	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
+	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+	sleep 5
+
+	verify_replica_cnt "1" "Single replica count test"
+	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, registered Replicas: 1" | wc -l)
+	if [ "$add_replica_exit" == 0 ]; then
+		collect_logs_and_exit
+	fi
+
+	sudo docker stop $replica1_id
+	wait
+	sudo docker start $replica1_id
+	sleep 5
+
+	verify_replica_cnt "1" "Single replica count test"
+	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, registered Replicas: 1" | wc -l)
+	if [ "$add_replica_exit" == 0 ]; then
+		collect_logs_and_exit
+	fi
+
+	echo "test_replication_factor --passed"
+	cleanup
+}
 
 test_single_replica_stop_start() {
 	echo "----------------Test_single_replica_stop_start--------------"
@@ -1003,6 +1030,7 @@ test_extent_support_file_system() {
 
 prepare_test_env
 test_single_replica_stop_start
+test_replication_factor
 test_two_replica_delete
 test_replica_ip_change
 test_two_replica_stop_start

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -434,22 +434,22 @@ test_replication_factor() {
 	echo "----------------Test_replication_factor--------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+	verify_replica_cnt "1" "Single replica count test"
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
 	sleep 5
 
 	verify_replica_cnt "1" "Single replica count test"
-	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, registered Replicas: 1" | wc -l)
+	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, added replicas: 1" | wc -l)
 	if [ "$add_replica_exit" == 0 ]; then
 		collect_logs_and_exit
 	fi
 
 	sudo docker stop $replica1_id
-	wait
 	sudo docker start $replica1_id
 	sleep 5
 
 	verify_replica_cnt "1" "Single replica count test"
-	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, registered Replicas: 1" | wc -l)
+	add_replica_exit=$(docker logs $orig_controller_id 2>&1 | grep "error: replication factor: 1, added replicas: 1" | wc -l)
 	if [ "$add_replica_exit" == 0 ]; then
 		collect_logs_and_exit
 	fi

--- a/controller/control.go
+++ b/controller/control.go
@@ -225,7 +225,7 @@ func (c *Controller) addReplica(address string, snapshot bool) error {
 		c.Unlock()
 		return fmt.Errorf("can't add %s, error: %v", address, err)
 	}
-
+	c.Unlock()
 	newBackend, err := c.factory.Create(address)
 	if err != nil {
 		logrus.Infof("remote creation addreplica failed %v", err)

--- a/controller/control.go
+++ b/controller/control.go
@@ -103,22 +103,22 @@ func (c *Controller) RegisterReplica(register types.RegReplica) error {
 	return c.registerReplica(register)
 }
 
-func (c *Controller) hasWOReplica() bool {
+func (c *Controller) hasWOReplica() (string, bool) {
 	for _, i := range c.replicas {
 		if i.Mode == types.WO {
-			return true
+			return i.Address, true
 		}
 	}
-	return false
+	return "", false
 }
 
 func (c *Controller) canAdd(address string) (bool, error) {
 	if c.hasReplica(address) {
-		return false, fmt.Errorf("%s is already added", address)
+		return false, fmt.Errorf("replica: %s is already added", address)
 	}
-	if c.hasWOReplica() {
-		return false, fmt.Errorf("Can only have one WO replica %s at a time",
-			address)
+	if woReplica, ok := c.hasWOReplica(); ok {
+		return false, fmt.Errorf("Can only have one WO replica at a time, found WO Replica: %s",
+			woReplica)
 	}
 	return true, nil
 }
@@ -200,11 +200,24 @@ func (c *Controller) addQuorumReplica(address string, snapshot bool) error {
 	return nil
 }
 
+func (c *Controller) verifyReplicationFactor() error {
+	replicationFactor := util.CheckReplicationFactor()
+	if replicationFactor == 0 {
+		return fmt.Errorf("REPLICATION_FACTOR not set")
+	}
+	if replicationFactor == len(c.replicas) {
+		return fmt.Errorf("replication factor: %v, registered Replicas: %v", replicationFactor, len(c.replicas))
+	}
+	return nil
+}
+
 func (c *Controller) addReplica(address string, snapshot bool) error {
 	c.Lock()
 	if ok, err := c.canAdd(address); !ok {
 		c.Unlock()
-		logrus.Infof("addReplica %s cant add %v", address, err)
+		return err
+	}
+	if err := c.verifyReplicationFactor(); err != nil {
 		return err
 	}
 	c.Unlock()
@@ -470,6 +483,7 @@ func (c *Controller) addReplicaNoLock(newBackend types.Backend, address string, 
 			newBackend.Close()
 			return err
 		}
+		// This replica is not added to backend yet
 		if err = newBackend.Snapshot(uuid, false, created); err != nil {
 			newBackend.Close()
 			return err

--- a/controller/control.go
+++ b/controller/control.go
@@ -209,7 +209,7 @@ func (c *Controller) verifyReplicationFactor() error {
 		return fmt.Errorf("REPLICATION_FACTOR not set")
 	}
 	if replicationFactor == len(c.replicas) {
-		return fmt.Errorf("replication factor: %v, registered Replicas: %v", replicationFactor, len(c.replicas))
+		return fmt.Errorf("replication factor: %v, added replicas: %v", replicationFactor, len(c.replicas))
 	}
 	return nil
 }

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -146,7 +146,6 @@ func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error 
 	logrus.Infof("Create Replica for address %v", replica.Address)
 
 	if err := s.c.AddReplica(replica.Address); err != nil {
-		logrus.Errorf("can't add replica: %s, error: %v", replica.Address, err)
 		return err
 	}
 

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -146,6 +146,7 @@ func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error 
 	logrus.Infof("Create Replica for address %v", replica.Address)
 
 	if err := s.c.AddReplica(replica.Address); err != nil {
+		logrus.Errorf("can't add replica: %s, error: %v", replica.Address, err)
 		return err
 	}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -290,20 +290,17 @@ func (t *Task) AddReplica(replicaAddress string, s *replica.Server) error {
 	defer ticker.Stop()
 	Replica, err := replica.CreateTempReplica()
 	if err != nil {
-		logrus.Errorf("CreateTempReplica failed, err: %v", err)
-		return err
+		return fmt.Errorf("failed to create temp replica, error: %s", err.Error())
 	}
 	server, err := replica.CreateTempServer()
 	if err != nil {
-		logrus.Errorf("CreateTempServer failed, err: %v", err)
-		return err
+		return fmt.Errorf("failed to create temp server, error: %s", err.Error())
 	}
 Register:
 	logrus.Infof("Get Volume info from controller")
 	volume, err := t.client.GetVolume()
 	if err != nil {
-		logrus.Errorf("Get volume info failed, err: %v", err)
-		return err
+		return fmt.Errorf("failed to get volume info, error: %s", err.Error())
 	}
 	addr := strings.Split(replicaAddress, "://")
 	parts := strings.Split(addr[1], ":")
@@ -316,7 +313,7 @@ Register:
 		logrus.Infof("Register replica at controller")
 		err := t.client.Register(parts[0], revisionCount, peerDetails, replicaType, upTime, string(state))
 		if err != nil {
-			logrus.Errorf("Error in sending register command, err: %v", err)
+			logrus.Errorf("Error in sending register command, error: %s", err)
 		}
 		select {
 		case <-ticker.C:
@@ -331,35 +328,30 @@ Register:
 	}
 	logrus.Infof("CheckAndResetFailedRebuild %v", replicaAddress)
 	if err := t.checkAndResetFailedRebuild(replicaAddress, s); err != nil {
-		logrus.Errorf("CheckAndResetFailedRebuild failed, err:%v", err)
-		return err
+		return fmt.Errorf("CheckAndResetFailedRebuild failed, error: %s", err.Error())
 	}
 
 	logrus.Infof("Adding replica %s in WO mode", replicaAddress)
 	_, err = t.client.CreateReplica(replicaAddress)
 	if err != nil {
-		logrus.Errorf("CreateReplica failed, err:%v", err)
 		return err
 	}
 
 	logrus.Infof("getTransferClients %v", replicaAddress)
 	fromClient, toClient, err := t.getTransferClients(replicaAddress)
 	if err != nil {
-		logrus.Errorf("getTransferClients failed, err:%v", err)
-		return err
+		return fmt.Errorf("failed to get transfer clients, error: %s", err.Error())
 	}
 
 	logrus.Infof("SetRebuilding %v", replicaAddress)
 	if err := toClient.SetRebuilding(true); err != nil {
-		logrus.Errorf("SetRebuilding failed, err:%v", err)
-		return err
+		return fmt.Errorf("failed to set rebuilding: true, error: %s", err.Error())
 	}
 
 	logrus.Infof("PrepareRebuild %v", replicaAddress)
 	output, err := t.client.PrepareRebuild(rest.EncodeID(replicaAddress))
 	if err != nil {
-		logrus.Errorf("PrepareRebuild failed, err:%v", err)
-		return err
+		return fmt.Errorf("failed to prepare rebuild, error: %s", err.Error())
 	}
 
 	logrus.Infof("syncFiles from:%v to:%v", fromClient, toClient)


### PR DESCRIPTION
On branch 3006-fix-add-replica
Changes to be committed:
	modified:   controller/control.go
	modified:   controller/rest/replica.go

This commit fix the issue where the new replicas are getting added
even if the RF condition is met. i.e, (Replication Factor = Replica
count)

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>