### PR TITLE
[US3310] fix(controller): Resolve issues with asynchronous ping goroutine

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -248,7 +248,7 @@ func (rf *Factory) Create(address string) (types.Backend, error) {
 		return nil, err
 	}
 
-	rpc := rpc.NewClient(conn)
+	rpc := rpc.NewClient(conn, r.closeChan)
 	r.ReaderWriterAt = rpc
 
 	if err := r.open(); err != nil {


### PR DESCRIPTION
Changes to be committed:
- modified: backend/remote/remote.go
- modified: rpc/client.go 
- modified: ci/start_init_test.sh

Issue:
There is a monitorping goroutine, which keeps on pinging the replicas every 2 seconds on the data path. This goroutine runs in parallel to the read/write IOs.
If the ping fails, it removes the replica entry from the controller. Ping has a timeout of 20 sec. 
Whenever the conn btw ctrl/rep breaks, the rpc client read call errors out closing reader/writer goroutines and setting error on that rpc client.
There is a time gap between closing reader/writer goroutine and closing the ping goroutine. In this time gap, if one more ping has been triggered, it will timeout eventually. But when it times out, it will again try to remove the replica from controller's list. If the replica is reattached between the time the read/write failed and this ping timeout happened, it will again be removed by this ping time out goroutine.

Fixes:
Close ping goroutine and then remove replica from controller.
Check rpc client state before enqueuing the requests.
 
Signed-off-by: Payes <payes.anand@cloudbyte.com>