### PR TITLE
[US3272] fix(resize): Fix replica crash due to resize

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1179,6 +1179,7 @@ test_volume_resize() {
 	docker start $orig_controller_id
 	verify_rw_rep_count "2"
 	di_test_on_raw_disk "2M"
+	cleanup
 	echo "Resize test passed"
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -296,6 +296,8 @@ func (r *Replica) Resize(obj interface{}) error {
 			return nil
 		}
 	}
+	r.Lock()
+	defer r.Unlock()
 	if r.info.Size > sizeInBytes {
 		return fmt.Errorf("Previous size %d is greater than %d", r.info.Size, sizeInBytes)
 	}
@@ -304,6 +306,8 @@ func (r *Replica) Resize(obj interface{}) error {
 			return err
 		}
 	}
+	byteArray := make([]byte, (sizeInBytes-r.info.Size)/4096)
+	r.volume.location = append(r.volume.location, byteArray...)
 	r.info.Size = sizeInBytes
 	return r.encodeToFile(&r.info, volumeMetaData)
 }


### PR DESCRIPTION
Location table contains a mapping of the block number of the volume to the snapshot file containing its latest copy.
After resizing the volume at replica, we were not increasing the size of the location table.
When a read/write was being received for that block, we were trying to access the same location in the table which was causing the crash.
  
Signed-off-by: Payes <payes.anand@cloudbyte.com>