### PR TITLE
(issue-#24) enhancing performace avoiding defer unlocks

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -100,12 +100,12 @@ func (r *Remote) doAction(action string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return fmt.Errorf("Bad status: %d %s", resp.StatusCode, resp.Status)
 	}
-
+	resp.Body.Close()
 	return nil
 }
 
@@ -200,13 +200,14 @@ func (r *Remote) info() (rest.Replica, error) {
 	if err != nil {
 		return replica, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
 		return replica, fmt.Errorf("Bad status: %d %s", resp.StatusCode, resp.Status)
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&replica)
+	resp.Body.Close()
 	return replica, err
 }
 


### PR DESCRIPTION
Signed-off-by: khushbuparakh <khushbuparakh@hotmail.com>
I started from ReadAt, WriteAt functions.
So func (s *Server) had a defer func.
I avoided using that defer function
Then used at the very low level I/O code and
follow the path to know IO path in controller side, and,
similarly Handle() in rpc/server.go for replica side IO handling.