### PR TITLE
added gitlab-ci yml to run ci and e2e in gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,56 @@
+stages:
+  - build
+  - baseline
+  - cleanup
+
+build-jiva:
+   stage: build
+   #image: harshvkarn/dind:v6
+   before_script:
+     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - sudo apt-get install -y
+     - sudo apt-get install -y curl open-iscsi
+     - export GOPATH=$HOME/go
+     - export PATH=$HOME/go/bin:$PATH
+     - mkdir -p $HOME/go/src/github.com/openebs/maya
+     - rsync -az --delete ${CI_PROJECT_DIR}/ ${HOME}/go/src/github.com/openebs/jiva/ #CI_PROJECT_DIR is full path where project is cloned
+     - cd ${HOME}/go/src/github.com/openebs/jiva
+     - find . -name 'push' -exec sed -i -e "s/ci/${COMMIT}/g" {} \;
+   script: 
+    - echo "Building-Jiva"
+    - echo $COMMIT
+    - make build
+baseline-image:
+  stage: baseline
+  script:
+     - pwd
+     - export BRANCH=${CI_COMMIT_REF_NAME}
+     - echo $BRANCH
+     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - echo $COMMIT
+     - git clone https://github.com/openebs/e2e-infrastructure.git
+     - cd e2e-infrastructure/baseline
+     - ansible-playbook commit-writer.yml --extra-vars "branch=$BRANCH repo=$CI_PROJECT_NAME commit=$COMMIT"
+     - git status
+     - git add baseline
+     - git status
+     - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
+     - git push  https://$user:$pass@github.com/openebs/e2e-infrastructure.git --all
+     - cat baseline
+     - echo "##############################################################################################"
+     - echo "JIVA-IMAGE Pushed to DOCKER is $COMMIT"
+     - echo "##############################################################################################"
+     - echo "###############################################################################################" 
+     - echo "Started E2E-PIPELINE"
+     - echo "###############################################################################################"
+     - curl -X POST -F token=$AWS -F ref=master https://gitlab.openebs.ci/api/v4/projects/7/trigger/pipeline
+     - curl -X POST -F token=$GCP -F ref=master https://gitlab.openebs.ci/api/v4/projects/9/trigger/pipeline
+     - curl -X POST -F token=$AZURE -F ref=master https://gitlab.openebs.ci/api/v4/projects/20/trigger/pipeline
+     - curl -X POST -F token=$PACKET-F ref=master https://gitlab.openebs.ci/api/v4/projects/19/trigger/pipeline
+
+cleanup:
+  stage: cleanup
+  script:
+     - sudo rm -r ~/go
+     - sudo docker images 
+     - sudo docker image prune -a


### PR DESCRIPTION
This PR contains the gitlab-ci yaml to build jiva and push the image with "commit id" to docker hub on each commit to 'Master' branch and run our E2E pipeline with new image.
Build Pipeline:
![screenshot from 2018-10-15 12-32-32](https://user-images.githubusercontent.com/30014772/46934754-8ae85380-d076-11e8-9892-3d5f47d499b7.png)

Signed-off-by: atulabhi <atulabhi@gmail.com>