### PR TITLE
Fix golint issue while triggering build in travis

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -29,7 +29,7 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
 RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
-    go get github.com/rancher/trash && go get github.com/golang/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
+    go get github.com/rancher/trash && go get -u golang.org/x/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
 ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \


### PR DESCRIPTION
This commit fixes the issue which was happening due to
the changes in the golint project. Replacing the go get
path to golang.org/x/lint/golint

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>
(cherry picked from commit 36e5c68bfdce43dcbe7d34b0450625cf46181064)