### PR TITLE
updated gitlab-ci yml and push script to build and push commit based

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,6 @@ stages:
 
 build-jiva:
    stage: build
-   #image: harshvkarn/dind:v6
    before_script:
      - export COMMIT=${CI_COMMIT_SHA:0:8}
      - sudo apt-get install -y
@@ -15,7 +14,6 @@ build-jiva:
      - mkdir -p $HOME/go/src/github.com/openebs/maya
      - rsync -az --delete ${CI_PROJECT_DIR}/ ${HOME}/go/src/github.com/openebs/jiva/ #CI_PROJECT_DIR is full path where project is cloned
      - cd ${HOME}/go/src/github.com/openebs/jiva
-     - find . -name 'push' -exec sed -i -e "s/ci/${COMMIT}/g" {} \;
    script: 
     - echo "Building-Jiva"
     - echo $COMMIT

--- a/scripts/push
+++ b/scripts/push
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 if [ -z ${IMAGE_REPO} ];
 then

--- a/scripts/push
+++ b/scripts/push
@@ -92,4 +92,19 @@ then
 else
   echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to quay";
 fi;
+#Push image to run openebs-e2e based on git commit
+function GitlabCommit() {
+  REPO="$1"
+
+  IMAGE_URI="${REPO}:${COMMIT}";
+  sudo docker tag ${IMAGEID} ${IMAGE_URI};
+  echo " push ${IMAGE_URI}";
+  sudo docker push ${IMAGE_URI};
+}
+if [ ! -z "${COMMIT}" ];
+then
+  sudo docker login -u "${DNAMEGL}" -p "${DPASSGL}";
+
+  # Push COMMIT tagged image - :COMMIT
+  GitlabCommit "${DIMAGE}" "${COMMIT}"
 

--- a/scripts/push
+++ b/scripts/push
@@ -93,18 +93,9 @@ else
   echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to quay";
 fi;
 #Push image to run openebs-e2e based on git commit
-function GitlabCommit() {
-  REPO="$1"
-
-  IMAGE_URI="${REPO}:${COMMIT}";
-  sudo docker tag ${IMAGEID} ${IMAGE_URI};
-  echo " push ${IMAGE_URI}";
-  sudo docker push ${IMAGE_URI};
-}
 if [ ! -z "${COMMIT}" ];
 then
   sudo docker login -u "${DNAMEGL}" -p "${DPASSGL}";
 
   # Push COMMIT tagged image - :COMMIT
-  GitlabCommit "${DIMAGE}" "${COMMIT}"
-
+  TagAndPushImage "${DIMAGE}" "${COMMIT}"

--- a/scripts/push
+++ b/scripts/push
@@ -99,3 +99,4 @@ then
 
   # Push COMMIT tagged image - :COMMIT
   TagAndPushImage "${DIMAGE}" "${COMMIT}"
+fi;

--- a/scripts/push
+++ b/scripts/push
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 if [ -z ${IMAGE_REPO} ];
 then
@@ -93,10 +93,10 @@ else
   echo "No docker credentials provided. Skip uploading ${IMAGE_REPO} to quay";
 fi;
 #Push image to run openebs-e2e based on git commit
-if [ ! -z "${COMMIT}" ];
+if [ ! -z "${COMMIT}" ] && [ ! -z "${DNAMEGL}" ] && [ ! -z "${DPASSGL}" ];
 then
   sudo docker login -u "${DNAMEGL}" -p "${DPASSGL}";
 
   # Push COMMIT tagged image - :COMMIT
-  TagAndPushImage "${DIMAGE}" "${COMMIT}"
+  TagAndPushImage "${IMAGE_REPO}" "${COMMIT}"
 fi;


### PR DESCRIPTION
Commit based images are required to run OpenEBS-E2E . These images will be push by gitlab-runner based on the commit from the github. The commit is fetch from github and update as an environment variable (COMMIT ) in gitlab-runner which is being utilised in the push script.