### PR TITLE
Remove RO functionality for snapshots while syncing

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -232,7 +232,7 @@ func startReplica(c *cli.Context) error {
 		logrus.Infof("Waiting for s.Replica() to be non nil")
 		time.Sleep(2 * time.Second)
 	}
-	go replica.CreateHoles(s)
+	go replica.CreateHoles()
 	if replicaType == "clone" && snapName != "" {
 		logrus.Infof("Starting clone process\n")
 		status := s.Replica().GetCloneStatus()

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1259,11 +1259,6 @@ update_file_sizes() {
 	done
 }
 
-update_disk_mode() {
-	curl -H "Content-Type: application/json" -X POST -d "{\"disk\":\"${1}\", \"mode\":\"${2}\"}" http://$REPLICA_IP1:9502/v1/replicas/1?action=updatediskmode
-	curl -H "Content-Type: application/json" -X POST -d "{\"disk\":\"${1}\", \"mode\":\"${2}\"}" http://$REPLICA_IP2:9502/v1/replicas/1?action=updatediskmode
-}
-
 test_duplicate_data_delete() {
 	echo "----------------Test_two_replica_stop_start---------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -128,18 +128,6 @@ func (c *ReplicaClient) SetRebuilding(rebuilding bool) error {
 	}, nil)
 }
 
-func (c *ReplicaClient) UpdateDiskMode(disk string, mode string) error {
-	r, err := c.GetReplica()
-	if err != nil {
-		logrus.Errorf("Updatediskmode for disk: %v failed %v", disk, mode)
-		return err
-	}
-	return c.post(r.Actions["updatediskmode"], &rest.UpdateDiskModeInput{
-		Disk: disk,
-		Mode: mode,
-	}, nil)
-}
-
 func (c *ReplicaClient) RemoveDisk(disk string) error {
 	r, err := c.GetReplica()
 	if err != nil {

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -26,10 +26,6 @@ type diffDisk struct {
 	// userCreated/Auto-Created accordingly. It should always be updated
 	// whenever modifying above "files" variable
 	UserCreatedSnap []bool
-	// A snapshot file is marked ReadOnly when it is helping sync some other
-	// replica
-	ReadOnlyIndx []bool
-	ROIndexSet   bool
 	// Index of latest user created snapshot
 	SnapIndx   int
 	sectorSize int64

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -53,12 +53,6 @@ type RebuildingInput struct {
 	Rebuilding bool `json:"rebuilding"`
 }
 
-type UpdateDiskModeInput struct {
-	client.Resource
-	Disk string `json:"disk"`
-	Mode string `json:"mode"`
-}
-
 type SnapshotInput struct {
 	client.Resource
 	Name        string `json:"name"`

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -122,18 +122,6 @@ func (s *Server) SetRebuilding(rw http.ResponseWriter, req *http.Request) error 
 	return s.doOp(req, s.s.SetRebuilding(input.Rebuilding))
 }
 
-func (s *Server) UpdateDiskMode(rw http.ResponseWriter, req *http.Request) error {
-	var input UpdateDiskModeInput
-	apiContext := api.GetApiContext(req)
-	if err := apiContext.Read(&input); err != nil && err != io.EOF {
-		logrus.Errorf("Err %v in reading for updateDiskMode", err)
-		return err
-	}
-	logrus.Infof("UpdateDiskMode for %v to %v", input.Disk, input.Mode)
-
-	return s.doOp(req, s.s.UpdateDiskMode(input.Disk, input.Mode))
-}
-
 func (s *Server) Create(rw http.ResponseWriter, req *http.Request) error {
 	var input CreateInput
 	apiContext := api.GetApiContext(req)

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -69,7 +69,6 @@ func NewRouter(s *Server) *mux.Router {
 		"removedisk":         s.RemoveDisk,
 		"replacedisk":        s.ReplaceDisk,
 		"setrebuilding":      s.SetRebuilding,
-		"updatediskmode":     s.UpdateDiskMode,
 		"create":             s.Create,
 		"revert":             s.RevertReplica,
 		"prepareremovedisk":  s.PrepareRemoveDisk,

--- a/replica/server.go
+++ b/replica/server.go
@@ -238,13 +238,6 @@ func (s *Server) SetRebuilding(rebuilding bool) error {
 	return s.r.SetRebuilding(rebuilding)
 }
 
-func (s *Server) UpdateDiskMode(disk string, mode string) error {
-	s.Lock()
-	defer s.Unlock()
-
-	return s.r.UpdateDiskMode(disk, mode)
-}
-
 func (s *Server) Resize(size string) error {
 	s.Lock()
 	defer s.Unlock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -408,17 +408,13 @@ func (t *Task) syncFiles(fromClient *replicaClient.ReplicaClient, toClient *repl
 		if strings.Contains(disk, "volume-head") {
 			return fmt.Errorf("Disk list shouldn't contain volume-head")
 		}
-		fromClient.UpdateDiskMode(disk, "RO")
 		if err := t.syncFile(disk, "", fromClient, toClient); err != nil {
-			fromClient.UpdateDiskMode(disk, "RW")
 			return err
 		}
 
 		if err := t.syncFile(disk+".meta", "", fromClient, toClient); err != nil {
-			fromClient.UpdateDiskMode(disk, "RW")
 			return err
 		}
-		fromClient.UpdateDiskMode(disk, "RW")
 
 	}
 


### PR DESCRIPTION
Why this feature was implemented ?
This feature was implemented to make sure we don't fallocate(create holes) on a file when it is helping in rebuilding of other replicas.
Why is it being removed now ?
Even if this data is synced and fallocate is called after that, the preload function in the replica being rebuilt takes care of removing this data over there.
Signed-off-by: Payes <payes.anand@mayadata.io>