### PR TITLE
Fix a small typo in json tag of VolumeStats struct

### DIFF
--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -69,7 +69,7 @@ type VolumeStats struct {
 
 	WriteIOPS            string `json:"WriteIOPS"`
 	TotalWriteTime       string `json:"TotalWriteTime"`
-	TotalWriteBlockCount string `json:"TotatWriteBlockCount"`
+	TotalWriteBlockCount string `json:"TotalWriteBlockCount"`
 
 	UsedLogicalBlocks string  `json:"UsedLogicalBlocks"`
 	UsedBlocks        string  `json:"UsedBlocks"`


### PR DESCRIPTION
This is part of the fix for openebs/openebs/issues/2214.