### PR TITLE
[TA3763] fix(stats): change type of uptime to string

### DIFF
--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -71,12 +71,12 @@ type VolumeStats struct {
 	TotalWriteTime       string `json:"TotalWriteTime"`
 	TotalWriteBlockCount string `json:"TotalWriteBlockCount"`
 
-	UsedLogicalBlocks string  `json:"UsedLogicalBlocks"`
-	UsedBlocks        string  `json:"UsedBlocks"`
-	SectorSize        string  `json:"SectorSize"`
-	Size              string  `json:"Size"`
-	UpTime            float64 `json:"UpTime"`
-	Name              string  `json:"Name"`
+	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
+	UsedBlocks        string `json:"UsedBlocks"`
+	SectorSize        string `json:"SectorSize"`
+	Size              string `json:"Size"`
+	UpTime            string `json:"UpTime"`
+	Name              string `json:"Name"`
 }
 
 type SnapshotInput struct {

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -56,7 +56,7 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 		UsedBlocks:        strconv.FormatInt(stats.UsedBlocks, 10),
 		SectorSize:        strconv.FormatInt(stats.SectorSize, 10),
 		Size:              strconv.FormatInt(s.c.GetSize(), 10),
-		UpTime:            time.Since(s.c.StartTime).Seconds(),
+		UpTime:            fmt.Sprintf("%f", time.Since(s.c.StartTime).Seconds()),
 		Name:              s.c.Name,
 	}
 	apiContext.Write(volumeStats)


### PR DESCRIPTION
JSON can only handle the data up to 53 bits precision,
so this needs to be converted into string.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>