### PR TITLE
[TA2752, TA2754] feat(jiva): delete snapshot api

### DIFF
--- a/controller/rest/delete.go
+++ b/controller/rest/delete.go
@@ -6,7 +6,10 @@ import (
 	"sync"
 
 	"github.com/Sirupsen/logrus"
+	replica_jiva "github.com/openebs/jiva/replica"
 	replicaClient "github.com/openebs/jiva/replica/client"
+	replica_rest "github.com/openebs/jiva/replica/rest"
+	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
@@ -103,5 +106,164 @@ func (s *Server) DeleteVolume(rw http.ResponseWriter, req *http.Request) error {
 	s.delete(&replicas, &wg)
 	wg.Wait()
 	apiContext.Write(SetDeleteReplicaOutput(replicas))
+	return nil
+}
+
+func rmDisk(replica *types.Replica, disk string) error {
+	repClient, err := replicaClient.NewReplicaClient(replica.Address)
+	if err != nil {
+		return err
+	}
+	return repClient.RemoveDisk(disk)
+}
+func replaceDisk(replica *types.Replica, target, source string) error {
+	repClient, err := replicaClient.NewReplicaClient(replica.Address)
+	if err != nil {
+		return err
+	}
+	return repClient.ReplaceDisk(target, source)
+}
+func (s *Server) processRemoveSnapshot(replica *types.Replica, snapshot string, ops []replica_jiva.PrepareRemoveAction) error {
+	if len(ops) == 0 {
+		return nil
+	}
+	if replica.Mode != "RW" {
+		return fmt.Errorf("Can only removed snapshot from replica in mode RW, got %s", replica.Mode)
+	}
+	repClient, err := replicaClient.NewReplicaClient(replica.Address)
+	if err != nil {
+		return err
+	}
+	for _, op := range ops {
+		switch op.Action {
+		case replica_jiva.OpRemove:
+			logrus.Infof("Removing %s on %s", op.Source, replica.Address)
+			if err := rmDisk(replica, op.Source); err != nil {
+				return err
+			}
+		case replica_jiva.OpCoalesce:
+			logrus.Infof("Coalescing %v to %v on %v", op.Target, op.Source, replica.Address)
+			if err = repClient.Coalesce(op.Target, op.Source); err != nil {
+				logrus.Errorf("Failed to coalesce %s on %s: %v", snapshot, replica.Address, err)
+				return err
+			}
+		case replica_jiva.OpReplace:
+			logrus.Infof("Replace %v with %v on %v", op.Target, op.Source, replica.Address)
+			if err = replaceDisk(replica, op.Target, op.Source); err != nil {
+				logrus.Errorf("Failed to replace %v with %v on %v", op.Target, op.Source, replica.Address)
+				return err
+			}
+		}
+	}
+	return nil
+}
+func (s *Server) prepareRemoveSnapshot(replica *types.Replica, snapshot string) ([]replica_jiva.PrepareRemoveAction, error) {
+	if replica.Mode != "RW" {
+		return nil, fmt.Errorf("Can only removed snapshot from replica in mode RW, got %s", replica.Mode)
+	}
+	client, err := replicaClient.NewReplicaClient(replica.Address)
+	if err != nil {
+		return nil, err
+	}
+	output, err := client.PrepareRemoveDisk(snapshot)
+	if err != nil {
+		return nil, err
+	}
+	return output.Operations, nil
+}
+func (s *Server) checkPrerequisits(replicas []types.Replica) error {
+	for _, replica := range replicas {
+		replicaInfo, err := getReplicaInfo(replica.Address)
+		if err != nil {
+			return err
+		}
+		if replicaInfo.Rebuilding {
+			return fmt.Errorf("Replica %s is rebuilding", replica.Address)
+		}
+	}
+	return nil
+}
+func getReplicaInfo(addr string) (replica_rest.Replica, error) {
+	repClient, err := replicaClient.NewReplicaClient(addr)
+	if err != nil {
+		return replica_rest.Replica{}, err
+	}
+	replicaInfo, err := repClient.GetReplica()
+	if err != nil {
+		return replica_rest.Replica{}, err
+	}
+	return replicaInfo, nil
+}
+func isRemovable(replicas []types.Replica, name string) error {
+	var replica types.Replica
+	for _, replica = range replicas {
+		if replica.Mode == "RW" {
+			break
+		}
+	}
+	info, err := getReplicaInfo(replica.Address)
+	if err != nil {
+		return err
+	}
+	snapName := fmt.Sprintf("volume-snap-%s.img", name)
+	if info.Chain[1] == snapName {
+		return fmt.Errorf("can't delete latest snapshot %s", snapName)
+	}
+	return nil
+}
+func (s *Server) deleteSnapshot(replicas []types.Replica, name string) error {
+	s.c.Lock()
+	defer s.c.Unlock()
+	logrus.Infof("check if snapshot %s is removable", name)
+	if err := isRemovable(replicas, name); err != nil {
+		return err
+	}
+	logrus.Info("check prerequisits")
+	err := s.checkPrerequisits(replicas)
+	if err != nil {
+		return err
+	}
+	ops := make(map[string][]replica_jiva.PrepareRemoveAction)
+	for _, replica := range replicas {
+		ops[replica.Address], err = s.prepareRemoveSnapshot(&replica, name)
+		if err != nil {
+			return err
+		}
+	}
+	for _, replica := range replicas {
+		if err := s.processRemoveSnapshot(&replica, name, ops[replica.Address]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func (s *Server) DeleteSnapshot(rw http.ResponseWriter, req *http.Request) error {
+	apiContext := api.GetApiContext(req)
+	var input SnapshotInput
+	if err := apiContext.Read(&input); err != nil {
+		return err
+	}
+	replicas := s.c.ListReplicas()
+	replicaCount := len(replicas)
+	if replicaCount == 0 {
+		return fmt.Errorf("Number of registered replicas with this controller instance is zero")
+	}
+	replicationFactor := util.CheckReplicationFactor()
+	if replicaCount != replicationFactor {
+		return fmt.Errorf("Replica count: %v is not equal to replication factor: %v", replicaCount, replicationFactor)
+	}
+	logrus.Infof("Delete snapshot: %s", input.Name)
+	err := s.deleteSnapshot(replicas, input.Name)
+	if err != nil {
+		return err
+	}
+	msg := fmt.Sprintf("Snapshot: %s deleted successfully", input.Name)
+	apiContext.Write(&SnapshotOutput{
+		client.Resource{
+			Id:   input.Name,
+			Type: "snapshotOutput",
+		},
+		msg,
+	})
 	return nil
 }

--- a/controller/rest/delete.go
+++ b/controller/rest/delete.go
@@ -116,6 +116,7 @@ func rmDisk(replica *types.Replica, disk string) error {
 	}
 	return repClient.RemoveDisk(disk)
 }
+
 func replaceDisk(replica *types.Replica, target, source string) error {
 	repClient, err := replicaClient.NewReplicaClient(replica.Address)
 	if err != nil {
@@ -123,6 +124,7 @@ func replaceDisk(replica *types.Replica, target, source string) error {
 	}
 	return repClient.ReplaceDisk(target, source)
 }
+
 func (s *Server) processRemoveSnapshot(replica *types.Replica, snapshot string, ops []replica_jiva.PrepareRemoveAction) error {
 	if len(ops) == 0 {
 		return nil
@@ -157,6 +159,7 @@ func (s *Server) processRemoveSnapshot(replica *types.Replica, snapshot string, 
 	}
 	return nil
 }
+
 func (s *Server) prepareRemoveSnapshot(replica *types.Replica, snapshot string) ([]replica_jiva.PrepareRemoveAction, error) {
 	if replica.Mode != "RW" {
 		return nil, fmt.Errorf("Can only removed snapshot from replica in mode RW, got %s", replica.Mode)
@@ -183,6 +186,7 @@ func (s *Server) checkPrerequisits(replicas []types.Replica) error {
 	}
 	return nil
 }
+
 func getReplicaInfo(addr string) (replica_rest.Replica, error) {
 	repClient, err := replicaClient.NewReplicaClient(addr)
 	if err != nil {
@@ -194,6 +198,7 @@ func getReplicaInfo(addr string) (replica_rest.Replica, error) {
 	}
 	return replicaInfo, nil
 }
+
 func isRemovable(replicas []types.Replica, name string) error {
 	var replica types.Replica
 	for _, replica = range replicas {
@@ -211,6 +216,7 @@ func isRemovable(replicas []types.Replica, name string) error {
 	}
 	return nil
 }
+
 func (s *Server) deleteSnapshot(replicas []types.Replica, name string) error {
 	s.c.Lock()
 	defer s.c.Unlock()
@@ -237,6 +243,7 @@ func (s *Server) deleteSnapshot(replicas []types.Replica, name string) error {
 	}
 	return nil
 }
+
 func (s *Server) DeleteSnapshot(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
 	var input SnapshotInput

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -28,6 +28,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "start").Handler(f(schemas, s.StartVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "shutdown").Handler(f(schemas, s.ShutdownVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "snapshot").Handler(f(schemas, s.SnapshotVolume))
+	router.Methods("DELETE").Path("/v1/volumes/{id}").Queries("action", "deletesnapshot").Handler(f(schemas, s.DeleteSnapshot))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "revert").Handler(f(schemas, s.RevertVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "resize").Handler(f(schemas, s.ResizeVolume))
 


### PR DESCRIPTION
Add api to delete the user created snapshots.

Deletion doesn't work if there exist latest snapshot because its
contains the latest data and it will be marked as removed.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>