### PR TITLE
[ON HOLD][TA3789] feat(jiva): add version api

### DIFF
--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -114,6 +114,13 @@ type RegReplica struct {
 	UpTime   time.Duration `json:"UpTime"`
 }
 
+type Version struct {
+	client.Resource
+	Version     string `json:"version"`
+	GitCommitID string `json:"commitid"`
+	BuildDate   string `json:"builddate"`
+}
+
 func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int) *Volume {
 	var ReadOnly string
 	if readOnly {
@@ -181,6 +188,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("revertInput", RevertInput{})
 	schemas.AddType("journalInput", JournalInput{})
 	schemas.AddType("prepareRebuildOutput", PrepareRebuildOutput{})
+	schemas.AddType("version", Version{})
 
 	replica := schemas.AddType("replica", Replica{})
 	replica.CollectionMethods = []string{"GET", "POST"}

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -49,6 +49,8 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/delete").Handler(f(schemas, s.DeleteVolume))
 	// Debug
 	router.Methods("POST").Path("/timeout").Handler(f(schemas, s.AddTimeout))
+	// Version
+	router.Methods("GET").Path("/v1/version/details").Handler(f(schemas, s.GetVersion))
 
 	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
 

--- a/controller/rest/version.go
+++ b/controller/rest/version.go
@@ -1,0 +1,26 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/openebs/jiva/util"
+	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
+)
+
+func (s *Server) GetVersion(rw http.ResponseWriter, req *http.Request) error {
+	logrus.Info("get version")
+	details := util.GetVersionDetails()
+	apiContext := api.GetApiContext(req)
+	apiContext.Write(&Version{
+		client.Resource{
+			Id:   "details",
+			Type: "version",
+		},
+		details.Version,
+		details.GitCommitID,
+		details.BuildDate,
+	})
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -13,8 +13,15 @@ import (
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/openebs/jiva/app"
 	"github.com/openebs/jiva/backup"
+	"github.com/openebs/jiva/util"
 	"github.com/rancher/sparse-tools/cli/sfold"
 	"github.com/rancher/sparse-tools/cli/ssync"
+)
+
+var (
+	Version     string
+	GitCommitID string
+	BuildDate   string
 )
 
 func main() {
@@ -72,7 +79,7 @@ func longhornCli() {
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
 	}
-
+	util.SetVersionDetails(Version, BuildDate, GitCommitID)
 	a := cli.NewApp()
 	a.Before = func(c *cli.Context) error {
 		if c.GlobalBool("debug") {

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -114,6 +114,13 @@ type Action struct {
 	Value string `json:"Action"`
 }
 
+type Version struct {
+	client.Resource
+	Version     string `json:"version"`
+	GitCommitID string `json:"commitid"`
+	BuildDate   string `json:"builddate"`
+}
+
 func NewReplica(context *api.ApiContext, state replica.State, info replica.Info, rep *replica.Replica) *Replica {
 	r := &Replica{
 		Resource: client.Resource{
@@ -271,6 +278,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("revisionCounter", RevisionCounter{})
 	schemas.AddType("replicaCounter", ReplicaCounter{})
 	schemas.AddType("replacediskInput", ReplaceDiskInput{})
+	schemas.AddType("version", Version{})
 
 	delete := schemas.AddType("delete", DeleteReplicaOutput{})
 	delete.ResourceMethods = []string{"DELETE"}

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -79,6 +79,8 @@ func NewRouter(s *Server) *mux.Router {
 		router.Methods("POST").Path("/v1/replicas/{id}").Queries("action", name).Handler(f(schemas, checkAction(s, action)))
 	}
 	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux)
+	// Version
+	router.Methods("GET").Path("/v1/version/details").Handler(f(schemas, s.GetVersion))
 
 	return router
 }

--- a/replica/rest/version.go
+++ b/replica/rest/version.go
@@ -1,0 +1,26 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/openebs/jiva/util"
+	"github.com/rancher/go-rancher/api"
+	"github.com/rancher/go-rancher/client"
+)
+
+func (s *Server) GetVersion(rw http.ResponseWriter, req *http.Request) error {
+	logrus.Info("get version")
+	details := util.GetVersionDetails()
+	apiContext := api.GetApiContext(req)
+	apiContext.Write(&Version{
+		client.Resource{
+			Id:   "details",
+			Type: "version",
+		},
+		details.Version,
+		details.GitCommitID,
+		details.BuildDate,
+	})
+	return nil
+}

--- a/scripts/build_binaries
+++ b/scripts/build_binaries
@@ -6,4 +6,9 @@ source $(dirname $0)/version
 cd $(dirname $0)/..
 
 mkdir -p bin
-go build -tags "tcmu qcow" -ldflags "-X main.VERSION=$VERSION -linkmode external -extldflags -static" -o bin/longhorn
+go build -tags "tcmu qcow" -ldflags \
+        "-X main.Version=$VERSION \
+        -X main.GitCommitID=$GITCOMMIT \
+        -X main.BuildDate=$BUILDDATE \
+        -linkmode external -extldflags -static" \
+        -o bin/longhorn

--- a/scripts/package
+++ b/scripts/package
@@ -16,4 +16,7 @@ cp ../bin/longhorn* .
 cp /usr/src/tgt/pkg/tgt_*.deb .
 docker build -t ${REPO}/jiva:${TAG} .
 
+IMAGE_ID=$(docker images -q ${REPO}/jiva:${TAG})
+
 echo Built ${REPO}/jiva:${TAG}
+echo IMAGE_ID: $IMAGE_ID

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -16,4 +16,7 @@ cp ../bin/debug/longhorn* .
 cp /usr/src/tgt/pkg/tgt_*.deb .
 docker build -t ${REPO}/jiva:${TAG} .
 
+IMAGE_ID=$(docker images -q ${REPO}/jiva:${TAG})
+
 echo Built ${REPO}/jiva:${TAG}
+echo IMAGE_ID: $IMAGE_ID

--- a/scripts/push
+++ b/scripts/push
@@ -7,8 +7,7 @@ then
   exit 1
 fi
 
-IMAGEID=""
-VERSION=""
+export IMAGEID
 source "$(dirname $0)/version"
 IMAGEID=$(docker images -q openebs/jiva:${VERSION})
 echo $IMAGEID

--- a/scripts/push
+++ b/scripts/push
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 if [ -z ${IMAGE_REPO} ];
 then
@@ -7,9 +7,11 @@ then
   exit 1
 fi
 
+IMAGEID=""
+VERSION=""
 source "$(dirname $0)/version"
-IMAGEID=$( docker images -q openebs/jiva:${VERSION} )
-echo $IMAGEID 
+IMAGEID=$(docker images -q openebs/jiva:${VERSION})
+echo $IMAGEID
 if [ -z ${IMAGEID} ];
 then
   echo "Error: unable to get IMAGEID for ${IMAGE_REPO}:${VERSION}";
@@ -19,7 +21,7 @@ fi
 function TagAndPushImage() {
   REPO="$1"
   TAG="$2"
-  
+
   IMAGE_URI="${REPO}:${TAG}";
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";

--- a/scripts/push
+++ b/scripts/push
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 if [ -z ${IMAGE_REPO} ];
 then
@@ -7,10 +7,9 @@ then
   exit 1
 fi
 
-export IMAGEID
 source "$(dirname $0)/version"
-IMAGEID=$(docker images -q openebs/jiva:${VERSION})
-echo $IMAGEID
+TAG=${TAG:-${VERSION}}
+IMAGE_ID=$(docker images -q ${IMAGE_REPO}:${TAG})
 if [ -z ${IMAGEID} ];
 then
   echo "Error: unable to get IMAGEID for ${IMAGE_REPO}:${VERSION}";

--- a/scripts/push
+++ b/scripts/push
@@ -16,29 +16,6 @@ then
   exit 1
 fi
 
-# Generate a uniqe tag based on the commit and tag
-BUILD_ID=$(git describe --tags --always)
-
-# Determine the current branch
-CURRENT_BRANCH=""
-if [ -z ${TRAVIS_BRANCH} ];
-then
-  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
-else
-  CURRENT_BRANCH=${TRAVIS_BRANCH}
-fi
-
-#Depending on the branch where builds are generated, 
-# set the tag CI (fixed) and build tags.
-BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
-CI_TAG="${CURRENT_BRANCH}-ci"
-if [ ${CURRENT_BRANCH} = "master" ]; then
-  CI_TAG="ci"
-fi
-
-echo "Set the fixed ci image tag as: ${CI_TAG}"
-echo "Set the build/unique image tag as: ${BUILD_TAG}"
-
 function TagAndPushImage() {
   REPO="$1"
   TAG="$2"

--- a/scripts/version
+++ b/scripts/version
@@ -1,6 +1,43 @@
 #!/bin/bash
 
-RELEASE_TAG="dev"
-COMMIT=$(git rev-parse --short HEAD)
-VERSION="${RELEASE_TAG}-${COMMIT}"
+set -x
+# Generate a uniqe tag based on the commit and tag
+BUILD_ID=$(git describe --tags --always)
 
+# Determine the current branch
+CURRENT_BRANCH=""
+if [ -z ${TRAVIS_BRANCH} ];
+then
+  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+else
+  CURRENT_BRANCH=${TRAVIS_BRANCH}
+fi
+
+#Depending on the branch where builds are generated, 
+# set the tag CI (fixed) and build tags.
+BUILD_TAG="${CURRENT_BRANCH}-${BUILD_ID}"
+CI_TAG="${CURRENT_BRANCH}-ci"
+if [ ${CURRENT_BRANCH} = "master" ]; then
+  CI_TAG="ci"
+fi
+
+echo "Set the fixed ci image tag as: ${CI_TAG}"
+echo "Set the build/unique image tag as: ${BUILD_TAG}"
+
+COMMIT=$(git rev-parse --short HEAD)
+BUILDDATE=$(date --rfc-3339=seconds)
+BUILDDATE=${BUILDDATE// /,} # skip spaces from above and add comma
+
+if [ ! -z "${TRAVIS_TAG}" ] ;
+  then
+    GITCOMMIT=${COMMIT}
+    VERSION=${TRAVIS_TAG}
+else
+  RELEASE_TAG=${CI_TAG}
+  GITCOMMIT=${COMMIT}
+  VERSION=${RELEASE_TAG}-${COMMIT}
+fi;
+
+echo "Git commit id: $GITCOMMIT"
+echo "Jiva version: $VERSION"
+echo "Build date: $BUILDDATE"

--- a/scripts/version
+++ b/scripts/version
@@ -27,14 +27,13 @@ echo "Set the build/unique image tag as: ${BUILD_TAG}"
 COMMIT=$(git rev-parse --short HEAD)
 BUILDDATE=$(date --rfc-3339=seconds)
 BUILDDATE=${BUILDDATE// /,} # skip spaces from above and add comma
+GITCOMMIT=${COMMIT}
 
 if [ ! -z "${TRAVIS_TAG}" ] ;
   then
-    GITCOMMIT=${COMMIT}
     VERSION=${TRAVIS_TAG}
 else
   RELEASE_TAG=${CI_TAG}
-  GITCOMMIT=${COMMIT}
   VERSION=${RELEASE_TAG}-${COMMIT}
 fi;
 

--- a/scripts/version
+++ b/scripts/version
@@ -8,7 +8,7 @@ BUILD_ID=$(git describe --tags --always)
 CURRENT_BRANCH=""
 if [ -z ${TRAVIS_BRANCH} ];
 then
-  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 else
   CURRENT_BRANCH=${TRAVIS_BRANCH}
 fi

--- a/util/util.go
+++ b/util/util.go
@@ -26,6 +26,18 @@ const (
 	BlockSizeLinux = 512
 )
 
+var (
+	Version     string
+	BuildDate   string
+	GitCommitID string
+)
+
+type VersionDetails struct {
+	Version     string
+	BuildDate   string
+	GitCommitID string
+}
+
 func ParseAddresses(name string) (string, string, string, error) {
 	matches := parsePattern.FindStringSubmatch(name)
 	if matches == nil {
@@ -172,4 +184,18 @@ func CheckReplicationFactor() int {
 		return int(replicationFactor)
 	}
 	return int(replicationFactor)
+}
+
+func SetVersionDetails(ver, date, commit string) {
+	Version = ver
+	BuildDate = date
+	GitCommitID = commit
+}
+
+func GetVersionDetails() VersionDetails {
+	return VersionDetails{
+		Version:     Version,
+		BuildDate:   BuildDate,
+		GitCommitID: GitCommitID,
+	}
 }


### PR DESCRIPTION
This commit adds the version api in both replica and controller.
This can be verified via following:
```
$ curl -X GET http://172.18.0.2:9501/v1/version/details
{
  "version": "add-snapshot-api-ci-e06474a",
  "actions": {},
  "builddate": "2018-10-29,12:55:46+00:00",
  "commitid": "e06474a",
  "id": "details",
  "links": {
    "self": "http://172.18.0.2:9501/v1/versions/details"
  },
  "type": "version"
}
```
Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>