### PR TITLE
[TA3796] fix(travis): update Dockerfile.dapper

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -20,7 +20,7 @@ RUN apt-get update -o Acquire::CompressionTypes::Order::=gz && apt-get update &&
     apt-get install -y cmake wget curl git less file \
         libglib2.0-dev libkmod-dev libnl-genl-3-dev linux-libc-dev pkg-config psmisc python-tox qemu-utils fuse python-dev \
         devscripts debhelper bash-completion librdmacm-dev libibverbs-dev xsltproc docbook-xsl \
-        libconfig-general-perl libaio-dev libc6-dev
+        libconfig-general-perl libaio-dev libc6-dev iptables libltdl7
 
 # needed for ${!var} substitution
 RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
@@ -32,11 +32,11 @@ RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARC
     go get github.com/rancher/trash && go get -u golang.org/x/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker
-ENV DOCKER_URL_amd64=https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 \
-DOCKER_URL_arm=https://github.com/rancher/docker/releases/download/v1.10.3-ros1/docker-1.10.3_arm \
+ENV DOCKER_URL_amd64=https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/amd64/docker-ce_17.03.3~ce-0~ubuntu-xenial_amd64.deb \
+DOCKER_URL_arm=https://download.docker.com/linux/ubuntu/dists/xenial/pool/stable/arm64/docker-ce_18.06.1~ce~3-0~ubuntu_arm64.deb \
 DOCKER_URL=DOCKER_URL_${ARCH}
 
-RUN wget -O /usr/bin/docker ${!DOCKER_URL} && chmod +x /usr/bin/docker
+RUN wget ${!DOCKER_URL} -O docker_ce_${ARCH} && dpkg -i docker_ce_${ARCH}
 
 # Build TCMU
 RUN cd /usr/src && \


### PR DESCRIPTION
This commit upgrades the docker version used to build the env
to latest stable ones.

Signed-off-by: Utkarsh Mani Tripathi <utkarshmani1997@gmail.com>