### PR TITLE
[TA3939, TA3971] feat(stats): Add rep/cont status field

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -176,6 +176,7 @@ func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	}
 
 	err = json.NewDecoder(resp.Body).Decode(&Details)
+	volUsage.RevisionCounter, _ = strconv.ParseInt(Details.RevisionCounter, 10, 64)
 	volUsage.UsedLogicalBlocks, _ = strconv.ParseInt(Details.UsedLogicalBlocks, 10, 64)
 	volUsage.UsedBlocks, _ = strconv.ParseInt(Details.UsedBlocks, 10, 64)
 	volUsage.SectorSize, _ = strconv.ParseInt(Details.SectorSize, 10, 64)

--- a/controller/control.go
+++ b/controller/control.go
@@ -923,6 +923,7 @@ func (c *Controller) Stats() (types.Stats, error) {
 	if c.frontend != nil {
 		stats := (types.Stats)(c.frontend.Stats())
 		volUsage, err := c.backend.GetVolUsage()
+		stats.RevisionCounter = volUsage.RevisionCounter
 		stats.UsedLogicalBlocks = volUsage.UsedLogicalBlocks
 		stats.UsedBlocks = volUsage.UsedBlocks
 		stats.SectorSize = volUsage.SectorSize

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -60,7 +60,7 @@ type SnapshotOutput struct {
 type VolumeStats struct {
 	client.Resource
 	RevisionCounter int64         `json:"RevisionCounter"`
-	ReplicaCounter  int64         `json:"ReplicaCounter"`
+	ReplicaCounter  int           `json:"ReplicaCounter"`
 	SCSIIOCount     map[int]int64 `json:"SCSIIOCount"`
 
 	ReadIOPS            string `json:"ReadIOPS"`
@@ -71,12 +71,14 @@ type VolumeStats struct {
 	TotalWriteTime       string `json:"TotalWriteTime"`
 	TotalWriteBlockCount string `json:"TotalWriteBlockCount"`
 
-	UsedLogicalBlocks string `json:"UsedLogicalBlocks"`
-	UsedBlocks        string `json:"UsedBlocks"`
-	SectorSize        string `json:"SectorSize"`
-	Size              string `json:"Size"`
-	UpTime            string `json:"UpTime"`
-	Name              string `json:"Name"`
+	UsedLogicalBlocks string          `json:"UsedLogicalBlocks"`
+	UsedBlocks        string          `json:"UsedBlocks"`
+	SectorSize        string          `json:"SectorSize"`
+	Size              string          `json:"Size"`
+	UpTime            string          `json:"UpTime"`
+	Name              string          `json:"Name"`
+	Replica           []types.Replica `json:"Replicas"`
+	ControllerStatus  string          `json:"Status"`
 }
 
 type SnapshotInput struct {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -271,6 +271,7 @@ func (r *Replica) SetRebuilding(rebuilding bool) error {
 
 func (r *Replica) GetUsage() (*types.VolUsage, error) {
 	return &types.VolUsage{
+		RevisionCounter:   r.revisionCache,
 		UsedLogicalBlocks: r.volume.UsedLogicalBlocks,
 		UsedBlocks:        r.volume.UsedBlocks,
 		SectorSize:        r.volume.sectorSize,

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -72,6 +72,7 @@ type RemoveDiskInput struct {
 
 type VolUsage struct {
 	client.Resource
+	RevisionCounter   string `json:"revisioncounter"`
 	UsedLogicalBlocks string `json:"usedlogicalblocks"`
 	UsedBlocks        string `json:"usedblocks"`
 	SectorSize        string `json:"sectorSize"`

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -91,6 +91,7 @@ func (s *Server) GetVolUsage(rw http.ResponseWriter, req *http.Request) error {
 			Actions: map[string]string{},
 			Links:   map[string]string{},
 		},
+		RevisionCounter:   strconv.FormatInt(usage.RevisionCounter, 10),
 		UsedLogicalBlocks: strconv.FormatInt(usage.UsedLogicalBlocks, 10),
 		UsedBlocks:        strconv.FormatInt(usage.UsedBlocks, 10),
 		SectorSize:        strconv.FormatInt(usage.SectorSize, 10),

--- a/types/types.go
+++ b/types/types.go
@@ -50,6 +50,7 @@ type BackendFactory interface {
 }
 
 type VolUsage struct {
+	RevisionCounter   int64
 	UsedLogicalBlocks int64
 	UsedBlocks        int64
 	SectorSize        int64
@@ -74,8 +75,8 @@ type Mode string
 type State string
 
 type Replica struct {
-	Address string
-	Mode    Mode
+	Address string `json:"Address"`
+	Mode    Mode   `json:"Mode"`
 }
 
 type RegReplica struct {


### PR DESCRIPTION
This commit adds the replica and controller status field in the stats
api
fix the issue in revision counter, where it was giving zero value
Add json tags into Replica struct

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>