### PR TITLE
[TA4284] fix(rpc): close connection at the client side

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -51,10 +51,10 @@ RUN cd /usr/src/tcmu-runner && \
     cp libtcmu_static.a /usr/local/lib/libtcmu.a
 
 # Install libqcow
-RUN wget -O - https://github.com/libyal/libqcow/releases/download/20180831/libqcow-alpha-20180831.tar.gz | tar xvzf - -C /usr/src
-RUN cd /usr/src/libqcow-20180831 && \
+RUN wget -O - https://github.com/libyal/libqcow/releases/download/20181216/libqcow-alpha-20181216.tar.gz | tar xvzf - -C /usr/src
+RUN cd /usr/src/libqcow-20181216 && \
     ./configure
-RUN cd /usr/src/libqcow-20180831 && \
+RUN cd /usr/src/libqcow-20181216 && \
     make -j$(nproc) && \
     make install
 

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -516,7 +516,7 @@ test_controller_rpc_close() {
 	echo "----------------Test_controller_rpc_close---------------"
 	debug_controller_id=$(start_debug_controller "$CONTROLLER_IP" "store1" "1" "RPC_PING_TIMEOUT" "25")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
-	sleep 30
+	sleep 40
 
         writer_exit=`docker logs $debug_controller_id 2>&1 | grep "Exiting rpc writer" | wc -l`
         reader_exit=`docker logs $debug_controller_id 2>&1 | grep "Exiting rpc reader" | wc -l`

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -12,7 +12,8 @@ import (
 
 type Timeout struct {
 	client.Resource
-	Timeout string `json:"timeout"`
+	Timeout        string `json:"timeout"`
+	RPCPingTimeout string `json:"rpcPingTimeout"`
 }
 
 type DeleteReplicaOutput struct {

--- a/controller/rest/timeout.go
+++ b/controller/rest/timeout.go
@@ -1,6 +1,7 @@
 package rest
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 
@@ -15,6 +16,13 @@ func (s *Server) AddTimeout(rw http.ResponseWriter, req *http.Request) error {
 		logrus.Error("failed to read the request body, error: %v", err)
 		return err
 	}
-	logrus.Infof("Added a timeout of %vs", timeout.Timeout)
-	return os.Setenv("DEBUG_TIMEOUT", timeout.Timeout)
+	if timeout.Timeout != "" {
+		logrus.Infof("Added a timeout of %vs", timeout.Timeout)
+		return os.Setenv("DEBUG_TIMEOUT", timeout.Timeout)
+	}
+	if timeout.RPCPingTimeout != "" {
+		logrus.Infof("Added a ping timeout of %vs", timeout.RPCPingTimeout)
+		return os.Setenv("RPC_PING_TIMEOUT", timeout.RPCPingTimeout)
+	}
+	return fmt.Errorf("Error in setting timeout, received empty value")
 }

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -4,3 +4,5 @@ package inject
 
 func AddTimeout() {
 }
+func AddPingTimeout() {
+}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -10,8 +10,21 @@ import (
 	"github.com/Sirupsen/logrus"
 )
 
+var (
+	pingTimeout = true
+)
+
 func AddTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("DEBUG_TIMEOUT"))
 	logrus.Infof("Add timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
+}
+
+func AddPingTimeout() {
+	if pingTimeout {
+		timeout, _ := strconv.Atoi(os.Getenv("RPC_PING_TIMEOUT"))
+		logrus.Infof("Add ping timeout of %vs for debug build", timeout)
+		time.Sleep(time.Duration(timeout) * time.Second)
+		pingTimeout = false
+	}
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -216,8 +216,6 @@ func (c *Client) operation(op uint32, buf []byte, offset int64, length int64) (i
 
 //Close replica client
 func (c *Client) Close() error {
-	//	c.wire.Close()
-	//	c.end <- struct{}{}
 	if err := c.wire.CloseRead(); err != nil {
 		return err
 	}
@@ -244,8 +242,6 @@ func (c *Client) loop() {
 
 	for {
 		select {
-		//		case <-c.end:
-		//			return
 		case req := <-c.requests:
 			c.handleRequest(req)
 		case resp := <-c.responses:

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -231,16 +231,14 @@ func (c *Client) Close() error {
 		}
 		time.Sleep(2 * time.Second)
 	}
-	close(c.send)
 	return c.wire.Close()
 }
 
 func (c *Client) loop() {
 	defer func() {
-	retry:
+		close(c.send)
 		if err := c.Close(); err != nil {
 			logrus.Error("failed to close conn, err: ", err)
-			goto retry
 		}
 	}()
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -47,7 +47,7 @@ func (s *Server) Handle() error {
 		default:
 		}
 	}()
-	ret := make(chan error)
+	ret := make(chan error, 1)
 	s.pingRecvd = time.Now()
 	go s.readWrite(ret)
 	for {

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -94,7 +94,6 @@ func (s *Server) readWrite(ret chan<- error) {
 		case TypeWrite:
 			s.handleWrite(msg)
 		case TypePing:
-			logrus.Info("ping received")
 			s.handlePing(msg)
 		case TypeSync:
 			s.handleSync(msg)

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 )
 
@@ -70,6 +71,7 @@ func (s *Server) Handle() error {
 func (s *Server) readWrite(ret chan<- error) {
 	s.pingStart = time.Now()
 	for {
+		inject.AddPingTimeout()
 		msg, err := s.wire.Read()
 		if err == io.EOF {
 			logrus.Errorf("Received EOF: %v", err)
@@ -106,7 +108,7 @@ func (s *Server) readWrite(ret chan<- error) {
 			break
 		}
 	}
-	logrus.Error("closing rpc server")
+	logrus.Error("Closing rpc server")
 	s.writeExit = true
 }
 

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -55,6 +55,9 @@ func (w *Wire) Write(msg *Message) error {
 		logrus.Errorf("Write len(msg.Data) failed, Error: %v", err)
 		return err
 	}
+	if w.readExit {
+		return fmt.Errorf("Can't write, read is closed on rpc conn")
+	}
 	if len(msg.Data) > 0 {
 		if _, err := w.writer.Write(msg.Data); err != nil {
 			logrus.Errorf("Write msg.Data failed, Error: %v", err)
@@ -102,7 +105,9 @@ func (w *Wire) Read() (*Message, error) {
 		logrus.Errorf("Read length failed, Error: %v", err)
 		return nil, err
 	}
-
+	if w.writeExit {
+		return &msg, fmt.Errorf("Can't read, write is closed on rpc conn")
+	}
 	if length > 0 {
 		msg.Data = make([]byte, length)
 		if _, err := io.ReadFull(w.reader, msg.Data); err != nil {

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -116,6 +116,7 @@ func (w *Wire) Read() (*Message, error) {
 
 func (w *Wire) CloseRead() error {
 	if conn, ok := w.conn.(*net.TCPConn); ok {
+		logrus.Warning("Closing read on rpc conn")
 		return conn.CloseRead()
 	}
 	return fmt.Errorf("failed to close, type assert error")
@@ -123,25 +124,13 @@ func (w *Wire) CloseRead() error {
 
 func (w *Wire) CloseWrite() error {
 	if conn, ok := w.conn.(*net.TCPConn); ok {
+		logrus.Warning("Closing write on rpc conn")
 		return conn.CloseWrite()
 	}
 	return fmt.Errorf("failed to close, type assert error")
 }
 
 func (w *Wire) Close() error {
-	logrus.Warning("Closing read on TCP conn")
-	if err := w.CloseRead(); err != nil {
-		return err
-	}
-	logrus.Warning("Closing write on TCP conn")
-	if err := w.CloseWrite(); err != nil {
-		return err
-	}
-	for {
-		if w.readExit && w.writeExit {
-			break
-		}
-	}
 	logrus.Warning("Closing TCP conn")
 	return w.conn.Close()
 }

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -55,9 +55,6 @@ func (w *Wire) Write(msg *Message) error {
 		logrus.Errorf("Write len(msg.Data) failed, Error: %v", err)
 		return err
 	}
-	if w.readExit {
-		return fmt.Errorf("Can't write, read is closed on rpc conn")
-	}
 	if len(msg.Data) > 0 {
 		if _, err := w.writer.Write(msg.Data); err != nil {
 			logrus.Errorf("Write msg.Data failed, Error: %v", err)
@@ -104,9 +101,6 @@ func (w *Wire) Read() (*Message, error) {
 	if err := binary.Read(w.reader, binary.LittleEndian, &length); err != nil {
 		logrus.Errorf("Read length failed, Error: %v", err)
 		return nil, err
-	}
-	if w.writeExit {
-		return &msg, fmt.Errorf("Can't read, write is closed on rpc conn")
 	}
 	if length > 0 {
 		msg.Data = make([]byte, length)


### PR DESCRIPTION
Controller initiates a new connection upon replica registration,
this might create some problem due to concurrent goroutines, as some
of the goroutine may not have been exited. To ensure graceful close
of the connection, i have added CloseRead and CloseWrite in both 
replica and controller.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>