### PR TITLE
[TA4197] fix(replica): preload issue due to large no of extents

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -86,6 +86,10 @@ func (f *Wrapper) GetCloneStatus() (string, error) {
 	return "", nil
 }
 
+func (f *Wrapper) GetPreloadStatus() (string, error) {
+	return "", nil
+}
+
 func (f *Wrapper) PingResponse() error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -42,7 +42,7 @@ type Remote struct {
 }
 
 func (r *Remote) Close() error {
-	logrus.Infof("Closing: %s", r.Name)
+	logrus.Infof("Close replica: %s", r.Name)
 	r.StopMonitoring()
 	return nil
 }
@@ -154,6 +154,14 @@ func (r *Remote) GetCloneStatus() (string, error) {
 		return "", err
 	}
 	return replica.CloneStatus, nil
+}
+
+func (r *Remote) GetPreloadStatus() (string, error) {
+	replica, err := r.info()
+	if err != nil {
+		return "", err
+	}
+	return string(replica.PreloadStatus), nil
 }
 
 func (r *Remote) GetVolUsage() (types.VolUsage, error) {
@@ -301,6 +309,6 @@ func (r *Remote) GetMonitorChannel() types.MonitorChannel {
 }
 
 func (r *Remote) StopMonitoring() {
-	logrus.Infof("stopping monitoring %v", r.Name)
+	logrus.Infof("Stop monitoring of replica: %v", r.Name)
 	r.closeChan <- struct{}{}
 }

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1178,6 +1178,7 @@ test_upgrade() {
 test_upgrades() {
        test_upgrade "openebs/jiva:0.6.0" "controller-replica"
        test_upgrade "openebs/jiva:0.7.0" "replica-controller"
+       test_upgrade "openebs/jiva:0.8.0" "replica-controller"
 }
 
 di_test_on_raw_disk() {

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -24,10 +24,6 @@ collect_logs_and_exit() {
 	echo "--------------------------REPLICA 3  LOGS ---------------------------------"
 	curl http://$REPLICA_IP3:9502/v1/replicas | jq
 
-	#Take system output
-	ps -auxwww
-	top -n 10 -b
-	netstat -nap
 
 #	i=0
 #	while [ "$i" != 10 ]; do
@@ -68,7 +64,11 @@ collect_logs_and_exit() {
 	docker logs $cloned_controller_id
 	echo "--------------------------CLONED REPLICA LOGS -----------------------------"
 	docker logs $cloned_replica_id
-	exit 1
+	#Take system output
+	ps -auxwww
+	top -n 10 -b
+	netstat -nap
+        exit 1
 }
 cleanup() {
 	rm -rf /tmp/vol*
@@ -563,7 +563,7 @@ test_preload() {
 		collect_logs_and_exit
 	fi
 
-	controller_exit=`docker logs $orig_controller_id 2>&1 | grep -c "stopping target"`
+	controller_exit=`docker logs $orig_controller_id 2>&1 | grep -c "Stopping controller"`
 	if [ "$controller_exit" == 0 ]; then
 		collect_logs_and_exit
 	fi

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -573,14 +573,9 @@ test_preload() {
 		collect_logs_and_exit
 	fi
 
-	restart_autoconfigure=`docker logs $debug_replica_id 2>&1 | grep -c "Restart AutoConfigure Process"`
-	if [ "$restart_autoconfigure" == 0 ]; then
-		collect_logs_and_exit
-	fi
-
         preload_success=0
         iter=0
-	while [ "$preload_success" -lt 2 ]; do
+	while [ "$preload_success" -lt 1 ]; do
 		preload_success=`docker logs $debug_replica_id 2>&1 | grep -c "Read extents successful"`
                 if [ "$iter" == 100 ]; then
                         collect_logs_and_exit

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -584,11 +584,6 @@ test_preload() {
                 sleep 2
         done
 
-        duplicate_preload_goroutine_exit=`docker logs $debug_replica_id 2>&1 | grep -c "Already reading extents in background"`
-        if [ "$duplicate_preload_goroutine_exit" == 0 ]; then
-                collect_logs_and_exit
-        fi
-
 	cleanup
 }
 

--- a/controller/control.go
+++ b/controller/control.go
@@ -1040,6 +1040,8 @@ func (c *Controller) monitoring(address string, backend types.Backend) {
 }
 
 func (c *Controller) monitorPreload(address string) {
+	c.Lock()
+	defer c.Unlock()
 	logrus.Infof("Get preload status of backend %s", address)
 	if err := c.backend.GetPreloadStatus(address); err != nil {
 		logrus.Errorf("Failed to monitor preload, error: %v", err)

--- a/controller/control.go
+++ b/controller/control.go
@@ -599,6 +599,9 @@ func (c *Controller) SetReplicaMode(address string, mode types.Mode) error {
 	case types.RW:
 		c.Lock()
 		defer c.Unlock()
+	case types.WO:
+		c.Lock()
+		defer c.Unlock()
 	default:
 		return fmt.Errorf("Can not set to mode %s", mode)
 	}
@@ -706,7 +709,7 @@ getCloneStatus:
 	} else if status == "error" {
 		return fmt.Errorf("Replica clone status returned error %s", address)
 	}
-	c.setReplicaModeNoLock(address, types.WO)
+	c.SetReplicaMode(address, types.WO)
 	go c.monitorPreload(address)
 	return nil
 }
@@ -1043,6 +1046,6 @@ func (c *Controller) monitorPreload(address string) {
 		return
 	}
 	c.startFrontend()
-	c.setReplicaModeNoLock(address, types.RW)
+	c.SetReplicaMode(address, types.RW)
 	c.UpdateVolStatus()
 }

--- a/controller/control.go
+++ b/controller/control.go
@@ -709,7 +709,7 @@ getCloneStatus:
 	} else if status == "error" {
 		return fmt.Errorf("Replica clone status returned error %s", address)
 	}
-	c.SetReplicaMode(address, types.WO)
+	c.setReplicaModeNoLock(address, types.WO)
 	go c.monitorPreload(address)
 	return nil
 }
@@ -1046,6 +1046,6 @@ func (c *Controller) monitorPreload(address string) {
 		return
 	}
 	c.startFrontend()
-	c.SetReplicaMode(address, types.RW)
+	c.setReplicaModeNoLock(address, types.RW)
 	c.UpdateVolStatus()
 }

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -508,11 +508,11 @@ func (r *replicator) GetCloneStatus(address string) (string, error) {
 }
 
 func (r *replicator) GetPreloadStatus(address string) error {
-	backend, ok := r.backends[address]
-	if !ok {
-		return fmt.Errorf("Cannot find backend %v", address)
-	}
 	for true {
+		backend, ok := r.backends[address]
+		if !ok {
+			return fmt.Errorf("Cannot find backend %v", address)
+		}
 		status, err := backend.backend.GetPreloadStatus()
 		if err != nil {
 			return err
@@ -526,7 +526,8 @@ func (r *replicator) GetPreloadStatus(address string) error {
 			time.Sleep(2 * time.Second)
 		case types.Error:
 			return fmt.Errorf("Preload status of backend is %s", status)
-		case "":
+		default:
+			logrus.Warningf("Preload is not done yet on backend %s, current status: %s", address, status)
 			time.Sleep(2 * time.Second)
 		}
 	}

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -526,6 +526,8 @@ func (r *replicator) GetPreloadStatus(address string) error {
 			time.Sleep(2 * time.Second)
 		case types.Error:
 			return fmt.Errorf("Preload status of backend is %s", status)
+		case "":
+			time.Sleep(2 * time.Second)
 		}
 	}
 	return nil

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/openebs/jiva/backend/remote"
@@ -507,29 +506,14 @@ func (r *replicator) GetCloneStatus(address string) (string, error) {
 	return status, nil
 }
 
-func (r *replicator) GetPreloadStatus(address string) error {
-	for true {
-		backend, ok := r.backends[address]
-		if !ok {
-			return fmt.Errorf("Cannot find backend %v", address)
-		}
-		status, err := backend.backend.GetPreloadStatus()
-		if err != nil {
-			return err
-		}
-		switch types.PreloadStatus(status) {
-		case types.Done:
-			logrus.Infof("Preload is completed on backend %s", address)
-			return nil
-		case types.Started:
-			logrus.Warningf("Preload is not done yet on backend %s, current status: %s", address, status)
-			time.Sleep(2 * time.Second)
-		case types.Error:
-			return fmt.Errorf("Preload status of backend is %s", status)
-		default:
-			logrus.Warningf("Preload is not done yet on backend %s, current status: %s", address, status)
-			time.Sleep(2 * time.Second)
-		}
+func (r *replicator) GetPreloadStatus(address string) (string, error) {
+	backend, ok := r.backends[address]
+	if !ok {
+		return "", fmt.Errorf("Cannot find backend %v", address)
 	}
-	return nil
+	status, err := backend.backend.GetPreloadStatus()
+	if err != nil {
+		return "", err
+	}
+	return status, nil
 }

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,7 +2,6 @@
 
 package inject
 
-func AddTimeout() {
-}
-func AddPingTimeout() {
-}
+func AddTimeout()        {}
+func AddPingTimeout()    {}
+func AddPreloadTimeout() {}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -28,3 +28,9 @@ func AddPingTimeout() {
 		pingTimeout = false
 	}
 }
+
+func AddPreloadTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("PRELOAD_TIMEOUT"))
+	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
+}

--- a/frontend/gotgt/frontend.go
+++ b/frontend/gotgt/frontend.go
@@ -149,10 +149,11 @@ func (t *goTgt) startScsiTarget(cfg *config.Config) error {
 
 func (t *goTgt) stopScsiTarget() error {
 	if t.targetDriver == nil {
+		logrus.Warning("No target is available, ignoring...")
 		return nil
 	}
-	logrus.Infof("stopping target %v ...", t.tgtName)
+	logrus.Infof("Stopping target %v ...", t.tgtName)
 	t.targetDriver.Stop()
-	logrus.Infof("target %v stopped", t.tgtName)
+	logrus.Infof("Target %v stopped", t.tgtName)
 	return nil
 }

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -306,7 +306,7 @@ func PreloadLunMap(d *diffDisk) error {
 			d.UsedLogicalBlocks++
 		}
 	}
-	logrus.Info("Updating preload status to '%v'", types.Done)
+	logrus.Infof("Updating preload status to '%v'", types.Done)
 	d.preloadStatus = types.Done
 	return nil
 }

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -291,12 +291,13 @@ func preload(d *diffDisk) error {
 }
 
 func PreloadLunMap(d *diffDisk) error {
+	d.rmLock.Lock()
+	defer d.rmLock.Unlock()
 	err := preload(d)
 	for _, val := range d.location {
 		if val != 0 {
 			d.UsedLogicalBlocks++
 		}
 	}
-	logrus.Info("Read extents completed (Preload)")
 	return err
 }

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -297,5 +297,6 @@ func PreloadLunMap(d *diffDisk) error {
 			d.UsedLogicalBlocks++
 		}
 	}
+	logrus.Info("Read extents completed (Preload)")
 	return err
 }

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -187,7 +187,6 @@ func (c *ReplicaClient) OpenReplica() error {
 
 func (c *ReplicaClient) GetReplica() (rest.Replica, error) {
 	var replica rest.Replica
-
 	err := c.get(c.address+"/replicas/1", &replica)
 	return replica, err
 }

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -31,6 +31,11 @@ type diffDisk struct {
 	// Index of latest user created snapshot
 	SnapIndx   int
 	sectorSize int64
+	// there are three status:
+	// Done    : Preload is completed
+	// Started : Preload is started and is running in background
+	// Error   : There was some error in preload
+	preloadStatus types.PreloadStatus
 }
 
 func (d *diffDisk) RemoveIndex(index int) error {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -227,6 +227,12 @@ func (r *Replica) Preload() error {
 	return nil
 }
 
+func (r *Replica) GetPreloadStatus() types.PreloadStatus {
+	r.RLock()
+	defer r.RUnlock()
+	return r.volume.preloadStatus
+}
+
 func GenerateSnapshotDiskName(name string) string {
 	return fmt.Sprintf(diskName, name)
 }

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -173,7 +173,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 		r.info.BackingFileName = backingFile.Name
 	}
 	r.volume.sectorSize = defaultSectorSize
-
+	r.volume.preloadStatus = types.None
 	// Scan all the disks to build the disk map
 	exists, err := r.readMetadata()
 	if err != nil {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -217,11 +217,14 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
 
-	if err := PreloadLunMap(&r.volume); err != nil {
-		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
-	}
-
 	return r, r.writeVolumeMetaData(true, r.info.Rebuilding)
+}
+
+func (r *Replica) Preload() error {
+	if err := PreloadLunMap(&r.volume); err != nil {
+		return fmt.Errorf("failed to load Lun map, error: %v", err)
+	}
+	return nil
 }
 
 func GenerateSnapshotDiskName(name string) string {

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -3,6 +3,8 @@ package rest
 import (
 	"strconv"
 
+	"github.com/openebs/jiva/types"
+
 	"github.com/openebs/jiva/replica"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
@@ -25,6 +27,7 @@ type Replica struct {
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
 	CloneStatus       string                      `json:"clonestatus"`
+	PreloadStatus     types.PreloadStatus         `json:"preloadStatus"`
 }
 
 type DeleteReplicaOutput struct {
@@ -204,6 +207,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
 		r.CloneStatus = rep.GetCloneStatus()
+		r.PreloadStatus = rep.GetPreloadStatus()
 	}
 	return r
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -109,9 +109,16 @@ func (s *Server) Create(size int64) error {
 
 func (s *Server) Preload() error {
 	logrus.Info("Start reading extents")
-	if s.r == nil {
+	s.Lock()
+	r := s.r
+	if r == nil {
+		s.Unlock()
 		return fmt.Errorf("Can't read extents, s.r is nil")
 	}
+	r.Lock()
+	defer r.Unlock()
+	s.Unlock()
+
 	s.PreloadStatus = types.Started
 	// injecting timeout in debug build
 	inject.AddPreloadTimeout()

--- a/replica/server.go
+++ b/replica/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 )
 
@@ -103,6 +104,7 @@ func (s *Server) Create(size int64) error {
 }
 
 func (s *Server) Preload() error {
+	inject.AddPreloadTimeout()
 	if s.r == nil {
 		return fmt.Errorf("Can't read extents, s.r is nil")
 	}

--- a/replica/server.go
+++ b/replica/server.go
@@ -102,6 +102,13 @@ func (s *Server) Create(size int64) error {
 	return r.Close()
 }
 
+func (s *Server) Preload() error {
+	if s.r == nil {
+		return fmt.Errorf("Can't read extents, s.r is nil")
+	}
+	return s.r.Preload()
+}
+
 func (s *Server) Open() error {
 	s.Lock()
 	defer s.Unlock()

--- a/replica/server.go
+++ b/replica/server.go
@@ -88,6 +88,9 @@ func (s *Server) Create(size int64) error {
 	state, _ := s.Status()
 
 	if state != Initial {
+		r := &Replica{}
+		r.volume.preloadStatus = types.None
+		s.r = r
 		fmt.Println("STATE = ", state)
 		return nil
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -325,7 +325,7 @@ Register:
 		if err := t.client.Start(replicaAddress); err != nil {
 			return err
 		}
-		go s.Preload()
+		s.Preload()
 		return nil
 	}
 	logrus.Infof("CheckAndResetFailedRebuild %v", replicaAddress)
@@ -367,12 +367,10 @@ Register:
 		return err
 	}
 
-	// Running as a saparate goroutine such that if controller
-	// disconnected while preload, replica get notified immediately
-	// on MonitorChannel.
 	logrus.Info("Preload and verify rebuild")
-	go t.preloadAndVerifyRebuild(replicaAddress, toClient, s)
-
+	if err := t.preloadAndVerifyRebuild(replicaAddress, toClient, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -397,25 +395,19 @@ func (t *Task) checkAndResetFailedRebuild(address string, server *replica.Server
 	return nil
 }
 
-func (t *Task) preloadAndVerifyRebuild(address string, repClient *replicaClient.ReplicaClient, s *replica.Server) {
+func (t *Task) preloadAndVerifyRebuild(address string, repClient *replicaClient.ReplicaClient, s *replica.Server) error {
 	if err := s.Preload(); err != nil {
 		logrus.Fatalf("Failed to preload, error: %v, exiting...", err)
-		return
 	}
 	// Verify rebuild and mark replica to RW by controller
 	if err := t.client.VerifyRebuildReplica(rest.EncodeID(address)); err != nil {
-		logrus.Errorf("Error in verifyRebuildReplica %s", address)
-		s.MonitorChannel <- struct{}{}
-		return
+		return fmt.Errorf("Error in verifyRebuildReplica %s", address)
 	}
 	// Set rebuilding to false since it's completed
 	if err := repClient.SetRebuilding(false); err != nil {
-		logrus.Errorf("Error in setRebuilding %s", address)
-		s.MonitorChannel <- struct{}{}
-		return
+		return fmt.Errorf("Error in setRebuilding %s", address)
 	}
-
-	return
+	return nil
 }
 
 func (t *Task) syncFiles(fromClient *replicaClient.ReplicaClient, toClient *replicaClient.ReplicaClient, disks []string) error {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -322,7 +322,13 @@ Register:
 	}
 	if action == "start" {
 		logrus.Infof("Received start from controller")
-		return t.client.Start(replicaAddress)
+		if err := t.client.Start(replicaAddress); err != nil {
+			return err
+		}
+		if err := s.Preload(); err != nil {
+			return err
+		}
+		return nil
 	}
 	logrus.Infof("CheckAndResetFailedRebuild %v", replicaAddress)
 	if err := t.checkAndResetFailedRebuild(replicaAddress, s); err != nil {
@@ -358,8 +364,12 @@ Register:
 	}
 
 	logrus.Infof("reloadAndVerify %v", replicaAddress)
-	return t.reloadAndVerify(replicaAddress, toClient)
+	if err := t.reloadAndVerify(replicaAddress, toClient); err != nil {
+		return err
+	}
 
+	logrus.Info("Start reading extents (Preload LUN map)")
+	return s.Preload()
 }
 
 func (t *Task) checkAndResetFailedRebuild(address string, server *replica.Server) error {

--- a/types/types.go
+++ b/types/types.go
@@ -14,6 +14,7 @@ const (
 	StateDown = State("Down")
 	Started   = PreloadStatus("Started")
 	Done      = PreloadStatus("Done")
+	None      = PreloadStatus("NA")
 	Error     = PreloadStatus("Error")
 )
 

--- a/types/types.go
+++ b/types/types.go
@@ -12,8 +12,12 @@ const (
 
 	StateUp   = State("Up")
 	StateDown = State("Down")
+	Started   = PreloadStatus("Started")
+	Done      = PreloadStatus("Done")
+	Error     = PreloadStatus("Error")
 )
 
+type PreloadStatus string
 type ReaderWriterAt interface {
 	io.ReaderAt
 	io.WriterAt
@@ -134,6 +138,7 @@ type Frontend interface {
 }
 
 type DataProcessor interface {
+	Close(signalMonitor bool) error
 	IOs
 	PingResponse() error
 	//Update() error

--- a/types/types.go
+++ b/types/types.go
@@ -47,6 +47,7 @@ type Backend interface {
 	RemainSnapshots() (int, error)
 	GetRevisionCounter() (int64, error)
 	GetCloneStatus() (string, error)
+	GetPreloadStatus() (string, error)
 	GetVolUsage() (VolUsage, error)
 	SetRevisionCounter(counter int64) error
 	SetRebuilding(rebuilding bool) error


### PR DESCRIPTION
Recently we have seen that if volume size is large then preload
takes time and hence openReplica fails due to timeouts and hence
neither of them succedes.

There are five calls where Preload is required
- When replica is in Initial state
- Replica received `open` signal from controller
- Replica is closed
- Replica is reloading
- Revert to snapshot

To solve the issue, we have removed it from the construct function
rather we are calling it after the sync is done.

Feature : Added `PreloadStatus` field in Replica structure, so status can be queried via REST api
There are three status:
```
Error    : In case of replica disconnection or syscall failure
Started  : If Preload is happening in the background
Done     : If Preload is completed. 
```
NOTE:
- Since we are running IO's and preload parallely, we may miss some block counts for iostats, this can be taken as improvement for the next iteration

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>
