### PR TITLE
fix(CI): Change the reference from $REPO to $BASELINE_REPO.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,14 +26,14 @@ baseline-image:
      - echo $BRANCH
      - export COMMIT=${CI_COMMIT_SHA:0:7}
      - echo $COMMIT
-     - git clone https://github.com/$REPO/e2e-infrastructure.git
+     - git clone https://github.com/$BASELINE_REPO/e2e-infrastructure.git
      - cd e2e-infrastructure/baseline
      - ansible-playbook commit-writer.yml --extra-vars "branch=$BRANCH repo=$CI_PROJECT_NAME commit=$COMMIT"
      - git status
      - git add baseline
      - git status
      - git commit -m "updated $CI_PROJECT_NAME commit:$COMMIT"
-     - git push  https://$user:$pass@github.com/$REPO/e2e-infrastructure.git --all
+     - git push  https://$user:$pass@github.com/$BASELINE_REPO/e2e-infrastructure.git --all
      - cat baseline
      - echo "##############################################################################################"
      - echo "JIVA-IMAGE Pushed to DOCKER is $COMMIT"


### PR DESCRIPTION
- The push scripts of Jiva already use the $REPO variables, which gets
overwritten by gitlabs $REPO value causing the build to fail.
- Renamed the $REPO variable in gitlab to $BASELINE_REPO in gitlab.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>