### PR TITLE
[TA4197] fix(replica): preload issue due to large no of extents

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -36,18 +35,10 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	for {
-		if replicaType == "quorum" {
-			err = task.AddQuorumReplica(replica, s)
-		} else {
-			err = task.AddReplica(replica, s)
-		}
-		if err != nil {
-			logrus.Errorf("Error adding replica, err: %v, will retry", err)
-			time.Sleep(2 * time.Second)
-			s.Close(false)
-			continue
-		}
-		return err
+	if replicaType == "quorum" {
+		err = task.AddQuorumReplica(replica, s)
+	} else {
+		err = task.AddReplica(replica, s)
 	}
+	return err
 }

--- a/app/replica.go
+++ b/app/replica.go
@@ -98,9 +98,13 @@ func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, 
 			continue
 		}
 		if err = AutoRmReplica(frontendIP, address); err != nil {
+			logrus.Warning("AutoRmReplica failed, retry after 5 second")
+			time.Sleep(5 * time.Second)
 			continue
 		}
 		if err = AutoAddReplica(s, frontendIP, address, replicaType); err != nil {
+			logrus.Warning("AutoAddReplica failed, retry after 5 second")
+			time.Sleep(5 * time.Second)
 			continue
 		}
 

--- a/app/replica.go
+++ b/app/replica.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -18,7 +19,7 @@ import (
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/replica/rpc"
-	"github.com/openebs/jiva/sync"
+	jiva_sync "github.com/openebs/jiva/sync"
 	"github.com/openebs/jiva/util"
 )
 
@@ -84,29 +85,36 @@ func CheckReplicaState(frontendIP string, replicaIP string) (string, error) {
 }
 
 func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, replicaType string) {
-checkagain:
-	state, err := CheckReplicaState(frontendIP, address)
-	logrus.Infof("Replicastate: %v err:%v", state, err)
-	if err == nil && (state == "" || state == "ERR") {
-		s.Close(false)
-	} else {
-		time.Sleep(5 * time.Second)
-		goto checkagain
-	}
-	AutoRmReplica(frontendIP, address)
-	AutoAddReplica(s, frontendIP, address, replicaType)
-	logrus.Infof("Waiting on MonitorChannel")
-	select {
-	case <-s.MonitorChannel:
+	for {
+		wg := sync.WaitGroup{}
+		state, err := CheckReplicaState(frontendIP, address)
+		logrus.Infof("Replicastate: %v err:%v", state, err)
+		if err == nil && (state == "" || state == "ERR") {
+			s.Close(false)
+		} else {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		AutoRmReplica(frontendIP, address)
+		logrus.Infof("Waiting on MonitorChannel")
+		wg.Add(2)
+		go func() {
+			<-s.MonitorChannel
+			wg.Done()
+		}()
 		logrus.Infof("Restart AutoConfigure Process")
-		goto checkagain
+		go func() {
+			AutoAddReplica(s, frontendIP, address, replicaType)
+			wg.Done()
+		}()
+		wg.Wait()
 	}
 }
 
 func CloneReplica(s *replica.Server, address string, cloneIP string, snapName string) error {
 	var err error
 	url := "http://" + cloneIP + ":9501"
-	task := sync.NewTask(url)
+	task := jiva_sync.NewTask(url)
 	if err = task.CloneReplica(url, address, cloneIP, snapName); err != nil {
 		return err
 	}

--- a/app/replica.go
+++ b/app/replica.go
@@ -91,7 +91,6 @@ func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, 
 	for {
 		state, err = CheckReplicaState(frontendIP, address)
 		logrus.Infof("Replicastate: %v err:%v", state, err)
-
 		if err != nil {
 			logrus.Infof("checkReplicaState failed, err:%v retry after 5sec..", err)
 			time.Sleep(5 * time.Second)

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -524,7 +524,7 @@ test_preload() {
 	echo "----------------Test_preload---------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "PRELOAD_TIMEOUT" "12")
-	sleep 1
+	sleep 12
 	sudo docker stop $orig_controller_id
 	sudo docker start $orig_controller_id
 	verify_replica_cnt "1" "One replica count test when controller is restarted"
@@ -588,8 +588,9 @@ test_replica_rpc_close() {
 	echo "----------------Test_replica_rpc_close---------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
-	sleep 50
-
+	sleep 5
+        docker stop $orig_controller_id
+        sleep 20
 	read_write_exit=`docker logs $debug_replica_id 2>&1 | grep -c "Closing TCP conn"`
         if [ "$read_write_exit" == 0 ]; then
 		collect_logs_and_exit
@@ -1170,6 +1171,8 @@ test_upgrade() {
 test_upgrades() {
        test_upgrade "openebs/jiva:0.6.0" "controller-replica"
        test_upgrade "openebs/jiva:0.7.0" "replica-controller"
+       test_upgrade "openebs/jiva:0.8.0" "replica-controller"
+       test_upgrade "openebs/jiva:0.8.0" "controller-replica"
 }
 
 di_test_on_raw_disk() {
@@ -1520,6 +1523,7 @@ test_duplicate_data_delete() {
 
 prepare_test_env
 test_preload
+test_replica_rpc_close
 test_controller_rpc_close
 test_single_replica_stop_start
 test_replication_factor

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1520,7 +1520,6 @@ test_duplicate_data_delete() {
 
 prepare_test_env
 test_preload
-test_replica_rpc_close
 test_controller_rpc_close
 test_single_replica_stop_start
 test_replication_factor

--- a/controller/control.go
+++ b/controller/control.go
@@ -1001,6 +1001,7 @@ func (c *Controller) Shutdown() error {
 		Need to shutdown frontend first because it will write
 		the final piece of data to backend
 	*/
+	logrus.Info("Stopping controller")
 	err := c.shutdownFrontend()
 	if err != nil {
 		logrus.Error("Error when shutting down frontend:", err)

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,7 +2,6 @@
 
 package inject
 
-func AddTimeout() {
-}
-func AddPingTimeout() {
-}
+func AddTimeout()        {}
+func AddPingTimeout()    {}
+func AddPreloadTimeout() {}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -28,3 +28,9 @@ func AddPingTimeout() {
 		pingTimeout = false
 	}
 }
+
+func AddPreloadTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("PRELOAD_TIMEOUT"))
+	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
+}

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -238,9 +238,6 @@ func preload(d *diffDisk) error {
 	d.preloadStatus = types.Started
 	logrus.Infof("Updating preload status to '%s'", d.preloadStatus)
 	for i, f := range d.files {
-		if d.preloadStatus == types.Error {
-			return fmt.Errorf("preload status: error, replica may got disconnected to controller")
-		}
 		if i == 0 {
 			continue
 		}

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -31,6 +31,11 @@ type diffDisk struct {
 	// Index of latest user created snapshot
 	SnapIndx   int
 	sectorSize int64
+	// there are three status:
+	// Done    : Preload is completed
+	// Started : Preload is started and is running in background
+	// Error   : There was some error in preload
+	preloadStatus types.PreloadStatus
 }
 
 func (d *diffDisk) RemoveIndex(index int) error {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -63,7 +63,6 @@ type Replica struct {
 	cloneStatus   string
 	CloneSnapName string
 	Clone         bool
-	PreloadStatus types.PreloadStatus
 }
 
 type Info struct {
@@ -218,13 +217,10 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
-	r.PreloadStatus = types.Started
 	inject.AddPreloadTimeout()
 	if err := PreloadLunMap(&r.volume); err != nil {
-		r.PreloadStatus = types.Error
 		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
 	}
-	r.PreloadStatus = types.Done
 	logrus.Info("Read extents successful")
 	return r, r.writeVolumeMetaData(true, r.info.Rebuilding)
 }

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -3,6 +3,8 @@ package rest
 import (
 	"strconv"
 
+	"github.com/openebs/jiva/types"
+
 	"github.com/openebs/jiva/replica"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
@@ -25,6 +27,7 @@ type Replica struct {
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
 	CloneStatus       string                      `json:"clonestatus"`
+	PreloadStatus     types.PreloadStatus         `json:"preloadStatus"`
 }
 
 type DeleteReplicaOutput struct {
@@ -204,6 +207,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
 		r.CloneStatus = rep.GetCloneStatus()
+		r.PreloadStatus = rep.GetPreloadStatus()
 	}
 	return r
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -376,17 +376,6 @@ func (s *Server) Close(signalMonitor bool) error {
 		return nil
 	}
 
-	if s.r.volume.preloadStatus != types.Done {
-		logrus.Warning("Already reading extents in background")
-		// This is to notify preload go routine to exit safely
-		s.r.volume.preloadStatus = types.Error
-		// verify if goroutine exited safely
-		for s.r.PreloadStatus == types.Started {
-			time.Sleep(1 * time.Second)
-			continue
-		}
-	}
-
 	if err := s.r.Close(); err != nil {
 		s.Unlock()
 		return err

--- a/replica/server.go
+++ b/replica/server.go
@@ -371,7 +371,7 @@ func (s *Server) Close(signalMonitor bool) error {
 	s.Lock()
 
 	if s.r == nil {
-		logrus.Infof("Close replica failed, s.r not set")
+		logrus.Infof("Skip closing replica, s.r not set")
 		s.Unlock()
 		return nil
 	}

--- a/replica/server.go
+++ b/replica/server.go
@@ -376,6 +376,17 @@ func (s *Server) Close(signalMonitor bool) error {
 		return nil
 	}
 
+	if s.r.volume.preloadStatus != types.Done {
+		logrus.Warning("Already reading extents in background")
+		// This is to notify preload go routine to exit safely
+		s.r.volume.preloadStatus = types.Error
+		// verify if goroutine exited safely
+		for s.r.PreloadStatus == types.Started {
+			time.Sleep(1 * time.Second)
+			continue
+		}
+	}
+
 	if err := s.r.Close(); err != nil {
 		s.Unlock()
 		return err

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -23,10 +23,6 @@ var (
 	opUnmapTimeout  = 30 * time.Second // client unmap
 	opPingTimeout   = 20 * time.Second
 	opUpdateTimeout = 15 * time.Second // client update
-	// upon testing we have observed that replica was
-	// taking 1 sec for reading one thousand extents
-	// per file.
-	pingDeadline = 600 * time.Second // client update
 )
 
 //SampleOp operation

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -17,7 +17,7 @@ type Wire struct {
 	conn                net.Conn
 	writer              *bufio.Writer
 	reader              io.Reader
-	readExit, writeExit bool
+	ReadExit, WriteExit bool
 }
 
 func NewWire(conn net.Conn) *Wire {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -282,18 +282,18 @@ func (t *Task) AddReplica(replicaAddress string, s *replica.Server) error {
 	var action string
 
 	if s == nil {
-		return fmt.Errorf("Server not present for %v, Add replica using CLI not supported", replicaAddress)
+		logrus.Fatalf("Server not present for %v, Add replica using CLI not supported", replicaAddress)
 	}
 	logrus.Infof("Addreplica %v", replicaAddress)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	Replica, err := replica.CreateTempReplica()
 	if err != nil {
-		return fmt.Errorf("failed to create temp replica, error: %s", err.Error())
+		logrus.Fatalf("failed to create temp replica, error: %s", err.Error())
 	}
 	server, err := replica.CreateTempServer()
 	if err != nil {
-		return fmt.Errorf("failed to create temp server, error: %s", err.Error())
+		logrus.Fatalf("failed to create temp server, error: %s", err.Error())
 	}
 Register:
 	logrus.Infof("Get Volume info from controller")

--- a/types/types.go
+++ b/types/types.go
@@ -12,7 +12,13 @@ const (
 
 	StateUp   = State("Up")
 	StateDown = State("Down")
+	Started   = PreloadStatus("Started")
+	Done      = PreloadStatus("Done")
+	None      = PreloadStatus("NA")
+	Error     = PreloadStatus("Error")
 )
+
+type PreloadStatus string
 
 type ReaderWriterAt interface {
 	io.ReaderAt


### PR DESCRIPTION
Recently we have seen that if volume size is large then preload
takes time and hence openReplica fails due to timeouts and hence
neither of them succedes.

There are five calls where Preload is required

* When replica is in Initial state
* Replica received `open` signal from controller
* Replica is closed
* Replica is reloading
* Revert to snapshot

To solve the issue, we have removed http client timeout, and fixed
other issues which was depending on this.

Feature : Added `PreloadStatus` field in Replica structure, so status can be queried via REST api
There are three status:

```
Error    : In case of replica disconnection or syscall failure
Started  : If Preload is happening in the background
Done     : If Preload is completed.
```

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>