### PR TITLE
[TA4197] fix(replica): remove timeout for open req

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -539,7 +539,7 @@ test_preload() {
 	verify_replica_cnt "1" "One replica count test when controller is restarted"
 	sleep 5
 
-	rpc_close=`docker logs $debug_replica_id 2>&1 | grep -c "Closing TCP conn"`
+	rpc_close=`docker logs $debug_replica_id 2>&1 | grep -c "Closing RPC conn with replica:"`
 	if [ "$rpc_close" == 0 ]; then
 		collect_logs_and_exit
 	fi
@@ -600,9 +600,9 @@ test_replica_rpc_close() {
 	debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	sleep 5
         docker stop $orig_controller_id
-        sleep 20
+        sleep 25
 
-	read_write_exit=`docker logs $debug_replica_id 2>&1 | grep -c "Closing TCP conn"`
+	read_write_exit=`docker logs $debug_replica_id 2>&1 | grep -c "Closing RPC conn with replica:"`
         if [ "$read_write_exit" == 0 ]; then
 		collect_logs_and_exit
 	fi

--- a/controller/control.go
+++ b/controller/control.go
@@ -1001,6 +1001,7 @@ func (c *Controller) Shutdown() error {
 		Need to shutdown frontend first because it will write
 		the final piece of data to backend
 	*/
+	logrus.Info("Stopping controller")
 	err := c.shutdownFrontend()
 	if err != nil {
 		logrus.Error("Error when shutting down frontend:", err)

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,7 +2,6 @@
 
 package inject
 
-func AddTimeout() {
-}
-func AddPingTimeout() {
-}
+func AddTimeout()        {}
+func AddPingTimeout()    {}
+func AddPreloadTimeout() {}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -28,3 +28,9 @@ func AddPingTimeout() {
 		pingTimeout = false
 	}
 }
+
+func AddPreloadTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("PRELOAD_TIMEOUT"))
+	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
+}

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -291,11 +291,14 @@ func preload(d *diffDisk) error {
 }
 
 func PreloadLunMap(d *diffDisk) error {
-	err := preload(d)
+	if err := preload(d); err != nil {
+		return err
+	}
+
 	for _, val := range d.location {
 		if val != 0 {
 			d.UsedLogicalBlocks++
 		}
 	}
-	return err
+	return nil
 }

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	units "github.com/docker/go-units"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/rancher/sparse-tools/sparse"
@@ -216,11 +217,12 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
-
+	inject.AddPreloadTimeout()
+	logrus.Info("Start reading extents")
 	if err := PreloadLunMap(&r.volume); err != nil {
 		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
 	}
-
+	logrus.Info("Read extents successful")
 	return r, r.writeVolumeMetaData(true, r.info.Rebuilding)
 }
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -371,7 +371,7 @@ func (s *Server) Close(signalMonitor bool) error {
 	s.Lock()
 
 	if s.r == nil {
-		logrus.Infof("Close replica failed, s.r not set")
+		logrus.Infof("Skip closing replica, s.r not set")
 		s.Unlock()
 		return nil
 	}

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -115,21 +115,21 @@ func (w *Wire) Read() (*Message, error) {
 
 func (w *Wire) CloseRead() error {
 	if conn, ok := w.conn.(*net.TCPConn); ok {
-		logrus.Warning("Closing read on rpc conn")
+		logrus.Info("Closing read on RPC connection")
 		return conn.CloseRead()
 	}
-	return fmt.Errorf("failed to close, type assert error")
+	return fmt.Errorf("failed to close read on RPC conn with replica: %v, type assert error", w.conn.RemoteAddr())
 }
 
 func (w *Wire) CloseWrite() error {
 	if conn, ok := w.conn.(*net.TCPConn); ok {
-		logrus.Warning("Closing write on rpc conn")
+		logrus.Info("Closing write on RPC connection")
 		return conn.CloseWrite()
 	}
-	return fmt.Errorf("failed to close, type assert error")
+	return fmt.Errorf("failed to close write on RPC conn with replica: %v, type assert error", w.conn.RemoteAddr())
 }
 
 func (w *Wire) Close() error {
-	logrus.Warning("Closing TCP conn")
+	logrus.Warning("Closing RPC conn with replica: ", w.conn.RemoteAddr())
 	return w.conn.Close()
 }


### PR DESCRIPTION
Recently we have seen that if volume size is large then preload
takes time and hence openReplica fails due to timeouts and hence
neither of them succedes.

To resolve this issue, we have set timeout to zero, which means
there will be no timeout only for open requests.

fixes issue:  openebs/openebs#2311

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>