### PR TITLE
fix(replica): modify autoregistration process

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -36,18 +35,10 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	for {
-		if replicaType == "quorum" {
-			err = task.AddQuorumReplica(replica, s)
-		} else {
-			err = task.AddReplica(replica, s)
-		}
-		if err != nil {
-			logrus.Errorf("Error adding replica, err: %v, will retry", err)
-			time.Sleep(2 * time.Second)
-			s.Close(false)
-			continue
-		}
-		return err
+	if replicaType == "quorum" {
+		err = task.AddQuorumReplica(replica, s)
+	} else {
+		err = task.AddReplica(replica, s)
 	}
+	return err
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -263,7 +263,7 @@ func (rf *Factory) Create(address string) (types.Backend, error) {
 	r.IOs = remote
 
 	if err := r.open(); err != nil {
-		logrus.Errorf("Failed to open replica, error: %v", err)
+		logrus.Errorf("Failed to open replica: %v, error: %v", conn.RemoteAddr(), err)
 		remote.Close()
 		return nil, err
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -282,24 +282,24 @@ func (t *Task) AddReplica(replicaAddress string, s *replica.Server) error {
 	var action string
 
 	if s == nil {
-		return fmt.Errorf("Server not present for %v, Add replica using CLI not supported", replicaAddress)
+		logrus.Fatalf("Server not present for %v, Add replica using CLI not supported", replicaAddress)
 	}
 	logrus.Infof("Addreplica %v", replicaAddress)
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 	Replica, err := replica.CreateTempReplica()
 	if err != nil {
-		return fmt.Errorf("failed to create temp replica, error: %s", err.Error())
+		logrus.Fatalf("Failed to create temp replica, error: %s", err.Error())
 	}
 	server, err := replica.CreateTempServer()
 	if err != nil {
-		return fmt.Errorf("failed to create temp server, error: %s", err.Error())
+		logrus.Fatalf("Failed to create temp server, error: %s", err.Error())
 	}
 Register:
 	logrus.Infof("Get Volume info from controller")
 	volume, err := t.client.GetVolume()
 	if err != nil {
-		return fmt.Errorf("failed to get volume info, error: %s", err.Error())
+		return fmt.Errorf("Failed to get volume info, error: %s", err.Error())
 	}
 	addr := strings.Split(replicaAddress, "://")
 	parts := strings.Split(addr[1], ":")
@@ -311,7 +311,7 @@ Register:
 		logrus.Infof("Register replica at controller")
 		err := t.client.Register(parts[0], revisionCount, replicaType, upTime, string(state))
 		if err != nil {
-			logrus.Errorf("Error in sending register command, error: %s", err)
+			logrus.Errorf("Replica failed to register with controller, error: %s", err)
 		}
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
1. Handle error for AutoAddReplica and AutoRmReplica
2. Fix logic for autoregistration in replica

Corner cases which this PR covers when replica goes for autoregistration : 
1. When this is first replica to go for autoregistration after restart:
    - open may take sometime and meanwhile controller get disconnected, rpc connection is closed and hence notified on monitorChannel, so replica will again check for it's state but will get empty state and hence will close itself
    - above case is valid for other replicas but it again proceeds to do some additional steps, so there are following edge cases where replica can stuck and until unless those get completed, replica wouldn't be proceed for autoregistration:
        * Create Replica : post a request to controller to be opened, so if controller get disconnected that request will get i/o timeout and replica would go for autoregistration.
        *  Sync : until unless sync get completed replica wouldn't go for autoregistration since there is no communication with controller in this process.
        *  ReloadAndVerify: reload is very similar to open call and replica get stuck here also

Fixes openebs/openebs#2399

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>