### PR TITLE
Enhancements and changes to GitLab CI YAML.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,8 +5,11 @@ stages:
 
 build-jiva:
    stage: build
+   only:
+     refs:
+       - ^(v[0-9][.][0-9][.]x|master)?$
    before_script:
-     - export COMMIT=${CI_COMMIT_SHA:0:8}
+     - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - sudo apt-get install -y
      - sudo apt-get install -y curl open-iscsi
      - export GOPATH=$HOME/go
@@ -20,13 +23,17 @@ build-jiva:
     - make build_gitlab
 baseline-image:
   stage: baseline
+  only:
+    refs:
+      - ^(v[0-9][.][0-9][.]x|master)?$
   script:
      - pwd
      - export BRANCH=${CI_COMMIT_REF_NAME}
      - echo $BRANCH
-     - export COMMIT=${CI_COMMIT_SHA:0:7}
+     - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - echo $COMMIT
      - git clone https://github.com/openebs/e2e-infrastructure.git
+     - git checkout $BRANCH
      - cd e2e-infrastructure/baseline
      - ansible-playbook commit-writer.yml --extra-vars "branch=$BRANCH repo=$CI_PROJECT_NAME commit=$COMMIT"
      - git status
@@ -41,14 +48,17 @@ baseline-image:
      - echo "###############################################################################################" 
      - echo "Started E2E-PIPELINE"
      - echo "###############################################################################################"
-     - curl -X POST -F token=$AZURE -F ref=master https://gitlab.openebs.ci/api/v4/projects/2/trigger/pipeline
-     - curl -X POST -F token=$EKS -F ref=master https://gitlab.openebs.ci/api/v4/projects/3/trigger/pipeline
-     - curl -X POST -F token=$GKE -F ref=master https://gitlab.openebs.ci/api/v4/projects/5/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-11 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-12 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
+     - curl -X POST -F variable[INFRA_BRANCH]=$BRANCH -F token=$PACKET -F ref=k8s-1-13 https://gitlab.openebs.ci/api/v4/projects/27/trigger/pipeline
 
 cleanup:
   when: always
   stage: cleanup
+  only:
+    refs:
+      - ^(v[0-9][.][0-9][.]x|master)?$  
   script:
      - sudo rm -r ~/go
      - sudo docker images 
-     - sudo docker image prune -a
+     - sudo docker image prune -a --force


### PR DESCRIPTION
- Check for master and .x branches for build to trigger by using only:
refs option.
- Use the new CI_COMMIT_SHORT_SHA env to get the short commit SHA.
- Push the commit details to respective branches on e2e-infrastructure.
- Pass the branch details of JIVA to the platform repos to checkout e2e-infrastructure for that particular branch when the infra-setup stage is run.
- Deprecate GKE, EKS and AKS platforms.
- Run Packet platform, with k8s 1.11, 1.12 and 1.13 for master branch.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>