### PR TITLE
Implement the fix for regex to work with GitLab.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ build-jiva:
    stage: build
    only:
      refs:
-       - ^(v[0-9][.][0-9][.]x|master)?$
+       - /^(v[0-9][.][0-9][.]x|master)?$/
    before_script:
      - export COMMIT=${CI_COMMIT_SHORT_SHA}
      - sudo apt-get install -y
@@ -25,7 +25,7 @@ baseline-image:
   stage: baseline
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|master)?$
+      - /^(v[0-9][.][0-9][.]x|master)?$/
   script:
      - pwd
      - export BRANCH=${CI_COMMIT_REF_NAME}
@@ -57,7 +57,7 @@ cleanup:
   stage: cleanup
   only:
     refs:
-      - ^(v[0-9][.][0-9][.]x|master)?$  
+      - /^(v[0-9][.][0-9][.]x|master)?$/  
   script:
      - sudo rm -r ~/go
      - sudo docker images 


### PR DESCRIPTION

- Implement the fix for regex to work with GitLab.
- GitLab needs a '/' in the front and back of the regex.

Signed-off-by: Uday Kiran Y <uday.kiran@openebs.io>