### PR TITLE
fix(ping timeout): increase ping timeout

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -571,9 +571,10 @@ test_preload() {
 
 test_controller_rpc_close() {
 	echo "----------------Test_controller_rpc_close---------------"
-	debug_controller_id=$(start_debug_controller "$CONTROLLER_IP" "store1" "1" "RPC_PING_TIMEOUT" "25")
+	debug_controller_id=$(start_debug_controller "$CONTROLLER_IP" "store1" "1" "RPC_PING_TIMEOUT" "45")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
-	sleep 40
+        # Adding this sleep to ensure ping timeout
+        sleep 60
 
         writer_exit=`docker logs $debug_controller_id 2>&1 | grep "Exiting rpc writer" | wc -l`
         reader_exit=`docker logs $debug_controller_id 2>&1 | grep "Exiting rpc reader" | wc -l`

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -21,7 +21,7 @@ var (
 	opWriteTimeout  = 15 * time.Second // client write
 	opSyncTimeout   = 30 * time.Second // client sync
 	opUnmapTimeout  = 30 * time.Second // client unmap
-	opPingTimeout   = 20 * time.Second
+	opPingTimeout   = 40 * time.Second
 	opUpdateTimeout = 15 * time.Second // client update
 )
 


### PR DESCRIPTION
Increase ping timeout to 40s since sync and unmap timeout is
30s, hence ping timeout should be greater than these.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>