### PR TITLE
fix(controller): add missing flag StartSignalled in case of error

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -272,15 +272,15 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 
 	if c.StartSignalled == true {
 		if c.MaxRevReplica == register.Address {
-			logrus.Infof("Replica %v signalled to start again, registered replicas: %v", c.MaxRevReplica, c.RegisteredReplicas)
+			logrus.Infof("Replica %v signalled to start again, registered replicas: %#v", c.MaxRevReplica, c.RegisteredReplicas)
 			if err := c.signalReplica(); err != nil {
 				return err
 			}
 		} else {
 			logrus.Infof("Can signal only to %s ,can't signal to %s, no of registered replicas are %d and replica count is %d",
 				c.MaxRevReplica, register.Address, len(c.RegisteredReplicas), c.replicaCount)
-			return nil
 		}
+		return nil
 	}
 
 	if register.RepState == "rebuilding" {
@@ -298,8 +298,7 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 
 	if (len(c.RegisteredReplicas) >= ((c.replicaCount / 2) + 1)) &&
 		((len(c.RegisteredReplicas) + len(c.RegisteredQuorumReplicas)) >= (((c.quorumReplicaCount + c.replicaCount) / 2) + 1)) {
-		logrus.Infof("Replica %v signalled to start, no of registered replicas are %d and replica count is %d", c.MaxRevReplica,
-			len(c.RegisteredReplicas), c.replicaCount)
+		logrus.Infof("Replica %v signalled to start, registered replicas: %#v", c.MaxRevReplica, c.RegisteredReplicas)
 		if err := c.signalReplica(); err != nil {
 			return err
 		}

--- a/controller/control.go
+++ b/controller/control.go
@@ -269,12 +269,11 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 		logrus.Infof("There are already some replicas attached")
 		return nil
 	}
+
 	if c.StartSignalled == true {
 		if c.MaxRevReplica == register.Address {
-			logrus.Infof("Replica %v signalled to start again %d:%d", c.MaxRevReplica,
-				len(c.RegisteredReplicas), c.replicaCount)
+			logrus.Infof("Replica %v signalled to start again, registered replicas: %v", c.MaxRevReplica, c.RegisteredReplicas)
 			if err := c.signalReplica(); err != nil {
-				c.StartSignalled = false
 				return err
 			}
 		} else {
@@ -283,6 +282,7 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 			return nil
 		}
 	}
+
 	if register.RepState == "rebuilding" {
 		logrus.Errorf("Cannot add replica in rebuilding state, addr: %v", register.Address)
 		return nil
@@ -303,7 +303,6 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 		if err := c.signalReplica(); err != nil {
 			return err
 		}
-		c.StartSignalled = true
 		return nil
 	}
 
@@ -322,8 +321,10 @@ func (c *Controller) signalReplica() error {
 			c.MaxRevReplica, err.Error())
 		delete(c.RegisteredReplicas, c.MaxRevReplica)
 		c.MaxRevReplica = ""
+		c.StartSignalled = false
 		return err
 	}
+	c.StartSignalled = true
 	return nil
 }
 


### PR DESCRIPTION
Fixes: openebs/openebs#2482

- Replica is not able to register again if signalled to start already
but startSignal() failed. This is due to missing flag StartSignalled
which was set to true.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>