### PR TITLE
feat(ci): add test case to verify fix of PR#195

### DIFF
--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -49,6 +49,7 @@ func (r *Remote) Close() error {
 
 func (r *Remote) open() error {
 	logrus.Infof("Opening: %s", r.Name)
+	inject.AddPreloadTimeout()
 	return r.doAction("open", nil)
 }
 

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,6 +2,8 @@
 
 package inject
 
-func AddTimeout()        {}
-func AddPingTimeout()    {}
-func AddPreloadTimeout() {}
+func AddTimeout()            {}
+func AddPingTimeout()        {}
+func AddPreloadTimeout()     {}
+func Panic()                 {}
+func IncStartCountAndPanic() {}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -12,6 +12,7 @@ import (
 
 var (
 	pingTimeout = true
+	startCount  int
 )
 
 func AddTimeout() {
@@ -33,4 +34,21 @@ func AddPreloadTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("PRELOAD_TIMEOUT"))
 	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
+}
+
+func Panic() {
+	ok := os.Getenv("SHOULD_PANIC")
+	if ok == "TRUE" {
+		time.Sleep(2 * time.Second)
+		panic("panic replica after getting start signal")
+	}
+}
+
+func IncStartCountAndPanic() {
+	count, _ := strconv.Atoi(os.Getenv("START_COUNT"))
+	logrus.Infof("Start signal count for debug build", count)
+	startCount++
+	if startCount == count {
+		panic("panic replica after getting start signal twice")
+	}
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 )
 
@@ -52,6 +53,7 @@ func NewServer(dir string, sectorSize int64, serverType string) *Server {
 }
 
 func (s *Server) Start(action string) error {
+	inject.IncStartCountAndPanic() // increase inject.startCount and panic for debug build
 	s.Lock()
 	defer s.Unlock()
 	ActionChannel <- action

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/openebs/jiva/controller/client"
 	"github.com/openebs/jiva/controller/rest"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/replica"
 	replicaClient "github.com/openebs/jiva/replica/client"
 )
@@ -313,6 +314,7 @@ Register:
 		if err != nil {
 			logrus.Errorf("Error in sending register command, error: %s", err)
 		}
+		inject.AddTimeout()
 		select {
 		case <-ticker.C:
 			logrus.Infof("TimedOut waiting for response from controller")
@@ -322,6 +324,8 @@ Register:
 	}
 	if action == "start" {
 		logrus.Infof("Received start from controller")
+		inject.AddTimeout() // inject delays for debug build
+		inject.Panic()      // inject panic for debug build
 		return t.client.Start(replicaAddress)
 	}
 	logrus.Infof("CheckAndResetFailedRebuild %v", replicaAddress)


### PR DESCRIPTION
This commit add a script which verifies that controller doesn't stuck
while replica registration due to the missing flag c.StartSignalled = false in error case.
This case is very hard to reproduce, here is the sequence to reproduce it:
- Start controller and two replica
- Kill the replica which gets start signal
- Start the killed replica and inject delay in registration at replica side so that registration of replica happens twice (goto statement get executed)
- Once you get two start signals from replica, kill it.
- You will be able to see following in the logs `Can signal only to  ,can't signal to`

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>