### PR TITLE
chore(cherry-pick): jiva stability fixes from master to 0.8.2

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -269,20 +269,20 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 		logrus.Infof("There are already some replicas attached")
 		return nil
 	}
+
 	if c.StartSignalled == true {
 		if c.MaxRevReplica == register.Address {
-			logrus.Infof("Replica %v signalled to start again %d:%d", c.MaxRevReplica,
-				len(c.RegisteredReplicas), c.replicaCount)
+			logrus.Infof("Replica %v signalled to start again, registered replicas: %#v", c.MaxRevReplica, c.RegisteredReplicas)
 			if err := c.signalReplica(); err != nil {
-				c.StartSignalled = false
 				return err
 			}
 		} else {
 			logrus.Infof("Can signal only to %s ,can't signal to %s, no of registered replicas are %d and replica count is %d",
 				c.MaxRevReplica, register.Address, len(c.RegisteredReplicas), c.replicaCount)
-			return nil
 		}
+		return nil
 	}
+
 	if register.RepState == "rebuilding" {
 		logrus.Errorf("Cannot add replica in rebuilding state, addr: %v", register.Address)
 		return nil
@@ -298,12 +298,10 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 
 	if (len(c.RegisteredReplicas) >= ((c.replicaCount / 2) + 1)) &&
 		((len(c.RegisteredReplicas) + len(c.RegisteredQuorumReplicas)) >= (((c.quorumReplicaCount + c.replicaCount) / 2) + 1)) {
-		logrus.Infof("Replica %v signalled to start, no of registered replicas are %d and replica count is %d", c.MaxRevReplica,
-			len(c.RegisteredReplicas), c.replicaCount)
+		logrus.Infof("Replica %v signalled to start, registered replicas: %#v", c.MaxRevReplica, c.RegisteredReplicas)
 		if err := c.signalReplica(); err != nil {
 			return err
 		}
-		c.StartSignalled = true
 		return nil
 	}
 
@@ -322,8 +320,10 @@ func (c *Controller) signalReplica() error {
 			c.MaxRevReplica, err.Error())
 		delete(c.RegisteredReplicas, c.MaxRevReplica)
 		c.MaxRevReplica = ""
+		c.StartSignalled = false
 		return err
 	}
+	c.StartSignalled = true
 	return nil
 }
 

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,4 +20,4 @@ github.com/jmespath/go-jmespath         c01cf91b011868172fdcd9f41838e80c9d716264
 github.com/yasker/go-iscsi-helper       9910689ad7c88f650262e01557b16bdc0d5b6a94
 github.com/yasker/nsfilelock            90eff0ebb9e2e0ee2f22519cfb8404f9fdd9c008
 github.com/yasker/backupstore           39c822e19eb3d54eca4dc5f75205e426c8357ac1
-github.com/openebs/gotgt		abeb8b9055e7079240704556ca40ee56d93d4612
+github.com/openebs/gotgt		dbc41c8fa1785e40d9f42a0c29941b59728ec2b4


### PR DESCRIPTION
This PR cherry picks the following jiva stability fixes into 0.8.2:
- https://github.com/openebs/jiva/pull/195
- https://github.com/openebs/jiva/pull/197