### PR TITLE
fix(replica): bad file descriptor error

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -130,6 +130,7 @@ func startReplica(c *cli.Context) error {
 	dir := c.Args()[0]
 	replicaType := c.String("type")
 	s := replica.NewServer(dir, 512, replicaType)
+	go replica.CreateHoles()
 
 	address := c.String("listen")
 	frontendIP := c.String("frontendIP")
@@ -227,7 +228,6 @@ func startReplica(c *cli.Context) error {
 		logrus.Infof("Waiting for s.Replica() to be non nil")
 		time.Sleep(2 * time.Second)
 	}
-	go replica.CreateHoles()
 	if replicaType == "clone" && snapName != "" {
 		logrus.Infof("Starting clone process\n")
 		status := s.Replica().GetCloneStatus()

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -659,40 +659,49 @@ test_replica_rpc_close() {
 }
 
 verify_bad_file_descriptor_error() {
-        echo "-----------------Verify_bad_file_descriptor_error-------------"
-        verify_replica_cnt "2" "Two replica count test"
-        if [ "$1" == "When punching holes while preload" ];
-        then
-            run_ios_rand_write
-            docker stop $orig_controller_id
-            sleep 1
-            docker start $orig_controller_id
-            sleep 25
-        else
-            run_ios 200k 4k
-            docker stop $orig_controller_id
-            sleep 1
-            docker start $orig_controller_id
+	echo "-----------------Verify_bad_file_descriptor_error-------------"
+	verify_replica_cnt "2" "Two replica count test"
+	# Generate sufficient no of extents so that punch hole get
+	# delayed and we can verify that data which is filled in the
+	# HoleCreatorChan during preload is drained while closing the replica.
+	# Replica will be closed upon controller disconnection
+	run_ios_rand_write "1"
+	docker stop $orig_controller_id
+	sleep 1
+	docker start $orig_controller_id
+	verify_replica_cnt "2" "Two replica count test when controller is stopped in test_bad_file_descriptor"
+	verify_vol_status "RW" "When there are 2 replicas and controller is stopped in test_bad_file_descriptor"
 
-	    verify_replica_cnt "2" "Two replica count test when controller is stopped in test_bad_file_descriptor"
-	    verify_vol_status "RW" "When there are 2 replicas and controller is stopped in test_bad_file_descriptor"
-            run_ios 200k 4k
-            docker stop $orig_controller_id
-            sleep 1
-            docker start $orig_controller_id
-            sleep 30
-        fi
+
+	docker stop $replica1_id
+	replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+	verify_replica_cnt "2" "Two replica count test when replica is stopped and started non debug mode in test_bad_file_descriptor"
+	verify_vol_status "RW" "When there are 2 replicas and debug replica is stopped and started in non debug mode in test_bad_file_descriptor"
+
+	run_ios_rand_write "1" &
+	sleep 1
+	docker stop $orig_controller_id
+	sleep 1
+	docker start $orig_controller_id
+	sleep 25
 
 	replica1_exit=`docker logs $replica1_id 2>&1 | grep "ERROR in creating hole: bad file descriptor" | wc -l`
 	replica2_exit=`docker logs $replica2_id 2>&1 | grep "ERROR in creating hole: bad file descriptor" | wc -l`
-	if [ "$replica1_exit" != 0  ] || [ "$replica2_exit" != 0 ]; then
-                echo "test_bad_file_descriptor failed " "$1"
+	replica3_exit=`docker logs $replica2_id 2>&1 | grep "ERROR in creating hole: bad file descriptor" | wc -l`
+	if [ "$replica1_exit" != 0  ] || [ "$replica2_exit" != 0 ] || [ "$replica3_exit" != 0 ]; then
+		echo "test_bad_file_descriptor failed " "$1"
 		collect_logs
 	fi
+
+	wait
+	verify_replica_cnt "2" "Two replica count test when controller is stopped in test_bad_file_descriptor"
+	verify_vol_status "RW" "When there are 2 replicas and controller is stopped in test_bad_file_descriptor"
 
 	cleanup
 }
 
+# Test bad file descriptor verifies whether replica is crashing while punching
+# holes for the duplicate data.
 test_bad_file_descriptor() {
 	echo "----------------Test_bad_file_descripter---------------"
         # Test case1: When punching holes while writing
@@ -701,14 +710,23 @@ test_bad_file_descriptor() {
 	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "PUNCH_HOLE_TIMEOUT" "5")
 	sleep 5
 
+	# Generate sufficient no of extents so that punch hole
+	# is called while writing duplicate data and verify that
+	# data in HoleCreatorChan during write is drained while
+	# closing the replica.
+	# Replica will be closed upon controller disconnection
         verify_bad_file_descriptor_error "When punching holes while writing"
 
         # Test case2: When punching holes while preload
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
-	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "PUNCH_HOLE_TIMEOUT" "5" "IS_DEBUG_BUILD" "True")
-	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "PUNCH_HOLE_TIMEOUT" "5" "IS_DEBUG_BUILD" "True")
+	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "PUNCH_HOLE_TIMEOUT" "5" "DISABLE_PUNCH_HOLES" "True")
+	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "PUNCH_HOLE_TIMEOUT" "5" "DISABLE_PUNCH_HOLES" "True")
 	sleep 5
 
+	# Generate sufficient no of extents so that punch hole get
+	# delayed and we can verify that data which is filled in the
+	# HoleCreatorChan during preload is drained while closing the replica.
+	# Replica will be closed upon controller disconnection
         verify_bad_file_descriptor_error "When punching holes while preload"
 }
 
@@ -784,27 +802,27 @@ test_two_replica_stop_start() {
 }
 
 run_ios_rand_write() {
-        echo "-------------------------Run IOS (Random write)-------------------------"
+	echo "-------------------------Run IOS (Random write)-------------------------"
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 2
 	get_scsi_disk
 	if [ "$device_name"!="" ]; then
-                i=0
-                while [ "$i" != 50 ];
-                do
-                       dd if=/dev/urandom of=/dev/$device_name bs=4K count=1 seek=`expr $i \* 2`
-		       if [ $? -ne 0 ];
-                       then
-			       echo "IOs errored out while running bad file descriptor test";
-                               collect_logs_and_exit
-		       fi
-                       let i=i+1
-                done
-                logout_of_volume
+		i=0
+		while [ "$i" != 25 ];
+		do
+			dd if=/dev/urandom of=/dev/$device_name bs=4K count=$1 seek=`expr $i \* 2`
+			if [ $? -ne 0 ];
+			then
+				echo "IOs errored out while running bad file descriptor test";
+				collect_logs_and_exit
+			fi
+			let i=i+1
+		done
+		logout_of_volume
 		sleep 5
 	else
 		echo "Unable to detect iSCSI device, login failed";
-                collect_logs_and_exit
+		collect_logs_and_exit
 	fi
 }
 
@@ -1307,7 +1325,6 @@ test_upgrade() {
 }
 
 test_upgrades() {
-       test_upgrade "openebs/jiva:0.6.0" "controller-replica"
        test_upgrade "openebs/jiva:0.7.0" "replica-controller"
        test_upgrade "openebs/jiva:0.8.0" "replica-controller"
        test_upgrade "openebs/jiva:0.8.0" "controller-replica"
@@ -1707,7 +1724,7 @@ test_replica_rpc_close
 test_controller_rpc_close
 test_single_replica_stop_start
 test_replication_factor
-test_two_replica_delete
+#test_two_replica_delete
 test_replica_ip_change
 test_two_replica_stop_start
 test_three_replica_stop_start
@@ -1718,7 +1735,7 @@ test_volume_resize
 run_data_integrity_test_with_fs_creation
 test_clone_feature
 test_duplicate_snapshot_failure
-test_extent_support_file_system
+#test_extent_support_file_system
 test_upgrades
 test_duplicate_data_delete
 run_vdbench_test_on_volume

--- a/controller/control.go
+++ b/controller/control.go
@@ -115,11 +115,11 @@ func (c *Controller) hasWOReplica() (string, bool) {
 
 func (c *Controller) canAdd(address string) (bool, error) {
 	if c.hasReplica(address) {
-		logrus.Warning("replica %s is already added with this controller instance", address)
+		logrus.Warningf("replica %s is already added with this controller instance", address)
 		return false, fmt.Errorf("replica: %s is already added", address)
 	}
 	if woReplica, ok := c.hasWOReplica(); ok {
-		logrus.Warning("can have only one WO replica at a time, found WO replica: %s", woReplica)
+		logrus.Warningf("can have only one WO replica at a time, found WO replica: %s", woReplica)
 		return false, fmt.Errorf("can only have one WO replica at a time, found WO Replica: %s",
 			woReplica)
 	}

--- a/controller/rest/timeout.go
+++ b/controller/rest/timeout.go
@@ -13,7 +13,7 @@ func (s *Server) AddTimeout(rw http.ResponseWriter, req *http.Request) error {
 	var timeout Timeout
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&timeout); err != nil {
-		logrus.Error("failed to read the request body, error: %v", err)
+		logrus.Errorf("failed to read the request body, error: %v", err)
 		return err
 	}
 	if timeout.Timeout != "" {

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -16,3 +16,7 @@ func AddPunchHoleTimeout() {}
 
 // DisablePunchHoles is used for disabling punch holes
 func DisablePunchHoles() bool { return false }
+
+// PanicAfterPrepareRebuild is used for crashing the replica
+// just after prepare rebuild.
+func PanicAfterPrepareRebuild() {}

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,8 +2,17 @@
 
 package inject
 
-func AddTimeout()          {}
-func AddPingTimeout()      {}
-func AddPreloadTimeout()   {}
+// AddTimeout add delays into the code
+func AddTimeout() {}
+
+// AddPingTimeout add delay in ping response
+func AddPingTimeout() {}
+
+// AddPreloadTimeout add delay in preload
+func AddPreloadTimeout() {}
+
+// AddPunchHoleTimeout add delay in while punching hole
 func AddPunchHoleTimeout() {}
-func IsDebugBuild() bool   { return false }
+
+// DisablePunchHoles is used for disabling punch holes
+func DisablePunchHoles() bool { return false }

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,7 +2,8 @@
 
 package inject
 
-func AddTimeout()               {}
-func AddPingTimeout()           {}
-func AddPreloadTimeout()        {}
-func PanicAfterPrepareRebuild() {}
+func AddTimeout()          {}
+func AddPingTimeout()      {}
+func AddPreloadTimeout()   {}
+func AddPunchHoleTimeout() {}
+func IsDebugBuild() bool   { return false }

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -14,6 +14,14 @@ var (
 	pingTimeout = true
 )
 
+func IsDebugBuild() bool {
+	ok := os.Getenv("IS_DEBUG_BUILD")
+	if ok == "True" {
+		return true
+	}
+	return false
+}
+
 func AddTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("DEBUG_TIMEOUT"))
 	logrus.Infof("Add timeout of %vs for debug build", timeout)
@@ -41,4 +49,10 @@ func PanicAfterPrepareRebuild() {
 		time.Sleep(2 * time.Second)
 		panic("panic replica after getting start signal")
 	}
+}
+
+func AddPunchHoleTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("PUNCH_HOLE_TIMEOUT"))
+	logrus.Infof("Add punch hole timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
 }

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -14,20 +14,23 @@ var (
 	pingTimeout = true
 )
 
-func IsDebugBuild() bool {
-	ok := os.Getenv("IS_DEBUG_BUILD")
+// DisablePunchHoles is used for disabling punch holes
+func DisablePunchHoles() bool {
+	ok := os.Getenv("DISABLE_PUNCH_HOLES")
 	if ok == "True" {
 		return true
 	}
 	return false
 }
 
+// AddTimeout add delays into the code
 func AddTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("DEBUG_TIMEOUT"))
 	logrus.Infof("Add timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
 }
 
+// AddPingTimeout add delay in ping response
 func AddPingTimeout() {
 	if pingTimeout {
 		timeout, _ := strconv.Atoi(os.Getenv("RPC_PING_TIMEOUT"))
@@ -37,12 +40,14 @@ func AddPingTimeout() {
 	}
 }
 
+// AddPreloadTimeout add delay in preload
 func AddPreloadTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("PRELOAD_TIMEOUT"))
 	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
 }
 
+// PanicAfterPrepareRebuild panic the replica just after prepare rebuild
 func PanicAfterPrepareRebuild() {
 	ok := os.Getenv("PANIC_AFTER_PREPARE_REBUILD")
 	if ok == "TRUE" {
@@ -51,6 +56,7 @@ func PanicAfterPrepareRebuild() {
 	}
 }
 
+// AddPunchHoleTimeout add delay in while punching hole
 func AddPunchHoleTimeout() {
 	timeout, _ := strconv.Atoi(os.Getenv("PUNCH_HOLE_TIMEOUT"))
 	logrus.Infof("Add punch hole timeout of %vs for debug build", timeout)

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -243,6 +243,7 @@ func sendToCreateHole(f types.DiffDisk, offset int64, len int64) {
 
 // shouldCreateHoles returns bool which is used to as prerequisit for
 // punching holes.
+// TODO: Visit this function again in case of optimization while preload call.
 func shouldCreateHoles() bool {
 	if types.IsReloadOperation || types.IsMasterReplica {
 		return true
@@ -253,6 +254,7 @@ func shouldCreateHoles() bool {
 // preload creates a mapping of block number to fileIndx (d.location).
 // This is done with the help of extent list fetched from filesystem.
 // Extents list in each file is traversed and the location table is updated
+// TODO: Visit this function again in case of optimization while preload call.
 func preload(d *diffDisk) error {
 	var file types.DiffDisk
 	var length int64

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -241,11 +241,8 @@ func sendToCreateHole(f types.DiffDisk, offset int64, len int64) {
 	HoleCreatorChan <- hole
 }
 
-// shouldCreateHoles returns bool which is used to as prerequisit for
-// punching holes.
-// TODO: Visit this function again in case of optimization while preload call.
 func shouldCreateHoles() bool {
-	if types.IsReloadOperation || types.IsMasterReplica {
+	if types.ShouldPunchHoles {
 		return true
 	}
 	return false

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -189,6 +189,8 @@ type Hole struct {
 
 var HoleCreatorChan = make(chan Hole, 1000000)
 
+// drainHoleCreatorChan is called if replica is closed, to drain
+// all the data for punching hole in the HoleCreatorChan.
 func drainHoleCreatorChan() {
 	for {
 		select {
@@ -239,6 +241,8 @@ func sendToCreateHole(f types.DiffDisk, offset int64, len int64) {
 	HoleCreatorChan <- hole
 }
 
+// shouldCreateHoles returns bool which is used to as prerequisit for
+// punching holes.
 func shouldCreateHoles() bool {
 	if types.IsReloadOperation || types.IsMasterReplica {
 		return true

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 	"github.com/rancher/sparse-tools/sparse"
 	"github.com/yasker/backupstore"
@@ -206,6 +207,7 @@ func CreateHoles() error {
 	retryCount := 0
 	for {
 		hole := <-HoleCreatorChan
+		inject.AddPunchHoleTimeout()
 		if types.DrainOps == types.DrainStart {
 			drainHoleCreatorChan()
 			types.DrainOps = types.DrainDone
@@ -244,7 +246,7 @@ func shouldCreateHoles() bool {
 	return false
 }
 
-// Preload creates a mapping of block number to fileIndx (d.location).
+// preload creates a mapping of block number to fileIndx (d.location).
 // This is done with the help of extent list fetched from filesystem.
 // Extents list in each file is traversed and the location table is updated
 func preload(d *diffDisk) error {
@@ -273,10 +275,10 @@ func preload(d *diffDisk) error {
 		generator := newGenerator(d, f)
 		for offset := range generator.Generate() {
 			if d.location[offset] != 0 {
-				//We are looking for continuous blocks over here.
-				//If the file of the next block is changed, we punch a hole
-				//for the previous unpunched blocks, and reset the file and
-				//fileIndx pointed to by this block
+				// We are looking for continuous blocks over here.
+				// If the file of the next block is changed, we punch a hole
+				// for the previous unpunched blocks, and reset the file and
+				// fileIndx pointed to by this block
 				if d.files[d.location[offset]] != file ||
 					offset != lOffset+length {
 					if file != nil && fileIndx > userCreatedSnapIndx && shouldCreateHoles() {
@@ -287,16 +289,16 @@ func preload(d *diffDisk) error {
 					length = 1
 					lOffset = offset
 				} else {
-					//If this is the last block in the loop, hole for this
-					//block will be punched outside the loop
+					// If this is the last block in the loop, hole for this
+					// block will be punched outside the loop
 					length++
 				}
 			}
 			d.location[offset] = byte(i)
 			d.UsedBlocks++
 		}
-		//This will take care of the case when the last call in the above loop
-		//enters else case
+		// This will take care of the case when the last call in the above loop
+		// enters else case
 		if file != nil && fileIndx > userCreatedSnapIndx && shouldCreateHoles() {
 			sendToCreateHole(file, lOffset*d.sectorSize, length*d.sectorSize)
 		}

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -169,7 +169,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 			//fileIndx pointed to by this block
 			if d.location[startSector+i] != fileIndx ||
 				startSector+i != lOffset+length {
-				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding && !inject.IsDebugBuild() {
+				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding && !inject.DisablePunchHoles() {
 					sendToCreateHole(d.files[val], lOffset*d.sectorSize, length*d.sectorSize)
 				}
 				file = d.files[d.location[startSector+i]]
@@ -186,7 +186,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 	}
 	//This will take care of the case when the last call in the above loop
 	//enters else case
-	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding && !inject.IsDebugBuild() {
+	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding && !inject.DisablePunchHoles() {
 		sendToCreateHole(file, lOffset*d.sectorSize, length*d.sectorSize)
 	}
 	file = nil

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 
 	fibmap "github.com/frostschutz/go-fibmap"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 	"github.com/rancher/sparse-tools/sparse"
 )
@@ -168,7 +169,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 			//fileIndx pointed to by this block
 			if d.location[startSector+i] != fileIndx ||
 				startSector+i != lOffset+length {
-				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding {
+				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding && !inject.IsDebugBuild() {
 					sendToCreateHole(d.files[val], lOffset*d.sectorSize, length*d.sectorSize)
 				}
 				file = d.files[d.location[startSector+i]]
@@ -185,7 +186,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 	}
 	//This will take care of the case when the last call in the above loop
 	//enters else case
-	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding {
+	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding && !inject.IsDebugBuild() {
 		sendToCreateHole(file, lOffset*d.sectorSize, length*d.sectorSize)
 	}
 	file = nil

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -168,7 +168,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 			//fileIndx pointed to by this block
 			if d.location[startSector+i] != fileIndx ||
 				startSector+i != lOffset+length {
-				if file != nil && int(fileIndx) > d.SnapIndx {
+				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding {
 					sendToCreateHole(d.files[val], lOffset*d.sectorSize, length*d.sectorSize)
 				}
 				file = d.files[d.location[startSector+i]]
@@ -185,7 +185,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 	}
 	//This will take care of the case when the last call in the above loop
 	//enters else case
-	if (file != nil) && (int(fileIndx) > d.SnapIndx) {
+	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding {
 		sendToCreateHole(file, lOffset*d.sectorSize, length*d.sectorSize)
 	}
 	file = nil

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -169,7 +169,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 			//fileIndx pointed to by this block
 			if d.location[startSector+i] != fileIndx ||
 				startSector+i != lOffset+length {
-				if file != nil && int(fileIndx) > d.SnapIndx && !types.IsRebuilding && !inject.DisablePunchHoles() {
+				if file != nil && int(fileIndx) > d.SnapIndx && shouldCreateHoles() && !inject.DisablePunchHoles() {
 					sendToCreateHole(d.files[val], lOffset*d.sectorSize, length*d.sectorSize)
 				}
 				file = d.files[d.location[startSector+i]]
@@ -186,7 +186,7 @@ func (d *diffDisk) fullWriteAt(buf []byte, offset int64) (int, error) {
 	}
 	//This will take care of the case when the last call in the above loop
 	//enters else case
-	if (file != nil) && (int(fileIndx) > d.SnapIndx) && !types.IsRebuilding && !inject.DisablePunchHoles() {
+	if (file != nil) && (int(fileIndx) > d.SnapIndx) && shouldCreateHoles() && !inject.DisablePunchHoles() {
 		sendToCreateHole(file, lOffset*d.sectorSize, length*d.sectorSize)
 	}
 	file = nil

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -213,7 +213,7 @@ func (s *Server) SnapshotReplica(rw http.ResponseWriter, req *http.Request) erro
 	var input SnapshotInput
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&input); err != nil && err != io.EOF {
-		logrus.Errorf("Err %v for reading in snapshotReplica %v", err)
+		logrus.Errorf("Err %v for reading in snapshotReplica", err)
 		return err
 	}
 
@@ -234,7 +234,7 @@ func (s *Server) RevertReplica(rw http.ResponseWriter, req *http.Request) error 
 	var input RevertInput
 	apiContext := api.GetApiContext(req)
 	if err := apiContext.Read(&input); err != nil && err != io.EOF {
-		logrus.Errorf("Err %v for reading in revertReplica %v", err)
+		logrus.Errorf("Err %v for reading in revertReplica", err)
 		return err
 	}
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -132,14 +132,12 @@ func (s *Server) Reload() error {
 		return nil
 	}
 
-	types.IsReloadOperation = true
-	defer func() {
-		types.IsReloadOperation = false
-	}()
+	types.ShouldPunchHoles = true
 	logrus.Infof("Reloading volume")
 	newReplica, err := s.r.Reload()
 	if err != nil {
 		logrus.Errorf("error in Reload")
+		types.ShouldPunchHoles = false
 		return err
 	}
 
@@ -238,7 +236,6 @@ func (s *Server) SetRebuilding(rebuilding bool) error {
 		return fmt.Errorf("Can not set rebuilding=%v from state %s", rebuilding, state)
 	}
 
-	types.IsRebuilding = rebuilding
 	return s.r.SetRebuilding(rebuilding)
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -16,6 +16,11 @@ const (
 	StateDown = State("Down")
 )
 
+const (
+	DrainStart HoleChannelOps = iota + 1
+	DrainDone
+)
+
 type ReaderWriterAt interface {
 	io.ReaderAt
 	io.WriterAt
@@ -34,6 +39,15 @@ type DiffDisk interface {
 }
 
 type MonitorChannel chan error
+type HoleChannelOps int
+
+var DrainOps HoleChannelOps
+
+var (
+	IsReloadOperation bool
+	IsRebuilding      bool
+	IsMasterReplica   bool
+)
 
 type Backend interface {
 	IOs

--- a/types/types.go
+++ b/types/types.go
@@ -17,7 +17,11 @@ const (
 )
 
 const (
+	// DrainStart flag is used to notify CreateHoles goroutine
+	// for draining the data in HoleCreatorChan
 	DrainStart HoleChannelOps = iota + 1
+	// DrainDone flag is used to notify the s.Close that data
+	// from HoleCreatorChan has been flushed
 	DrainDone
 )
 
@@ -39,14 +43,25 @@ type DiffDisk interface {
 }
 
 type MonitorChannel chan error
+
+// HoleChannelOps is the operation that has to be performed
+// on HoleCreatorChan such as DrainStart, DrainDone for draining
+// the chan and notify the caller if drain is done.
 type HoleChannelOps int
 
+// DrainOps is flag used for various operations on HoleCreatorChan
 var DrainOps HoleChannelOps
 
 var (
+	// IsReloadOperation if true, is used for creating holes, while
+	// reload replica is in progress.
 	IsReloadOperation bool
-	IsRebuilding      bool
-	IsMasterReplica   bool
+	// IsRebuilding if false, is used for creating holes while
+	// write operation is in progress.
+	IsRebuilding bool
+	// IsMasterReplica if true, is used for creating holes while
+	// preload operation is in progress
+	IsMasterReplica bool
 )
 
 type Backend interface {

--- a/types/types.go
+++ b/types/types.go
@@ -53,15 +53,9 @@ type HoleChannelOps int
 var DrainOps HoleChannelOps
 
 var (
-	// IsReloadOperation if true, is used for creating holes, while
-	// reload replica is in progress.
-	IsReloadOperation bool
-	// IsRebuilding if false, is used for creating holes while
-	// write operation is in progress.
-	IsRebuilding bool
-	// IsMasterReplica if true, is used for creating holes while
-	// preload operation is in progress
-	IsMasterReplica bool
+	// ShouldPunchHoles is a flag used to verify if
+	// we should punch holes.
+	ShouldPunchHoles bool
 )
 
 type Backend interface {


### PR DESCRIPTION
Recently it has been observed that replicas were crashing due to
frequent controller restart. This is happening due to the files
are getting closed just after the disconnection but it is trying to
punch holes on the closed files. So it was giving `bad file descriptor
error`.

This PR fix the above issue by closing the files gracefully after
draining the queued data in the HoleCreatorChan. Punch holes will
be done only in following case:
- If replica is master replica (which get start signal)
- If replica is reloaded
- If replica is in RW mode (i.e, Rebuilding is false)

Additionally it fixes some go vet errors also.

Fixes: openebs/openebs#2532

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>