### PR TITLE
fix(jiva): update revisioncounter only during rw mode

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -55,6 +55,7 @@ func (f *Wrapper) GetVolUsage() (types.VolUsage, error) {
 	return types.VolUsage{}, nil
 }
 
+// SetReplicaMode ...
 func (f *Wrapper) SetReplicaMode(mode types.Mode) error {
 	return nil
 }

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -55,6 +55,10 @@ func (f *Wrapper) GetVolUsage() (types.VolUsage, error) {
 	return types.VolUsage{}, nil
 }
 
+func (f *Wrapper) SetReplicaMode(mode types.Mode) error {
+	return nil
+}
+
 func (f *Wrapper) SetRevisionCounter(counter int64) error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -194,6 +194,19 @@ func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	return volUsage, err
 }
 
+func (r *Remote) SetReplicaMode(mode types.Mode) error {
+	var m string
+	logrus.Infof("Set replica mode of %s to : %v", r.Name, mode)
+	if mode == types.RW {
+		m = "RW"
+	} else if mode == types.WO {
+		m = "WO"
+	} else {
+		return fmt.Errorf("invalid mode string %v", mode)
+	}
+	return r.doAction("setreplicamode", &map[string]string{"mode": m})
+}
+
 func (r *Remote) SetRevisionCounter(counter int64) error {
 	logrus.Infof("Set revision counter of %s to : %v", r.Name, counter)
 	localRevCount := strconv.FormatInt(counter, 10)

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -194,6 +194,7 @@ func (r *Remote) GetVolUsage() (types.VolUsage, error) {
 	return volUsage, err
 }
 
+// SetReplicaMode ...
 func (r *Remote) SetReplicaMode(mode types.Mode) error {
 	var m string
 	logrus.Infof("Set replica mode of %s to : %v", r.Name, mode)

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1425,7 +1425,11 @@ test_restart_during_prepare_rebuild() {
 	rev_counter1=`cat /tmp/vol1/revision.counter`
 	rev_counter2=`cat /tmp/vol2/revision.counter`
 	if [ $rev_counter1 -ne $rev_counter2 ]; then
-		echo "replica restart during prepare rebuild -- failed"
+		echo "replica restart during prepare rebuild1 -- failed"
+		collect_logs_and_exit
+	fi
+	if [ $rev_counter1 -lt 5 ]; then
+		echo "replica restart during prepare rebuild2 -- failed"
 		collect_logs_and_exit
 	fi
 	cleanup

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -103,6 +103,24 @@ verify_replica_cnt() {
 	return
 }
 
+verify_container_dead() {
+	i=0
+	replica_id=`echo $1 | cut -b 1-12`
+	echo $replica_id
+	while [ $i -lt 100 ]; do
+		cnt=`docker ps -a | grep $replica_id | grep -w Exited | wc -l`
+		if [ $cnt -eq 1 ]; then
+			return
+		fi
+		sleep 2
+		i=`expr $i + 1`
+	done
+	docker ps -a
+	echo $1
+	echo $2 " -- failed"
+	collect_logs_and_exit
+}
+
 # RW=1 RO=0
 # verify_rw_status "RO/RW"
 verify_rw_status() {
@@ -254,6 +272,23 @@ verify_vol_status() {
 	return
 }
 
+verify_replica_mode() {
+	i=0
+	while [ "$i" != 50 ]; do
+		date
+		rep_mode=`curl http://$3:9502/v1/replicas | jq '.data[0].replicamode' | tr -d '"'`
+		if [ "$rep_mode" == "$4" ]; then
+			passed=`expr $passed + 1`
+		fi
+		if [ "$passed" == "$1" ]; then
+			echo $2 " -- passed"
+			return
+		fi
+	done
+	echo $2 " -- failed"
+	collect_logs_and_exit
+}
+
 #$1 - pass count
 #$2 - message
 #$3 - Replica IP
@@ -359,7 +394,7 @@ start_replica() {
 # start_replica CONTROLLER_IP REPLICA_IP folder_name
 start_debug_replica() {
 	replica_id=$(docker run -d --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI_DEBUG \
-	env $4=$5 launch replica --frontendIP "$1" --listen "$2":9502 --size 2g /"$3")
+	env $4=$5 $6=$7 launch replica --frontendIP "$1" --listen "$2":9502 --size 2g /"$3")
 	echo "$replica_id"
 }
 
@@ -1203,7 +1238,7 @@ di_test_on_raw_disk() {
 			hash2=$(md5sum test_file2 | awk '{print $1}')
 			if [ $hash1 == $hash2 ]; then echo "DI Test: PASSED"
 			else
-				echo "DI Test: FAILED"; collect_logs_and_exit1
+				echo "DI Test: FAILED"; collect_logs_and_exit
 			fi
 			logout_of_volume
 			sleep 5
@@ -1358,6 +1393,42 @@ update_file_sizes() {
 		snapsize[$i]=$x
 		let i=i+1
 	done
+}
+
+test_restart_during_prepare_rebuild() {
+	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
+	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+	verify_replica_cnt "2" "test restart during add"
+
+	login_to_volume "$CONTROLLER_IP:3260"
+	sleep 5
+	get_scsi_disk
+	if [ "$device_name"!="" ]; then
+		mkfs.ext2 -F /dev/$device_name
+		mount /dev/$device_name /mnt/store
+		if [ $? -ne 0 ]; then
+			echo "mount failed in test_restart_during_add_replica"
+			collect_logs_and_exit
+		fi
+		umount /mnt/store
+	else
+		echo "Unable to detect iSCSI device during test_restart_add_replica"; collect_logs_and_exit
+	fi
+	logout_of_volume
+
+	docker stop $replica2_id
+	sleep 1
+	verify_replica_mode 1 "replica mode in test with restart during prepare rebuild" "$REPLICA_IP1" "RW"
+	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "PANIC_AFTER_PREPARE_REBUILD" "TRUE")
+	verify_container_dead $replica2_id "restart during prepare rebuild"
+	rev_counter1=`cat /tmp/vol1/revision.counter`
+	rev_counter2=`cat /tmp/vol2/revision.counter`
+	if [ $rev_counter1 -ne $rev_counter2 ]; then
+		echo "replica restart during prepare rebuild -- failed"
+		collect_logs_and_exit
+	fi
+	cleanup
 }
 
 test_duplicate_data_delete() {
@@ -1534,6 +1605,7 @@ test_duplicate_data_delete() {
 
 
 prepare_test_env
+test_restart_during_prepare_rebuild
 test_preload
 test_replica_rpc_close
 test_controller_rpc_close

--- a/controller/control.go
+++ b/controller/control.go
@@ -701,7 +701,7 @@ func (c *Controller) addReplicaDuringStartNoLock(address string) error {
 	}
 getCloneStatus:
 	if status, err1 = c.backend.GetCloneStatus(address); err1 != nil {
-		_ := c.RemoveReplicaNoLock(address)
+		_ = c.RemoveReplicaNoLock(address)
 		return err1
 	}
 	if status == "" || status == "inProgress" {
@@ -709,12 +709,12 @@ getCloneStatus:
 		time.Sleep(2 * time.Second)
 		goto getCloneStatus
 	} else if status == "error" {
-		_ := c.RemoveReplicaNoLock(address)
+		_ = c.RemoveReplicaNoLock(address)
 		return fmt.Errorf("Replica clone status returned error %s", address)
 	}
 
 	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
-		_ := c.RemoveReplicaNoLock(address)
+		_ = c.RemoveReplicaNoLock(address)
 		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
 	}
 
@@ -831,7 +831,7 @@ func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					_ := c.RemoveReplicaNoLock(address)
+					_ = c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -858,7 +858,7 @@ func (c *Controller) Sync() (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					_ := c.RemoveReplicaNoLock(address)
+					_ = c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -885,7 +885,7 @@ func (c *Controller) Unmap(offset int64, length int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					_ := c.RemoveReplicaNoLock(address)
+					_ = c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -920,7 +920,7 @@ func (c *Controller) ReadAt(b []byte, off int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					_ := c.RemoveReplicaNoLock(address)
+					_ = c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -1046,5 +1046,5 @@ func (c *Controller) monitoring(address string, backend types.Backend) {
 		c.setReplicaModeNoLock(address, types.ERR)
 	}
 	logrus.Infof("Monitoring stopped %v", address)
-	_ := c.RemoveReplicaNoLock(address)
+	_ = c.RemoveReplicaNoLock(address)
 }

--- a/controller/control.go
+++ b/controller/control.go
@@ -701,7 +701,7 @@ func (c *Controller) addReplicaDuringStartNoLock(address string) error {
 	}
 getCloneStatus:
 	if status, err1 = c.backend.GetCloneStatus(address); err1 != nil {
-		c.RemoveReplicaNoLock(address)
+		_ := c.RemoveReplicaNoLock(address)
 		return err1
 	}
 	if status == "" || status == "inProgress" {
@@ -709,12 +709,12 @@ getCloneStatus:
 		time.Sleep(2 * time.Second)
 		goto getCloneStatus
 	} else if status == "error" {
-		c.RemoveReplicaNoLock(address)
+		_ := c.RemoveReplicaNoLock(address)
 		return fmt.Errorf("Replica clone status returned error %s", address)
 	}
 
 	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
-		c.RemoveReplicaNoLock(address)
+		_ := c.RemoveReplicaNoLock(address)
 		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
 	}
 
@@ -831,7 +831,7 @@ func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					c.RemoveReplicaNoLock(address)
+					_ := c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -858,7 +858,7 @@ func (c *Controller) Sync() (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					c.RemoveReplicaNoLock(address)
+					_ := c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -885,7 +885,7 @@ func (c *Controller) Unmap(offset int64, length int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					c.RemoveReplicaNoLock(address)
+					_ := c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -920,7 +920,7 @@ func (c *Controller) ReadAt(b []byte, off int64) (int, error) {
 		if bErr, ok := err.(*BackendError); ok {
 			if len(bErr.Errors) > 0 {
 				for address := range bErr.Errors {
-					c.RemoveReplicaNoLock(address)
+					_ := c.RemoveReplicaNoLock(address)
 				}
 			}
 		}
@@ -1046,5 +1046,5 @@ func (c *Controller) monitoring(address string, backend types.Backend) {
 		c.setReplicaModeNoLock(address, types.ERR)
 	}
 	logrus.Infof("Monitoring stopped %v", address)
-	c.RemoveReplicaNoLock(address)
+	_ := c.RemoveReplicaNoLock(address)
 }

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -149,11 +149,11 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
 	c.Lock()
 	defer c.Unlock()
-/*
-	if err := c.backend.SetRevisionCounter(address, 0); err != nil {
-		return nil, fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
-	}
-*/
+	/*
+		if err := c.backend.SetRevisionCounter(address, 0); err != nil {
+			return nil, fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
+		}
+	*/
 	replica, rwReplica, err := c.getCurrentAndRWReplica(address)
 	if err != nil {
 		return nil, err

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -97,6 +97,9 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 	if err := c.backend.SetRevisionCounter(address, counter); err != nil {
 		return fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
 	}
+	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
+		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
+	}
 	logrus.Debugf("WO replica %v's chain verified, update mode to RW", address)
 	c.setReplicaModeNoLock(address, types.RW)
 	if len(c.replicas) > c.replicaCount {

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -146,11 +146,11 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
 	c.Lock()
 	defer c.Unlock()
-
+/*
 	if err := c.backend.SetRevisionCounter(address, 0); err != nil {
 		return nil, fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
 	}
-
+*/
 	replica, rwReplica, err := c.getCurrentAndRWReplica(address)
 	if err != nil {
 		return nil, err

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -94,11 +94,11 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 	}
 	logrus.Infof("rw replica %s revision counter %d", rwReplica.Address, counter)
 
-	if err := c.backend.SetRevisionCounter(address, counter); err != nil {
-		return fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
-	}
 	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
 		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
+	}
+	if err := c.backend.SetRevisionCounter(address, counter); err != nil {
+		return fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
 	}
 	logrus.Debugf("WO replica %v's chain verified, update mode to RW", address)
 	c.setReplicaModeNoLock(address, types.RW)
@@ -149,11 +149,6 @@ func syncFile(from, to string, fromReplica, toReplica *types.Replica) error {
 func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
 	c.Lock()
 	defer c.Unlock()
-	/*
-		if err := c.backend.SetRevisionCounter(address, 0); err != nil {
-			return nil, fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
-		}
-	*/
 	replica, rwReplica, err := c.getCurrentAndRWReplica(address)
 	if err != nil {
 		return nil, err

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -428,6 +428,21 @@ func (r *replicator) RemainSnapshots() (int, error) {
 	return ret, nil
 }
 
+func (r *replicator) SetReplicaMode(address string, mode types.Mode) error {
+	backend, ok := r.backends[address]
+	if !ok {
+		return fmt.Errorf("Cannot find backend %v", address)
+	}
+
+	if err := backend.backend.SetReplicaMode(mode); err != nil {
+		return err
+	}
+
+	logrus.Infof("Set backend %s replica mode to %v", address, mode)
+
+	return nil
+}
+
 func (r *replicator) SetRevisionCounter(address string, counter int64) error {
 	backend, ok := r.backends[address]
 	if !ok {

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -2,6 +2,7 @@
 
 package inject
 
-func AddTimeout()        {}
-func AddPingTimeout()    {}
-func AddPreloadTimeout() {}
+func AddTimeout()               {}
+func AddPingTimeout()           {}
+func AddPreloadTimeout()        {}
+func PanicAfterPrepareRebuild() {}

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -34,3 +34,11 @@ func AddPreloadTimeout() {
 	logrus.Infof("Add preload timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
 }
+
+func PanicAfterPrepareRebuild() {
+	ok := os.Getenv("PANIC_AFTER_PREPARE_REBUILD")
+	if ok == "TRUE" {
+		time.Sleep(2 * time.Second)
+		panic("panic replica after getting start signal")
+	}
+}

--- a/replica/backup_test.go
+++ b/replica/backup_test.go
@@ -24,6 +24,8 @@ func (s *TestSuite) TestBackup(c *C) {
 	r, err := New(10*mb, bs, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	buf := make([]byte, 2*mb)
 	fill(buf, 1)
@@ -87,6 +89,8 @@ func (s *TestSuite) testBackupWithBackups(c *C, backingFile *BackingFile) {
 	r, err := New(10*mb, bs, dir, backingFile, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	// Write layout as follows
 	//               0 1 2 3 4 5 6 7 8 9 mb

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1180,6 +1180,7 @@ func (r *Replica) getDiskSize(disk string) int64 {
 	return util.GetFileActualSize(r.diskPath(disk))
 }
 
+// GetReplicaMode ...
 func (r *Replica) GetReplicaMode() string {
 	r.Lock()
 	defer r.Unlock()

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1000,7 +1000,7 @@ func (r *Replica) Close() error {
 	r.Lock()
 	defer r.Unlock()
 
-	r.mode = types.Closed
+	r.mode = types.CLOSED
 	return r.close()
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1000,6 +1000,7 @@ func (r *Replica) Close() error {
 	r.Lock()
 	defer r.Unlock()
 
+	r.mode = types.Closed
 	return r.close()
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1179,6 +1179,12 @@ func (r *Replica) getDiskSize(disk string) int64 {
 	return util.GetFileActualSize(r.diskPath(disk))
 }
 
+func (r *Replica) GetReplicaMode() string {
+	r.Lock()
+	defer r.Unlock()
+	return string(r.mode)
+}
+
 func (r *Replica) SetReplicaMode(mode string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -51,7 +51,7 @@ type Replica struct {
 	diskChildrenMap  map[string]map[string]bool
 	activeDiskData   []*disk
 	readOnly         bool
-	mode		 types.Mode
+	mode             types.Mode
 
 	revisionLock  sync.Mutex
 	revisionCache int64
@@ -123,7 +123,7 @@ func CreateTempReplica() (*Replica, error) {
 	r := &Replica{
 		dir:              Dir,
 		ReplicaStartTime: StartTime,
-		mode:		  types.INIT,
+		mode:             types.INIT,
 	}
 	if err := r.initRevisionCounter(); err != nil {
 		logrus.Errorf("Error in initializing revision counter while creating temp replica")
@@ -168,7 +168,7 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 		activeDiskData:  make([]*disk, 1),
 		diskData:        make(map[string]*disk),
 		diskChildrenMap: map[string]map[string]bool{},
-		mode:		 types.INIT,
+		mode:            types.INIT,
 	}
 	r.info.Size = size
 	r.info.SectorSize = sectorSize
@@ -1089,9 +1089,9 @@ func (r *Replica) Unmap(offset int64, length int64) (int, error) {
 
 func (r *Replica) WriteAt(buf []byte, offset int64) (int, error) {
 	var (
-		c	int
-		err	error
-		mode	types.Mode
+		c    int
+		err  error
+		mode types.Mode
 	)
 	if r.readOnly {
 		return 0, fmt.Errorf("Can not write on read-only replica")
@@ -1192,4 +1192,3 @@ func (r *Replica) SetReplicaMode(mode string) error {
 	}
 	return nil
 }
-

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1186,6 +1186,7 @@ func (r *Replica) GetReplicaMode() string {
 	return string(r.mode)
 }
 
+// SetReplicaMode ...
 func (r *Replica) SetReplicaMode(mode string) error {
 	r.Lock()
 	defer r.Unlock()

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -33,6 +33,8 @@ func (s *TestSuite) TestCreate(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 }
 
 func getNow() string {
@@ -49,6 +51,8 @@ func (s *TestSuite) TestSnapshot(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	createdTime0 := getNow()
 
@@ -130,6 +134,8 @@ func (s *TestSuite) TestRevert(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	createdTime0 := getNow()
 	err = r.Snapshot("000", true, createdTime0)
@@ -242,6 +248,8 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -317,6 +325,8 @@ func (s *TestSuite) TestRemoveLast(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -363,6 +373,8 @@ func (s *TestSuite) TestRemoveMiddle(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -409,6 +421,8 @@ func (s *TestSuite) TestRemoveFirst(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -440,6 +454,8 @@ func (s *TestSuite) TestRemoveOutOfChain(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -516,6 +532,8 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	r, err := New(9, 3, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	now := getNow()
 	err = r.Snapshot("000", true, now)
@@ -645,6 +663,8 @@ func (s *TestSuite) TestRead(c *C) {
 	r, err := New(9*b, b, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	buf := make([]byte, 3*b)
 	_, err = r.ReadAt(buf, 0)
@@ -660,6 +680,8 @@ func (s *TestSuite) TestWrite(c *C) {
 	r, err := New(9*b, b, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	buf := make([]byte, 9*b)
 	fill(buf, 1)
@@ -682,6 +704,8 @@ func (s *TestSuite) TestSnapshotReadWrite(c *C) {
 	r, err := New(3*b, b, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	buf := make([]byte, 3*b)
 	fill(buf, 3)
@@ -742,6 +766,8 @@ func (s *TestSuite) TestBackingFile(c *C) {
 	r, err := New(3*b, b, dir, backing, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	chain, err := r.Chain()
 	c.Assert(err, IsNil)
@@ -775,6 +801,8 @@ func (s *TestSuite) partialWriteRead(c *C, totalLength, writeLength, writeOffset
 	r, err := New(totalLength, b, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	_, err = r.WriteAt(buf, 0)
 	c.Assert(err, IsNil)
@@ -823,6 +851,8 @@ func (s *TestSuite) testPartialRead(c *C, totalLength int64, readBuf []byte, off
 	r, err := New(totalLength, b, dir, nil, "Backend")
 	c.Assert(err, IsNil)
 	defer r.Close()
+	err = r.SetReplicaMode("RW")
+	c.Assert(err, IsNil)
 
 	for i := int64(0); i < totalLength; i += b {
 		buf := make([]byte, totalLength-i)

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -20,7 +20,7 @@ type Replica struct {
 	Chain             []string                    `json:"chain"`
 	Disks             map[string]replica.DiskInfo `json:"disks"`
 	RemainSnapshots   int                         `json:"remainsnapshots"`
-	ReplicaMode	  string		      `json:"replicamode"`
+	ReplicaMode       string                      `json:"replicamode"`
 	RevisionCounter   string                      `json:"revisioncounter"`
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -153,6 +153,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["replacedisk"] = true
 		actions["revert"] = true
 		actions["prepareremovedisk"] = true
+		actions["setreplicamode"] = true
 		actions["setrevisioncounter"] = true
 		actions["updatecloneinfo"] = true
 		actions["setreplicacounter"] = true
@@ -187,6 +188,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["setrebuilding"] = true
 		actions["close"] = true
 		actions["reload"] = true
+		actions["setreplicamode"] = true
 		actions["setrevisioncounter"] = true
 		actions["setreplicacounter"] = true
 		actions["updatecloneinfo"] = true
@@ -209,6 +211,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.Disks = rep.ListDisks()
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
+		r.ReplicaMode = rep.GetReplicaMode()
 		r.CloneStatus = rep.GetCloneStatus()
 	}
 	return r

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -20,6 +20,7 @@ type Replica struct {
 	Chain             []string                    `json:"chain"`
 	Disks             map[string]replica.DiskInfo `json:"disks"`
 	RemainSnapshots   int                         `json:"remainsnapshots"`
+	ReplicaMode	  string		      `json:"replicamode"`
 	RevisionCounter   string                      `json:"revisioncounter"`
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
@@ -98,6 +99,11 @@ type PrepareRemoveDiskInput struct {
 type PrepareRemoveDiskOutput struct {
 	client.Resource
 	Operations []replica.PrepareRemoveAction `json:"operations"`
+}
+
+type ReplicaMode struct {
+	client.Resource
+	Mode string `json:"mode"`
 }
 
 type RevisionCounter struct {
@@ -243,6 +249,9 @@ func setReplicaResourceActions(replica *client.Schema) {
 			Input:  "prepareRemoveDiskInput",
 			Output: "prepareRemoveDiskOutput",
 		},
+		"setreplicamode": {
+			Input: "replicaMode",
+		},
 		"setrevisioncounter": {
 			Input: "revisionCounter",
 		},
@@ -269,6 +278,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("revertInput", RevertInput{})
 	schemas.AddType("prepareRemoveDiskInput", PrepareRemoveDiskInput{})
 	schemas.AddType("prepareRemoveDiskOutput", PrepareRemoveDiskOutput{})
+	schemas.AddType("replicaMode", ReplicaMode{})
 	schemas.AddType("revisionCounter", RevisionCounter{})
 	schemas.AddType("replicaCounter", ReplicaCounter{})
 	schemas.AddType("replacediskInput", ReplaceDiskInput{})

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -178,6 +178,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["replacedisk"] = true
 		actions["updatediskmode"] = true
 		actions["revert"] = true
+		actions["setreplicamode"] = true
 		actions["prepareremovedisk"] = true
 		actions["setreplicacounter"] = true
 		actions["updatecloneinfo"] = true

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -101,6 +101,7 @@ type PrepareRemoveDiskOutput struct {
 	Operations []replica.PrepareRemoveAction `json:"operations"`
 }
 
+// ReplicaMode ...
 type ReplicaMode struct {
 	client.Resource
 	Mode string `json:"mode"`

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -291,6 +291,17 @@ func (s *Server) StartReplica(rw http.ResponseWriter, req *http.Request) error {
 	return s.doOp(req, s.s.Start(action.Value))
 }
 
+func (s *Server) SetReplicaMode(rw http.ResponseWriter, req *http.Request) error {
+	var mode ReplicaMode
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&mode); err != nil && err != io.EOF {
+		logrus.Errorf("Err %v during read in setReplicaMode", err)
+		return err
+	}
+	logrus.Infof("SetReplicaMode to %v", mode.Mode)
+	return s.doOp(req, s.s.SetReplicaMode(mode.Mode))
+}
+
 func (s *Server) SetRevisionCounter(rw http.ResponseWriter, req *http.Request) error {
 	var input RevisionCounter
 	apiContext := api.GetApiContext(req)

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -291,6 +291,7 @@ func (s *Server) StartReplica(rw http.ResponseWriter, req *http.Request) error {
 	return s.doOp(req, s.s.Start(action.Value))
 }
 
+// SetReplicaMode ...
 func (s *Server) SetReplicaMode(rw http.ResponseWriter, req *http.Request) error {
 	var mode ReplicaMode
 	apiContext := api.GetApiContext(req)

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -73,6 +73,7 @@ func NewRouter(s *Server) *mux.Router {
 		"revert":             s.RevertReplica,
 		"prepareremovedisk":  s.PrepareRemoveDisk,
 		"setrevisioncounter": s.SetRevisionCounter,
+		"setreplicamode":     s.SetReplicaMode,
 	}
 
 	for name, action := range actions {

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -67,7 +67,7 @@ func (r *Replica) initRevisionCounter() error {
 			logrus.Errorf("failed to open revision counter file")
 			return err
 		}
-		if err := r.writeRevisionCounter(0); err != nil {
+		if err := r.writeRevisionCounter(1); err != nil {
 			logrus.Errorf("failed to update revision counter")
 			return err
 		}

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -2,6 +2,7 @@ package replica
 
 import (
 	"fmt"
+	"github.com/openebs/jiva/types"
 	"io"
 	"os"
 	"strconv"
@@ -104,6 +105,12 @@ func (r *Replica) GetRevisionCounter() int64 {
 }
 
 func (r *Replica) SetRevisionCounter(counter int64) error {
+	r.Lock()
+	if r.mode != types.RW {
+		r.Unlock()
+		return fmt.Errorf("setting revisioncounter during %v mode is invalid", r.mode)
+	}
+	r.Unlock()
 	r.revisionLock.Lock()
 	defer r.revisionLock.Unlock()
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -433,6 +433,17 @@ func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	return i, err
 }
 
+func (s *Server) SetReplicaMode(mode string) error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.r == nil {
+		logrus.Infof("s.r is nil during setReplicaMode")
+		return nil
+	}
+	return s.r.SetReplicaMode(mode)
+}
+
 func (s *Server) SetRevisionCounter(counter int64) error {
 	s.Lock()
 	defer s.Unlock()

--- a/replica/server.go
+++ b/replica/server.go
@@ -433,6 +433,7 @@ func (s *Server) ReadAt(buf []byte, offset int64) (int, error) {
 	return i, err
 }
 
+// SetReplicaMode ...
 func (s *Server) SetReplicaMode(mode string) error {
 	s.Lock()
 	defer s.Unlock()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/openebs/jiva/controller/client"
 	"github.com/openebs/jiva/controller/rest"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/replica"
 	replicaClient "github.com/openebs/jiva/replica/client"
 )
@@ -351,7 +352,7 @@ Register:
 	if err != nil {
 		return fmt.Errorf("failed to prepare rebuild, error: %s", err.Error())
 	}
-
+	inject.PanicAfterPrepareRebuild()
 	logrus.Infof("syncFiles from:%v to:%v", fromClient, toClient)
 	if err = t.syncFiles(fromClient, toClient, output.Disks); err != nil {
 		return err

--- a/types/types.go
+++ b/types/types.go
@@ -6,10 +6,11 @@ import (
 )
 
 const (
-	WO   = Mode("WO")
-	RW   = Mode("RW")
-	ERR  = Mode("ERR")
-	INIT = Mode("INIT")
+	WO     = Mode("WO")
+	RW     = Mode("RW")
+	ERR    = Mode("ERR")
+	INIT   = Mode("INIT")
+	CLOSED = Mode("CLOSED")
 
 	StateUp   = State("Up")
 	StateDown = State("Down")

--- a/types/types.go
+++ b/types/types.go
@@ -9,6 +9,7 @@ const (
 	WO  = Mode("WO")
 	RW  = Mode("RW")
 	ERR = Mode("ERR")
+	INIT = Mode("INIT")
 
 	StateUp   = State("Up")
 	StateDown = State("Down")
@@ -44,6 +45,7 @@ type Backend interface {
 	GetRevisionCounter() (int64, error)
 	GetCloneStatus() (string, error)
 	GetVolUsage() (VolUsage, error)
+	SetReplicaMode(mode Mode) error
 	SetRevisionCounter(counter int64) error
 	SetRebuilding(rebuilding bool) error
 	GetMonitorChannel() MonitorChannel

--- a/types/types.go
+++ b/types/types.go
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	WO  = Mode("WO")
-	RW  = Mode("RW")
-	ERR = Mode("ERR")
+	WO   = Mode("WO")
+	RW   = Mode("RW")
+	ERR  = Mode("ERR")
 	INIT = Mode("INIT")
 
 	StateUp   = State("Up")


### PR DESCRIPTION
Currently, jiva controller resets revisionCounter of replica to 0 whenever replica is added in WO mode. Jiva replica increments revisionCounter all the time.

When there is any disconnection or restarts of replica after revisionCounter is set to 0, then, it loses the context of the amount of data that replica had. This makes controller in picking wrong replica as the master.

This PR does the following:
- Remove re-setting revisionCounter to 0
- Controller sets replicaMode of replica to RW when it add replica in RW
- Controller sets replicaMode of replica to WO when it adds replica in WO mode
- Controller sets replicaMode of replica to RW when replica completed its sync process
- Increment revisionCounter in replica only when the replica is in RW state

Signed-off-by: Vitta <vitta@mayadata.io>