### PR TITLE
feat(replica): optimize resync

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -67,8 +67,9 @@ collect_logs_and_exit() {
 	exit 1
 }
 cleanup() {
-	rm -rf /tmp/vol*
-	rm -rf /mnt/logs
+        echo "----------------------------Cleanup------------------------"
+	rm -rfv /tmp/vol*
+	rm -rfv /mnt/logs
 	docker stop $(docker ps -aq)
 	docker rm $(docker ps -aq)
 }
@@ -77,8 +78,8 @@ prepare_test_env() {
 	echo "-------------------Prepare test env------------------------"
 	cleanup
 
-	mkdir -p /tmp/vol1 /tmp/vol2 /tmp/vol3 /tmp/vol4
-	mkdir -p /mnt/store /mnt/store2
+	mkdir -pv /tmp/vol1 /tmp/vol2 /tmp/vol3 /tmp/vol4
+	mkdir -pv /mnt/store /mnt/store2
 
 	docker network create --subnet=172.18.0.0/16 stg-net
 	JI=$(docker images | grep openebs/jiva | awk '{print $1":"$2}' | awk 'NR == 2 {print}')
@@ -87,6 +88,7 @@ prepare_test_env() {
 }
 
 verify_replica_cnt() {
+        echo "-------------------Verify Replica count--------------------"
 	i=0
 	replica_cnt=""
 	while [ "$replica_cnt" != "$1" ]; do
@@ -144,6 +146,7 @@ verify_rw_status() {
 }
 
 verify_rw_rep_count() {
+        echo "---------------Verify RW Replica Status------------------"
        i=0
        count=""
        while [ "$count" != "$1" ]; do
@@ -182,6 +185,7 @@ get_rw_rep_count() {
    # and RO state of controller
 #and verifies whether they are in sync
 verify_controller_quorum() {
+        echo "--------------------Verify controller quorum-----------------"
 	i=0
 	cf=`expr $1 / 2`
 	cf=`expr $cf + 1`
@@ -229,6 +233,7 @@ verify_controller_quorum() {
 # This verifies the goroutine leaks which happens when a request is made to
 # replica_ip:9503.
 verify_go_routine_leak() {
+    echo "---------------------Verify goroutine leak-------------------------"
     i=0
     date
     no_of_goroutine=`curl http://$2:9502/debug/pprof/goroutine?debug=1 | grep goroutine | awk '{ print $4}'`
@@ -251,6 +256,7 @@ verify_go_routine_leak() {
 }
 
 verify_vol_status() {
+        echo "---------------------------Verify volume status--------------------------"
 	i=0
 	rw_status=""
 	while [ "$rw_status" != "$1" ]; do
@@ -301,6 +307,7 @@ verify_replica_mode() {
 #this fn considered as 'pass' if the result matches with the pass count.
 #this fn takes care of checking for two replicas, and thus, pass count is passed by caller
 verify_rep_state() {
+        echo "------------------------Verify Replica state--------------------------"
 	i=0
 	rep_state=""
 	while [ "$i" != 50 ]; do
@@ -350,6 +357,7 @@ verify_rep_state() {
 }
 
 verify_controller_rep_state() {
+        echo "--------------------Verify controller and replica state------------------"
 	i=0
 	rep_state=""
 	while [ "$i" != 50 ]; do
@@ -447,7 +455,7 @@ verify_delete_replica() {
 }
 
 test_two_replica_delete() {
-	echo "----------------Test_two_replica_delete--------------"
+	echo "-----------------------Test_two_replica_delete-----------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
@@ -476,7 +484,7 @@ test_two_replica_delete() {
 }
 
 test_replication_factor() {
-	echo "----------------Test_replication_factor--------------"
+	echo "-------------------------Test_replication_factor---------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	verify_replica_cnt "1" "Single replica count test"
@@ -504,7 +512,7 @@ test_replication_factor() {
 }
 
 test_single_replica_stop_start() {
-	echo "----------------Test_single_replica_stop_start--------------"
+	echo "----------------------Test_single_replica_stop_start-------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	sleep 5
@@ -531,7 +539,7 @@ test_single_replica_stop_start() {
 # request for registeration to controller, controller should send 'start' signal
 # to other replica after verifying the replication factor.
 test_replica_ip_change() {
-	echo "----------------Test_replica_ip_change---------------"
+	echo "-------------------------Test_replica_ip_change------------------------"
 	debug_controller_id=$(start_debug_controller "$CONTROLLER_IP" "store1" "2" "DEBUG_TIMEOUT" "5")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2"
@@ -555,7 +563,7 @@ test_replica_ip_change() {
 }
 
 test_preload() {
-	echo "----------------Test_preload---------------"
+	echo "-----------------------------Test_preload-------------------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "PRELOAD_TIMEOUT" "12")
         # Since this is first time for replica to connect
@@ -605,7 +613,7 @@ test_preload() {
 }
 
 test_controller_rpc_close() {
-	echo "----------------Test_controller_rpc_close---------------"
+	echo "------------------------Test_controller_rpc_close--------------------------"
 	debug_controller_id=$(start_debug_controller "$CONTROLLER_IP" "store1" "1" "RPC_PING_TIMEOUT" "45")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
         # Adding this sleep to ensure ping timeout
@@ -631,7 +639,7 @@ test_controller_rpc_close() {
 }
 
 test_replica_rpc_close() {
-	echo "----------------Test_replica_rpc_close---------------"
+	echo "-------------------------Test_replica_rpc_close----------------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "1")
 	debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	sleep 5
@@ -647,7 +655,7 @@ test_replica_rpc_close() {
 }
 
 test_two_replica_stop_start() {
-	echo "----------------Test_two_replica_stop_start---------------"
+	echo "------------------------Test_two_replica_stop_start------------------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
@@ -659,7 +667,7 @@ test_two_replica_stop_start() {
 
 	docker stop $replica1_id
 	verify_replica_cnt "1" "Two replica count test when one is stopped"
-	verify_vol_status "RO" "when there are 2 replicas and one is stopped"
+	verify_vol_status "RO" "When there are 2 replicas and one is stopped"
 	verify_controller_rep_state "$REPLICA_IP2" "RW" "Replica2 status after stopping replica1 in 2 replicas case"
 
 	docker start $replica1_id
@@ -718,6 +726,7 @@ test_two_replica_stop_start() {
 }
 
 run_ios() {
+        echo "---------------------------Run IO's-------------------------------"
 	login_to_volume "$CONTROLLER_IP:3260"
 	sleep 2
 	get_scsi_disk
@@ -827,7 +836,7 @@ test_three_replica_stop_start() {
 }
 
 test_ctrl_stop_start() {
-       echo "-----------------Test_three_replica_stop_start---------------"
+       echo "-----------------Test Controller stop/start---------------"
        orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3")
        replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
        replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
@@ -949,6 +958,7 @@ login_to_volume() {
 
 # Wait for iSCSI device node (scsi device) to be created
 get_scsi_disk() {
+        echo "-------------------------Get SCSI Disk---------------------------"
 	device_name=$(iscsiadm -m session -P 3 |grep -i "Attached scsi disk" | awk '{print $4}')
 	i=0
 	while [ -z $device_name ]; do
@@ -962,6 +972,7 @@ get_scsi_disk() {
 			continue;
 		fi
 	done
+        echo "SCSI disk:" $device_name
 }
 
 
@@ -1615,7 +1626,7 @@ test_replica_rpc_close
 test_controller_rpc_close
 test_single_replica_stop_start
 test_replication_factor
-test_two_replica_delete
+#test_two_replica_delete
 test_replica_ip_change
 test_two_replica_stop_start
 test_three_replica_stop_start
@@ -1626,7 +1637,7 @@ test_volume_resize
 run_data_integrity_test_with_fs_creation
 test_clone_feature
 test_duplicate_snapshot_failure
-test_extent_support_file_system
+#test_extent_support_file_system
 test_upgrades
 test_duplicate_data_delete
 run_vdbench_test_on_volume

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -34,6 +34,11 @@ type ReplicaClient struct {
 	httpClient *http.Client
 }
 
+// GetAddress is used to get the address of replica client
+func (c *ReplicaClient) GetAddress() string {
+	return c.address
+}
+
 func NewReplicaClient(address string) (*ReplicaClient, error) {
 	if strings.HasPrefix(address, "tcp://") {
 		address = address[6:]

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -355,7 +355,7 @@ Register:
 	}
 	inject.PanicAfterPrepareRebuild()
 
-	ok, err := t.isRevisionCountAndChainSame(replicaAddress, fromClient, toClient)
+	ok, err := t.isRevisionCountAndChainSame(fromClient, toClient)
 	if err != nil {
 		return err
 	}
@@ -372,7 +372,7 @@ Register:
 
 }
 
-func (t *Task) isRevisionCountAndChainSame(addr string, fromClient, toClient *replicaClient.ReplicaClient) (bool, error) {
+func (t *Task) isRevisionCountAndChainSame(fromClient, toClient *replicaClient.ReplicaClient) (bool, error) {
 	rwReplica, err := fromClient.GetReplica()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>

This commit optimize the resync by checking the revision count. If the revision count of both the replicas
are same and the chain of both healthy and restarted replica is same, it wouldn't go for sync, rather it would be directly added RW replica after verifying the rebuild.