### PR TITLE
fix(replica): remove MonitorChan and improve autoregistration logic

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -36,18 +35,10 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	for {
-		if replicaType == "quorum" {
-			err = task.AddQuorumReplica(replica, s)
-		} else {
-			err = task.AddReplica(replica, s)
-		}
-		if err != nil {
-			logrus.Errorf("Error adding replica, err: %v, will retry", err)
-			time.Sleep(2 * time.Second)
-			s.Close(false)
-			continue
-		}
-		return err
+	if replicaType == "quorum" {
+		err = task.AddQuorumReplica(replica, s)
+	} else {
+		err = task.AddReplica(replica, s)
 	}
+	return err
 }

--- a/app/replica.go
+++ b/app/replica.go
@@ -105,6 +105,10 @@ checkagain:
 		time.Sleep(5 * time.Second)
 		goto checkagain
 	} else {
+		// Replica might be in rebuilding state, closing will change it to
+		// closed state, then it can be registered, else register replica
+		// will fail.
+		_ = s.Close()
 		// this is just to be sure that replica is not attached to
 		// controller. Assumption is replica might be in RO, RW or in
 		// "" state and not removed from controller.

--- a/app/replica.go
+++ b/app/replica.go
@@ -96,6 +96,7 @@ checkagain:
 		time.Sleep(5 * time.Second)
 		goto checkagain
 	} else if state == "ERR" {
+		retryCount++
 		logrus.Infof("Got replica state: %v", state)
 		// replica may be in errored state marked by controller and
 		// not yet removed. The cause of ERR state would be following:

--- a/app/replica.go
+++ b/app/replica.go
@@ -84,22 +84,34 @@ func CheckReplicaState(frontendIP string, replicaIP string) (string, error) {
 }
 
 func AutoConfigureReplica(s *replica.Server, frontendIP string, address string, replicaType string) {
+	retryCount := 10
 checkagain:
+	retryCount--
 	state, err := CheckReplicaState(frontendIP, address)
-	logrus.Infof("Replicastate: %v err:%v", state, err)
-	if err == nil && (state == "" || state == "ERR") {
-		s.Close(false)
-	} else {
+	if err != nil {
+		logrus.Warningf("Failed to check replica state, err: %v, will retry (%v retry left)", err, retryCount)
+		if retryCount == 0 {
+			logrus.Fatalf("Retry count exceeded, Shutting down...")
+		}
 		time.Sleep(5 * time.Second)
 		goto checkagain
-	}
-	AutoRmReplica(frontendIP, address)
-	AutoAddReplica(s, frontendIP, address, replicaType)
-	logrus.Infof("Waiting on MonitorChannel")
-	select {
-	case <-s.MonitorChannel:
-		logrus.Infof("Restart AutoConfigure Process")
+	} else if state == "ERR" {
+		logrus.Infof("Got replica state: %v", state)
+		// replica may be in errored state marked by controller and
+		// not yet removed. The cause of ERR state would be following:
+		// - I/O error while R/W operations
+		// - Failed to revert snapshot
+		time.Sleep(5 * time.Second)
 		goto checkagain
+	} else {
+		// this is just to be sure that replica is not attached to
+		// controller. Assumption is replica might be in RO, RW or in
+		// "" state and not removed from controller.
+		AutoRmReplica(frontendIP, address)
+		if err := AutoAddReplica(s, frontendIP, address, replicaType); err != nil {
+			s.Close()
+			logrus.Fatalf("Failed to add replica to controller, err: %v, Shutting down...", err)
+		}
 	}
 }
 
@@ -225,6 +237,7 @@ func startReplica(c *cli.Context) error {
 		}
 		go AutoConfigureReplica(s, frontendIP, "tcp://"+address, replicaType)
 	}
+
 	for s.Replica() == nil {
 		logrus.Infof("Waiting for s.Replica() to be non nil")
 		time.Sleep(2 * time.Second)

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1159,7 +1159,7 @@ create_snapshot() {
 }
 
 test_duplicate_snapshot_failure() {
-	echo "--------------create_and_verify_snapshot-------------"
+	echo "--------------Test duplicate snapshot Failure-------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
@@ -1736,6 +1736,8 @@ test_duplicate_data_delete() {
 prepare_test_env
 #test_restart_during_prepare_rebuild
 #test_bad_file_descriptor
+test_duplicate_data_delete
+exit
 test_preload
 test_replica_rpc_close
 test_controller_rpc_close

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1734,10 +1734,9 @@ test_duplicate_data_delete() {
 
 
 prepare_test_env
-#test_restart_during_prepare_rebuild
+test_two_replica_stop_start
 #test_bad_file_descriptor
 test_duplicate_data_delete
-exit
 test_preload
 test_replica_rpc_close
 test_controller_rpc_close
@@ -1750,6 +1749,7 @@ test_three_replica_stop_start
 test_ctrl_stop_start
 test_replica_reregistration
 test_replica_controller_continuous_stop_start
+test_restart_during_prepare_rebuild
 test_volume_resize
 run_data_integrity_test_with_fs_creation
 test_clone_feature

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -266,7 +266,7 @@ func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) erro
 
 func (s *Server) CloseReplica(rw http.ResponseWriter, req *http.Request) error {
 	logrus.Infof("CloseReplica")
-	return s.doOp(req, s.s.Close(true))
+	return s.doOp(req, s.s.Close())
 }
 
 func (s *Server) DeleteReplica(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/rpc/server.go
+++ b/replica/rpc/server.go
@@ -52,17 +52,14 @@ func (s *Server) ListenAndServe() error {
 
 		logrus.Infof("New connection from: %v", conn.RemoteAddr())
 
-		go func(conn net.Conn) {
-			server := rpc.NewServer(conn, s.s)
-			if err := server.Handle(); err != nil {
-				// ignore err for below operations,as connection may be
-				// closed from the other side and also files may have
-				// been closed already or not initialized yet.
-				_ = server.Stop() // shutdown fd and conn
-				_ = s.s.Close()   // close all the open files before fataling
-				logrus.Fatalf("Failed to handle connection, err: %v, shutdown replica...", err)
-			}
-
-		}(conn)
+		server := rpc.NewServer(conn, s.s)
+		if err := server.Handle(); err != nil {
+			// ignore err for below operations,as connection may be
+			// closed from the other side and also files may have
+			// been closed already or not initialized yet.
+			_ = server.Stop() // shutdown fd and conn
+			_ = s.s.Close()   // close all the open files before fataling
+			logrus.Fatalf("Failed to handle connection, err: %v, shutdown replica...", err)
+		}
 	}
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -368,13 +368,15 @@ func (s *Server) DeleteAll() error {
 	return err
 }
 
-func (s *Server) Close(signalMonitor bool) error {
+// Close drain the data from HoleCreatorChan and close
+// all the associated files with the replica instance.
+func (s *Server) Close() error {
 	logrus.Infof("Closing replica")
 	s.Lock()
 
+	defer s.Unlock()
 	if s.r == nil {
 		logrus.Infof("Skip closing replica, s.r not set")
-		s.Unlock()
 		return nil
 	}
 
@@ -388,16 +390,10 @@ func (s *Server) Close(signalMonitor bool) error {
 	}
 
 	if err := s.r.Close(); err != nil {
-		s.Unlock()
 		return err
 	}
 
 	s.r = nil
-	s.Unlock()
-	if signalMonitor {
-		logrus.Infof("Signal MonitorChannel")
-		s.MonitorChannel <- struct{}{}
-	}
 	return nil
 }
 

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -58,11 +58,7 @@ func (s *Server) Handle() error {
 		case err = <-ret:
 			if err != nil {
 				if err == errInvalidReq {
-					logrus.Warningf("Failed to serve client: %v, rejecting request, err: %v", s.wire.conn.RemoteAddr(), err)
-					// ignore error, connection may be closed from the other side.
-					_ = s.Stop() // close connection with the invalid client
-					// return nil since, no need to close files
-					return nil
+					logrus.Warningf("Failed to serve client: %v, rejecting request", s.wire.conn.RemoteAddr())
 				}
 				return err
 			}

--- a/rpc/server.go
+++ b/rpc/server.go
@@ -74,7 +74,7 @@ func (s *Server) Handle() error {
 			}
 			since := time.Since(s.pingRecvd)
 			if since >= opPingTimeout*2 {
-				return fmt.Errorf("Couldn't received ping since: %v", since)
+				return fmt.Errorf("Didn't received ping since: %v", since)
 			}
 		}
 	}
@@ -126,12 +126,9 @@ func (s *Server) readWrite(ret chan<- error) {
 			// This is done to ignore the requests from invalid clients
 			// such as Prometheus which by default scraps from all the open
 			// ports.
-			msg, errRead := s.wire.ReadMessage()
-			if errRead == nil {
-				if msg.MagicVersion != MagicVersion {
-					ret <- errInvalidReq
-					break
-				}
+			if msg.MagicVersion != MagicVersion {
+				ret <- errInvalidReq
+				break
 			}
 			ret <- err
 			break

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -113,6 +113,16 @@ func (w *Wire) Read() (*Message, error) {
 	return &msg, nil
 }
 
+// ReadMessage read the response from the client
+func (w *Wire) ReadMessage() (Message, error) {
+	var msg Message
+	if err := binary.Read(w.reader, binary.LittleEndian, &msg.MagicVersion); err != nil {
+		logrus.Errorf("Read msg.Version failed, Error: %v", err)
+		return Message{}, err
+	}
+	return msg, nil
+}
+
 func (w *Wire) CloseRead() error {
 	if conn, ok := w.conn.(*net.TCPConn); ok {
 		logrus.Info("Closing read on RPC connection")

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -77,7 +77,7 @@ func (w *Wire) Read() (*Message, error) {
 		return nil, err
 	}
 	if msg.MagicVersion != MagicVersion {
-		return nil, fmt.Errorf("Wrong API version received: 0x%x", &msg.MagicVersion)
+		return &msg, fmt.Errorf("Wrong API version received: 0x%x", &msg.MagicVersion)
 	}
 	if err := binary.Read(w.reader, binary.LittleEndian, &msg.Seq); err != nil {
 		logrus.Errorf("Read msg.Seq failed, Error: %v", err)
@@ -111,16 +111,6 @@ func (w *Wire) Read() (*Message, error) {
 	}
 
 	return &msg, nil
-}
-
-// ReadMessage read the response from the client
-func (w *Wire) ReadMessage() (Message, error) {
-	var msg Message
-	if err := binary.Read(w.reader, binary.LittleEndian, &msg.MagicVersion); err != nil {
-		logrus.Errorf("Read msg.Version failed, Error: %v", err)
-		return Message{}, err
-	}
-	return msg, nil
 }
 
 func (w *Wire) CloseRead() error {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -345,7 +345,8 @@ Register:
 	logrus.Infof("Adding replica %s in WO mode", replicaAddress)
 	_, err = t.client.CreateReplica(replicaAddress)
 	if err != nil {
-		logrus.Errorf("Failed to create replica, error: %s", err.Error())
+		logrus.Errorf("Failed to create replica, error: %s, will retry", err.Error())
+		time.Sleep(5 * time.Second)
 		// cases for above failure:
 		// - controller is not reachable
 		// - replica is already added (remove replica in progress)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -303,7 +303,7 @@ Register:
 	// replica might be in WO state and opened files but failed to
 	// get added to controller since rebuild is happening on other replicas
 	// please read the comments below for more info.
-	s.Close()
+	_ = s.Close()
 	logrus.Infof("Get Volume info from controller")
 	volume, err := t.client.GetVolume()
 	if err != nil {


### PR DESCRIPTION
This commit fixes the issue, where replica is getting blocked on
MonitorChan for forever while registration/sync process if controller
is restarted or removed the replicas due to network disconnection
or any other explicit reason.

Now replicas will be fataled as soon as controller is disconnected
after closing the files gracefully.

Upgrade scenarios have been changed also, now user should first upgrade
the controller, which will stop the replicas and then upgrade the
replicas one by one.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>