### PR TITLE
fix(controller): set c.StartSignalled to false in case of error

### DIFF
--- a/controller/control.go
+++ b/controller/control.go
@@ -519,6 +519,7 @@ func (c *Controller) rmReplicaFromRegisteredReplicas(address string) {
 	logrus.Infof("Remove replica %s from register replica map", address)
 	delete(c.RegisteredReplicas, address)
 	c.StartSignalled = false
+	c.MaxRevReplica = ""
 }
 
 func (c *Controller) RemoveReplicaNoLock(address string) error {


### PR DESCRIPTION
This commit fix the issue openebs/openebs#2600, where replicas, were
not getting attached to controller after upgrade due to a missing
corner case in startReplica, where c.StartSignalled is not getting
updated to false in case of any error while adding the replicas.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>