### PR TITLE
cherry-pick(replica): remove MonitorChan and improve autoregistration logic

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -36,18 +35,10 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	for {
-		if replicaType == "quorum" {
-			err = task.AddQuorumReplica(replica, s)
-		} else {
-			err = task.AddReplica(replica, s)
-		}
-		if err != nil {
-			logrus.Errorf("Error adding replica, err: %v, will retry", err)
-			time.Sleep(2 * time.Second)
-			s.Close(false)
-			continue
-		}
-		return err
+	if replicaType == "quorum" {
+		err = task.AddQuorumReplica(replica, s)
+	} else {
+		err = task.AddReplica(replica, s)
 	}
+	return err
 }

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -x
+#set -x
 PS4='${LINENO}: '
 CONTROLLER_IP="172.18.0.2"
 REPLICA_IP1="172.18.0.3"
@@ -122,7 +122,7 @@ verify_container_dead() {
 	replica_id=`echo $1 | cut -b 1-12`
 	echo $replica_id
 	while [ $i -lt 100 ]; do
-		cnt=`docker ps -a | grep $replica_id | grep -w Exited | wc -l`
+		cnt=`docker ps -a | grep $replica_id | grep -w Restarting | wc -l`
 		if [ $cnt -eq 1 ]; then
 			return
 		fi
@@ -252,7 +252,7 @@ verify_go_routine_leak() {
     passed=0
     req_cnt=0
     while [ "$i" != 30 ]; do
-            curl http://$2:9503 &
+            curl -m 5 http://$2:9503 &
             i=`expr $i + 1`
             sleep 2
     done
@@ -292,6 +292,7 @@ verify_vol_status() {
 
 verify_replica_mode() {
 	i=0
+        passed=0
 	while [ "$i" != 50 ]; do
 		date
 		rep_mode=`curl http://$3:9502/v1/replicas | jq '.data[0].replicamode' | tr -d '"'`
@@ -406,14 +407,14 @@ start_controller() {
 
 # start_replica CONTROLLER_IP REPLICA_IP folder_name
 start_replica() {
-	replica_id=$(docker run -d --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI \
+	replica_id=$(docker run --restart unless-stopped -d --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI \
 		launch replica --frontendIP "$1" --listen "$2":9502 --size 2g /"$3")
 	echo "$replica_id"
 }
 
 # start_replica CONTROLLER_IP REPLICA_IP folder_name
 start_debug_replica() {
-	replica_id=$(docker run -d --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI_DEBUG \
+	replica_id=$(docker run --restart unless-stopped -d --net stg-net --ip "$2" -P --expose 9502-9504 -v /tmp/"$3":/"$3" $JI_DEBUG \
 	env $4=$5  $6=$7 launch replica --frontendIP "$1" --listen "$2":9502 --size 2g /"$3")
 	echo "$replica_id"
 }
@@ -530,7 +531,6 @@ test_single_replica_stop_start() {
 	sleep 5
 
 	verify_replica_cnt "1" "Single replica count test"
-
 	docker stop $replica1_id
 	sleep 5
 
@@ -675,8 +675,14 @@ verify_bad_file_descriptor_error() {
 	# Replica will be closed upon controller disconnection
 	run_ios_rand_write "1"
 	docker stop $orig_controller_id
-	sleep 1
+
+	verify_container_dead $replica1_id "controller restart in verify_bad_file_descriptor_error test"
+	verify_container_dead $replica2_id "controller restart in verify_bad_file_descriptor_error test"
+
+	sleep 5
 	docker start $orig_controller_id
+	docker start $replica1_id
+	docker start $replica2_id
 	verify_replica_cnt "2" "Two replica count test when controller is stopped in test_bad_file_descriptor"
 	verify_vol_status "RW" "When there are 2 replicas and controller is stopped in test_bad_file_descriptor"
 
@@ -1153,7 +1159,7 @@ create_snapshot() {
 }
 
 test_duplicate_snapshot_failure() {
-	echo "--------------create_and_verify_snapshot-------------"
+	echo "--------------Test duplicate snapshot Failure-------------"
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2")
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
@@ -1336,9 +1342,9 @@ test_upgrade() {
 }
 
 test_upgrades() {
-       test_upgrade "openebs/jiva:0.7.0" "replica-controller"
-       test_upgrade "openebs/jiva:0.8.0" "replica-controller"
        test_upgrade "openebs/jiva:0.8.0" "controller-replica"
+       test_upgrade "openebs/jiva:0.8.2" "controller-replica"
+       test_upgrade "openebs/jiva:0.9.0" "replica-controller"
 }
 
 di_test_on_raw_disk() {
@@ -1541,6 +1547,8 @@ test_restart_during_prepare_rebuild() {
 	verify_replica_mode 1 "replica mode in test with restart during prepare rebuild" "$REPLICA_IP1" "RW"
 	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "PANIC_AFTER_PREPARE_REBUILD" "TRUE")
 	verify_container_dead $replica2_id "restart during prepare rebuild"
+	docker stop $replica2_id
+        replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	rev_counter1=`cat /tmp/vol1/revision.counter`
 	rev_counter2=`cat /tmp/vol2/revision.counter`
 	if [ $rev_counter1 -ne $rev_counter2 ]; then
@@ -1728,8 +1736,15 @@ test_duplicate_data_delete() {
 
 
 prepare_test_env
+test_single_replica_stop_start
 test_restart_during_prepare_rebuild
-test_bad_file_descriptor
+test_two_replica_stop_start
+test_three_replica_stop_start
+test_ctrl_stop_start
+test_replica_controller_continuous_stop_start
+test_restart_during_prepare_rebuild
+#test_bad_file_descriptor
+test_duplicate_data_delete
 test_preload
 test_replica_rpc_close
 test_controller_rpc_close
@@ -1737,17 +1752,12 @@ test_single_replica_stop_start
 test_replication_factor
 #test_two_replica_delete
 test_replica_ip_change
-test_two_replica_stop_start
-test_three_replica_stop_start
-test_ctrl_stop_start
 test_replica_reregistration
-test_replica_controller_continuous_stop_start
 test_volume_resize
 run_data_integrity_test_with_fs_creation
 test_clone_feature
 test_duplicate_snapshot_failure
 #test_extent_support_file_system
 test_upgrades
-test_duplicate_data_delete
 run_vdbench_test_on_volume
 run_libiscsi_test_suite

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM openebs/jiva:base-xenial-20180417
+FROM openebs/jiva:base-xenial-20190515
 #RUN apt-get update && apt-get install -y kmod curl nfs-common fuse \
 #        libibverbs1 librdmacm1 libconfig-general-perl libaio1 \
 #        && rm -rf /var/lib/apt/lists/*

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -266,7 +266,7 @@ func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) erro
 
 func (s *Server) CloseReplica(rw http.ResponseWriter, req *http.Request) error {
 	logrus.Infof("CloseReplica")
-	return s.doOp(req, s.s.Close(true))
+	return s.doOp(req, s.s.Close())
 }
 
 func (s *Server) DeleteReplica(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/rpc/server.go
+++ b/replica/rpc/server.go
@@ -52,10 +52,14 @@ func (s *Server) ListenAndServe() error {
 
 		logrus.Infof("New connection from: %v", conn.RemoteAddr())
 
-		go func(conn net.Conn) {
-			server := rpc.NewServer(conn, s.s)
-			server.SetMonitorChannel(s.s.MonitorChannel)
-			server.Handle()
-		}(conn)
+		server := rpc.NewServer(conn, s.s)
+		if err := server.Handle(); err != nil {
+			// ignore err for below operations,as connection may be
+			// closed from the other side and also files may have
+			// been closed already or not initialized yet.
+			_ = server.Stop() // shutdown fd and conn
+			_ = s.s.Close()   // close all the open files before fataling
+			logrus.Fatalf("Failed to handle connection, err: %v, shutdown replica...", err)
+		}
 	}
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -368,13 +368,15 @@ func (s *Server) DeleteAll() error {
 	return err
 }
 
-func (s *Server) Close(signalMonitor bool) error {
+// Close drain the data from HoleCreatorChan and close
+// all the associated files with the replica instance.
+func (s *Server) Close() error {
 	logrus.Infof("Closing replica")
 	s.Lock()
 
+	defer s.Unlock()
 	if s.r == nil {
 		logrus.Infof("Skip closing replica, s.r not set")
-		s.Unlock()
 		return nil
 	}
 
@@ -388,16 +390,10 @@ func (s *Server) Close(signalMonitor bool) error {
 	}
 
 	if err := s.r.Close(); err != nil {
-		s.Unlock()
 		return err
 	}
 
 	s.r = nil
-	s.Unlock()
-	if signalMonitor {
-		logrus.Infof("Signal MonitorChannel")
-		s.MonitorChannel <- struct{}{}
-	}
 	return nil
 }
 

--- a/rpc/wire.go
+++ b/rpc/wire.go
@@ -77,7 +77,7 @@ func (w *Wire) Read() (*Message, error) {
 		return nil, err
 	}
 	if msg.MagicVersion != MagicVersion {
-		return nil, fmt.Errorf("Wrong API version received: 0x%x", &msg.MagicVersion)
+		return &msg, fmt.Errorf("Wrong API version received: 0x%x", &msg.MagicVersion)
 	}
 	if err := binary.Read(w.reader, binary.LittleEndian, &msg.Seq); err != nil {
 		logrus.Errorf("Read msg.Seq failed, Error: %v", err)


### PR DESCRIPTION
Cherry-pick:
- fix(replica): remove MonitorChan and improve autoregistration logic
-  chore(build): update the base ubuntu to latest

This commit fixes the issue, where replica is getting blocked on
MonitorChan for forever while registration/sync process if controller
is restarted or removed the replicas due to network disconnection
or any other explicit reason.

Now replicas will be fataled as soon as controller is disconnected
after closing the files gracefully.

Added a new function ReadMessage to read the reqeust's MagicVersion
to reject the request from invalid clients (exp: Prometheus) on data
connection, which by default scrapes from all the open ports.

Upgrade scenarios have been changed also, now user should first upgrade
the controller, which will stop the replicas and then upgrade the
replicas one by one.




Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>