### PR TITLE
fix(jiva): handle corner cases for snapshot delete

### DIFF
--- a/replica/backup.go
+++ b/replica/backup.go
@@ -189,6 +189,17 @@ type Hole struct {
 
 var HoleCreatorChan = make(chan Hole, 1000000)
 
+func holeDrainer() {
+	types.DrainOps = types.DrainStart
+	HoleCreatorChan <- Hole{}
+	for {
+		if types.DrainOps == types.DrainDone {
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
 // drainHoleCreatorChan is called if replica is closed, to drain
 // all the data for punching hole in the HoleCreatorChan.
 func drainHoleCreatorChan() {

--- a/replica/backup.go
+++ b/replica/backup.go
@@ -226,6 +226,9 @@ func CreateHoles() error {
 			types.DrainOps = types.DrainDone
 			continue
 		}
+		if (Hole{}) == hole {
+			continue
+		}
 		fd = hole.f.Fd()
 	retry:
 		if err := syscall.Fallocate(int(fd),

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -17,13 +17,19 @@ type fileType struct {
 
 type diffDisk struct {
 	rmLock sync.Mutex
-	// mapping of sector to index in the files array. a value of 0 is special meaning
-	// we don't know the location yet.
+	// mapping of sector to index in the files array. a value of 0
+	// is special meaning we don't know the location yet.
 	location          []byte
 	UsedLogicalBlocks int64
 	UsedBlocks        int64
-	// list of files in child, parent, grandparent, etc order.
-	// index 0 is nil and index 1 is the active write layer
+	// list of files in grandparent, parent, child order
+	// For exp: H->S4->S3->S2->S1->S0
+	// H is active file, and S4 is latest snapshot and is
+	// parent of H. H has no child, S0 has no parent.
+	// So files = {nil, S0, S1, S2, S3, S4, H}
+	// index 0 is nil and index 1 is base snapshot and last index
+	// is the active write layer.
+	// First index is nil for doing comparisons.
 	files []types.DiffDisk
 	// list representing file index marked true/false for
 	// userCreated/Auto-Created accordingly. It should always be updated
@@ -34,6 +40,22 @@ type diffDisk struct {
 	sectorSize int64
 }
 
+// RemoveIndex remove the index from list the files
+// and update the location of offsets in respective
+// new files where it is merged before deletion of
+// the snapshot.
+//
+// Let's consider this case: H->S4->US3->S2->S1->S0
+// Update d.location and latest user created snapshot
+// index if S2 is deleted, US3 will take position of S2
+// So resultant chain is H->S4->US3->S1->S0
+//
+// You can notice here as position of S0 and S1 is still
+// the same but we shifting the positions of the childrens.
+// NOTE: UserCreatedSnap contains the truth value of
+// whether snapshot is UserCreated or not in increasing
+// order of index. i.e, last index will have the truthy
+// value of latest snapshot
 func (d *diffDisk) RemoveIndex(index int) error {
 	if err := d.files[index].Close(); err != nil {
 		return err
@@ -42,19 +64,15 @@ func (d *diffDisk) RemoveIndex(index int) error {
 	//TODO Decide if d.location should be preloaded again over here
 	for i := 0; i < len(d.location); i++ {
 		if d.location[i] > byte(index) && d.location[i] != byte(1) {
-			// set back to unknown
 			d.location[i]--
 		}
 	}
 
 	d.files = append(d.files[:index], d.files[index+1:]...)
-	// only update latest snapshot index if deleting user created snapshot
-	if d.UserCreatedSnap[index] {
-		d.UserCreatedSnap = append(d.UserCreatedSnap[:index], d.UserCreatedSnap[index+1:]...)
-		for i, userCreated := range d.UserCreatedSnap {
-			if userCreated {
-				d.SnapIndx = i
-			}
+	d.UserCreatedSnap = append(d.UserCreatedSnap[:index], d.UserCreatedSnap[index+1:]...)
+	for i, userCreated := range d.UserCreatedSnap {
+		if userCreated {
+			d.SnapIndx = i
 		}
 	}
 

--- a/replica/diff_disk.go
+++ b/replica/diff_disk.go
@@ -41,17 +41,20 @@ func (d *diffDisk) RemoveIndex(index int) error {
 
 	//TODO Decide if d.location should be preloaded again over here
 	for i := 0; i < len(d.location); i++ {
-		if d.location[i] >= byte(index) {
+		if d.location[i] > byte(index) && d.location[i] != byte(1) {
 			// set back to unknown
-			d.location[i] = 0
+			d.location[i]--
 		}
 	}
 
 	d.files = append(d.files[:index], d.files[index+1:]...)
-	d.UserCreatedSnap = append(d.UserCreatedSnap[:index], d.UserCreatedSnap[index+1:]...)
-	for i, userCreated := range d.UserCreatedSnap {
-		if userCreated {
-			d.SnapIndx = i
+	// only update latest snapshot index if deleting user created snapshot
+	if d.UserCreatedSnap[index] {
+		d.UserCreatedSnap = append(d.UserCreatedSnap[:index], d.UserCreatedSnap[index+1:]...)
+		for i, userCreated := range d.UserCreatedSnap {
+			if userCreated {
+				d.SnapIndx = i
+			}
 		}
 	}
 

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -296,6 +296,9 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 	c.Assert(r.diskChildrenMap["volume-snap-001.img"]["volume-snap-002.img"], Equals, true)
 	c.Assert(r.diskChildrenMap["volume-snap-002.img"], IsNil)
 
+	// Assign empty function as HoleCreatorChan is not initialized
+	// Since this is just an UT only individual function is tested.
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-snap-002.img")
 	c.Assert(err, IsNil)
 
@@ -306,6 +309,7 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 
 	c.Assert(r.diskChildrenMap["volume-snap-001.img"], IsNil)
 
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-snap-001.img")
 	c.Assert(err, IsNil)
 
@@ -346,6 +350,7 @@ func (s *TestSuite) TestRemoveLast(c *C) {
 	c.Assert(r.activeDiskData[1].Name, Equals, "volume-snap-000.img")
 	c.Assert(r.activeDiskData[1].Parent, Equals, "")
 
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-snap-000.img")
 	c.Assert(err, IsNil)
 	c.Assert(len(r.activeDiskData), Equals, 3)
@@ -394,22 +399,24 @@ func (s *TestSuite) TestRemoveMiddle(c *C) {
 	c.Assert(r.activeDiskData[1].Name, Equals, "volume-snap-000.img")
 	c.Assert(r.activeDiskData[1].Parent, Equals, "")
 
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-snap-001.img")
-	c.Assert(err, IsNil)
-	c.Assert(len(r.activeDiskData), Equals, 3)
-	c.Assert(len(r.volume.files), Equals, 3)
+	c.Assert(err, NotNil)
+	c.Assert(len(r.activeDiskData), Equals, 4)
+	c.Assert(len(r.volume.files), Equals, 4)
 	c.Assert(r.info.Head, Equals, "volume-head-002.img")
-	c.Assert(r.activeDiskData[2].Name, Equals, "volume-head-002.img")
+	c.Assert(r.activeDiskData[3].Name, Equals, "volume-head-002.img")
+	c.Assert(r.activeDiskData[3].Parent, Equals, "volume-snap-001.img")
+	c.Assert(r.activeDiskData[2].Name, Equals, "volume-snap-001.img")
 	c.Assert(r.activeDiskData[2].Parent, Equals, "volume-snap-000.img")
 	c.Assert(r.activeDiskData[1].Name, Equals, "volume-snap-000.img")
 	c.Assert(r.activeDiskData[1].Parent, Equals, "")
 
-	c.Assert(len(r.diskData), Equals, 2)
+	c.Assert(len(r.diskData), Equals, 3)
 	c.Assert(r.diskData["volume-snap-000.img"].Parent, Equals, "")
-	c.Assert(r.diskData["volume-head-002.img"].Parent, Equals, "volume-snap-000.img")
+	c.Assert(r.diskData["volume-head-002.img"].Parent, Equals, "volume-snap-001.img")
 
 	c.Assert(len(r.diskChildrenMap["volume-snap-000.img"]), Equals, 1)
-	c.Assert(r.diskChildrenMap["volume-snap-000.img"]["volume-head-002.img"], Equals, true)
 	c.Assert(r.diskChildrenMap["volume-head-002.img"], IsNil)
 }
 
@@ -442,6 +449,7 @@ func (s *TestSuite) TestRemoveFirst(c *C) {
 	c.Assert(r.activeDiskData[1].Name, Equals, "volume-snap-000.img")
 	c.Assert(r.activeDiskData[1].Parent, Equals, "")
 
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-head-002.img")
 	c.Assert(err, NotNil)
 }
@@ -503,6 +511,7 @@ func (s *TestSuite) TestRemoveOutOfChain(c *C) {
 	c.Assert(r.diskChildrenMap["volume-snap-001.img"]["volume-snap-002.img"], Equals, true)
 	c.Assert(r.diskChildrenMap["volume-snap-002.img"], IsNil)
 
+	r.holeDrainer = func() {}
 	err = r.RemoveDiffDisk("volume-snap-001.img")
 	c.Assert(err, IsNil)
 	c.Assert(len(r.activeDiskData), Equals, 3)

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -561,9 +561,9 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	*/
 
 	actions, err := r.PrepareRemoveDisk("001")
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 	c.Assert(actions, HasLen, 0)
-	c.Assert(r.activeDiskData[2].Removed, Equals, true)
+	c.Assert(r.activeDiskData[2].Removed, Equals, false)
 
 	actions, err = r.PrepareRemoveDisk("volume-snap-000.img")
 	c.Assert(err, IsNil)
@@ -591,15 +591,15 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 
 	/* https://github.com/openebs/jiva/issues/184 */
 	actions, err = r.PrepareRemoveDisk("002")
-	c.Assert(err, IsNil)
-	c.Assert(actions, HasLen, 2)
-	c.Assert(actions[0].Action, Equals, OpCoalesce)
-	c.Assert(actions[0].Source, Equals, "volume-snap-001.img")
-	c.Assert(actions[0].Target, Equals, "volume-snap-002.img")
-	c.Assert(actions[1].Action, Equals, OpReplace)
-	c.Assert(actions[1].Source, Equals, "volume-snap-001.img")
-	c.Assert(actions[1].Target, Equals, "volume-snap-002.img")
-
+	c.Assert(err, NotNil)
+	c.Assert(actions, HasLen, 0)
+	/*	c.Assert(actions[0].Action, Equals, OpCoalesce)
+		c.Assert(actions[0].Source, Equals, "volume-snap-001.img")
+		c.Assert(actions[0].Target, Equals, "volume-snap-002.img")
+		c.Assert(actions[1].Action, Equals, OpReplace)
+		c.Assert(actions[1].Source, Equals, "volume-snap-001.img")
+		c.Assert(actions[1].Target, Equals, "volume-snap-002.img")
+	*/
 	err = r.Snapshot("003", true, now)
 	c.Assert(err, IsNil)
 
@@ -620,19 +620,19 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 
 	actions, err = r.PrepareRemoveDisk("003")
 	c.Assert(err, IsNil)
-	c.Assert(actions, HasLen, 4)
-	c.Assert(actions[0].Action, Equals, OpCoalesce)
-	c.Assert(actions[0].Source, Equals, "volume-snap-002.img")
-	c.Assert(actions[0].Target, Equals, "volume-snap-003.img")
+	c.Assert(actions, HasLen, 2)
+	/*	c.Assert(actions[0].Action, Equals, OpCoalesce)
+		c.Assert(actions[0].Source, Equals, "volume-snap-002.img")
+		c.Assert(actions[0].Target, Equals, "volume-snap-003.img")
+		c.Assert(actions[1].Action, Equals, OpReplace)
+		c.Assert(actions[1].Source, Equals, "volume-snap-002.img")
+		c.Assert(actions[1].Target, Equals, "volume-snap-003.img")
+	*/c.Assert(actions[0].Action, Equals, OpCoalesce)
+	c.Assert(actions[0].Source, Equals, "volume-snap-003.img")
+	c.Assert(actions[0].Target, Equals, "volume-snap-004.img")
 	c.Assert(actions[1].Action, Equals, OpReplace)
-	c.Assert(actions[1].Source, Equals, "volume-snap-002.img")
-	c.Assert(actions[1].Target, Equals, "volume-snap-003.img")
-	c.Assert(actions[2].Action, Equals, OpCoalesce)
-	c.Assert(actions[2].Source, Equals, "volume-snap-003.img")
-	c.Assert(actions[2].Target, Equals, "volume-snap-004.img")
-	c.Assert(actions[3].Action, Equals, OpReplace)
-	c.Assert(actions[3].Source, Equals, "volume-snap-003.img")
-	c.Assert(actions[3].Target, Equals, "volume-snap-004.img")
+	c.Assert(actions[1].Source, Equals, "volume-snap-003.img")
+	c.Assert(actions[1].Target, Equals, "volume-snap-004.img")
 	c.Assert(r.activeDiskData[4].Removed, Equals, true)
 }
 

--- a/replica/server.go
+++ b/replica/server.go
@@ -380,14 +380,9 @@ func (s *Server) Close() error {
 		return nil
 	}
 
-	types.DrainOps = types.DrainStart
-	HoleCreatorChan <- Hole{}
-	for {
-		if types.DrainOps == types.DrainDone {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
+	// r.holeDrainer is initialized at construct
+	// function in replica.go
+	s.r.holeDrainer()
 
 	if err := s.r.Close(); err != nil {
 		return err


### PR DESCRIPTION
This commit fixes the following corner cases around delete snapshot command
- return error if it's the latest snapshot
- Optimizing lun map, so that there won't be need of preload
- Drain the data for punch hole from HoleCreatorChan, since file will be
  deleted and closed, therefore avoiding case of bad file descriptor
  error.

Command to list snapshot: `longhorn snapshot ls`
Command to remove snapshot: `longhorn snapshot rm <snap_name>`

Note: We may miss punching holes for few blocks, if it's already in
progress and delete snapshot request comes up.

Test cases that need to be covered:
1. H->S2->S1->S0:
   - Where S0 is autogenerated, S1 is autogenerated but both have data
     on different offset. S2 is user created with same data as S0 and
     delete S1.
   - Where S0 is autogenerated, S1 is autogenerated but both have data
     on different offset. S2 is user created with same data as S0 and
     delete S0.
   - Where S0 is autogenerated, S1 is usercreated but have data on the
     same offsets. S2 is autogenerated and data on the same offset and
     delete S1.
    - Where S0 is autogenerated, S1 is usercreated but have data on the
     same offsets. S2 is autogenerated and data on the same offset and
     delete S0.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>