### PR TITLE
feat(snap deletion): add rest api to delete snapshot

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -28,7 +28,7 @@ RUN rm -f /bin/sh && ln -s /bin/bash /bin/sh
 # Install Go & tools
 ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
     GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
-RUN wget -O - https://storage.googleapis.com/golang/go1.10.3.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
+RUN wget -O - https://storage.googleapis.com/golang/go1.12.4.linux-${!GOLANG_ARCH}.tar.gz | tar -xzf - -C /usr/local && \
     go get github.com/rancher/trash && go get -u golang.org/x/lint/golint && go get github.com/prometheus/client_golang/prometheus/promhttp
 
 # Docker

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -104,7 +104,6 @@ verify_replica_cnt() {
 	i=0
 	replica_cnt=""
 	while [ "$replica_cnt" != "$1" ]; do
-		date
 		replica_cnt=`curl -s http://$CONTROLLER_IP:9501/v1/volumes | jq '.data[0].replicaCount'`
 		i=`expr $i + 1`
 		if [ "$i" == 100 ]; then
@@ -170,7 +169,7 @@ verify_rw_rep_count() {
                fi
                sleep 2
        done
-       echo "0"
+       echo "Verify RW Replica status test -- passed"
 }
 
 #returns number of replicas connected to controller in RW mode
@@ -247,7 +246,6 @@ verify_controller_quorum() {
 verify_go_routine_leak() {
     echo "---------------------Verify goroutine leak-------------------------"
     i=0
-    date
     no_of_goroutine=`curl http://$2:9502/debug/pprof/goroutine?debug=1 | grep goroutine | awk '{ print $4}'`
     passed=0
     req_cnt=0
@@ -272,7 +270,6 @@ verify_vol_status() {
 	i=0
 	rw_status=""
 	while [ "$rw_status" != "$1" ]; do
-		date
 		ro_status=`curl -s http://$CONTROLLER_IP:9501/v1/volumes | jq '.data[0].readOnly' | tr -d '"'`
 		if [ "$ro_status" == "true" ]; then
 			rw_status="RO"
@@ -957,19 +954,13 @@ test_ctrl_stop_start() {
        replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
        replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3")
 
-       if [ $(verify_rw_rep_count "3") != 0 ]; then
-               echo "test_ctrl_stop_start() Verify_rw_rep_count failed"
-               collect_logs_and_exit
-       fi
+       verify_rw_rep_count "3"
 
        docker stop $orig_controller_id
        docker start $orig_controller_id
 
-       if [ $(verify_rw_rep_count "3") != 0 ]; then
-               echo "test_ctrl_stop_start() Verify_rw_rep_count failed"
-               collect_logs_and_exit
-       fi
-
+       verify_rw_rep_count "3"
+       echo "Test Controller stop/start test --passed"
        cleanup
 }
 
@@ -1342,9 +1333,7 @@ test_upgrade() {
 }
 
 test_upgrades() {
-       test_upgrade "openebs/jiva:0.8.0" "controller-replica"
-       test_upgrade "openebs/jiva:0.8.2" "controller-replica"
-       test_upgrade "openebs/jiva:0.9.0" "replica-controller"
+       test_upgrade "openebs/jiva:1.0.0" "replica-controller"
 }
 
 di_test_on_raw_disk() {
@@ -1735,6 +1724,8 @@ test_duplicate_data_delete() {
 	cleanup
 }
 
+# run_dd run io's on the block device in $1 file and skip $2 no of
+# blocks in $1 file.
 run_dd() {
 	dd if=/dev/urandom of=$1 bs=4k count=100000 seek=$2
         sync
@@ -1743,6 +1734,9 @@ run_dd() {
         echo "$hash1"
 }
 
+
+# copy_files_into_mnt_dir login to iscsi target and discovers block device
+# format it and copy's $1 and $2 files
 copy_files_into_mnt_dir() {
 	echo "------------------Copy files into mnt dir------------------"
 	login_to_volume "$CONTROLLER_IP:3260"
@@ -1771,32 +1765,47 @@ copy_files_into_mnt_dir() {
 
 verify_delete_snapshot_failure() {
 	echo "-------------Verify delete snapshots failure---------------"
-        declare -a errors=("Failed to coalesce" "Can not remove a snapshot because tcp://"$1":9502 is rebuilding" "A Snapshot is already being deleted" "Can not remove a snapshot because, RF: 3, replica count: 2")
-        i=""
-        cnt=0
-        snap=""
-        snap_ls="docker exec "$orig_controller_id" jivactl snapshot ls"
+        declare -a errors=("Failed to coalesce" "Replica tcp://"$1":9502 mode is" "Snapshot deletion process is in progress" "Can not remove a snapshot because, RF: 3, replica count: 2" "Client.Timeout exceeded while awaiting headers")
+        local i=""
+        local cnt=0
+        local snap=""
+        local msg=""
+        local snap_ls="docker exec "$orig_controller_id" jivactl snapshot ls"
         snap=$(eval $snap_ls | tail -1)
         cmd="docker exec "$orig_controller_id" jivactl snapshot rm "$snap""
         msg=$(eval $cmd 2>&1)
+        echo "$msg"
         for i in "${errors[@]}"
         do
+                # match the substring with the given array of strings
                 if [[ "$msg" == *"$i"* ]]; then
                         cnt=$((cnt + 1))
-                        echo "Verify delete snapshot failure" -- "passed"
+                        echo "Verify delete snapshot failure -- passed"
                         return
                 fi
         done
-        if [ "$cnt" == "0" ]; then
-                echo "Verify delete snapshot failure" -- "failed"
+        if [ "$cnt" == "0" ] && [ "$2" == "true" ]; then
+                if [[ "$msg" == *"deleted snapshot"* ]]; then
+                        echo "Verify delete snapshot failure -- passed"
+                        return
+                else
+                        echo "Verify delete snapshot failure -- failed"
+                        collect_logs_and_exit
+                        return
+                fi
+        elif [ "$cnt" == "0" ]; then
+                echo "Verify delete snapshot failure -- failed"
+                collect_logs_and_exit
         fi
 
 }
 
+# delete_snapshot delete all the snapshot except for Head and latest snapshot.
 delete_snapshots() {
 	echo "---------------------delete snapshots----------------------"
-        snaps=""
-        i=3
+        local snaps=""
+        local i=3
+        local lines=""
         snaps=$(docker exec -it "$orig_controller_id" jivactl snapshot ls)
         lines=$(echo "$snaps" | wc -w)
         while [ "$i" -lt "$lines" ]
@@ -1808,6 +1817,9 @@ delete_snapshots() {
         done
 }
 
+# mount_and_verify_hash does login to iscsi target and mount the block
+# device to /mnt/store dir and verifies checksum ($1, $3) of file $2
+# and $4 respectively.
 mount_and_verify_hash() {
 	echo "--------------------Mount and verify hash------------------"
        	login_to_volume "$CONTROLLER_IP:3260"
@@ -1837,6 +1849,7 @@ mount_and_verify_hash() {
 	fi
 }
 
+# start_stop_replica start and stop replica $2 for $1 no of times
 start_stop_replica() {
 	echo "----------------------Start stop replica---------------------"
         i=0
@@ -1849,29 +1862,43 @@ start_stop_replica() {
         done
 }
 
+# verify if snapshot deletion has been failed while replica restarts
+# and other cases. $1 and $2 are the files that to be
 verify_replica_restart_while_snap_deletion() {
 	echo "--------Verify replica restart while snap deletion--------"
-        copy_files_into_mnt_dir "$1" "$3" &
-        start_stop_replica "4" "$replica3_id"
+        copy_files_into_mnt_dir "$1" "$2" &
+        sleep 5
+        start_stop_replica "4" "$3"
         verify_replica_cnt "3" "Three replica count test"
+        sudo docker stop "$3"
         wait
-        sleep 1
-        start_stop_replica "1" "$replica3_id" &
-        sleep 1
-        verify_delete_snapshot_failure "$REPLICA_IP3"
-        verify_replica_cnt "3" "Three replica count test"
-        wait
+        # case 1: Rebuild in progress
+        sudo docker start "$3"
+        sleep 5
+        verify_delete_snapshot_failure "$4" "false"
+        verify_rw_rep_count "3"
 
-        sudo docker stop "$replica3_id"
-        verify_delete_snapshot_failure "$REPLICA_IP3"
+        # case 2: Replication factor is not met
+        sudo docker stop "$3"
+        verify_delete_snapshot_failure "$4" "false"
+
+        # case 3: Coalesce failed or client timeout exceeded
         sleep 2
-        sudo docker start "$replica3_id"
-
+        sudo docker start "$3"
         verify_replica_cnt "3" "Three replica count test"
         verify_rw_rep_count "3"
-        verify_delete_snapshot_failure "$REPLICA_IP3" &
+        verify_delete_snapshot_failure "$4" & "false"
         sleep 2
-        sudo docker stop "$replica3_id"
+        sudo docker stop "$3"
+        wait
+
+        # case 4: Already a snapshot being deleted
+        sudo docker start "$3"
+        verify_replica_cnt "3" "Three replica count test"
+        verify_rw_rep_count "3"
+        verify_delete_snapshot_failure "$4" "true" &
+        sleep 0.5
+        verify_delete_snapshot_failure "$4" "false"
         wait
 }
 
@@ -1894,6 +1921,9 @@ test_delete_snapshot() {
         hash_file2=$(run_dd "$file2" "100000")
         copy_files_into_mnt_dir "$file1" "$file2" &
 
+        # start stop replica such that data is written across various
+        # snapshots
+        sleep 1
         start_stop_replica "4" "$replica3_id"
         wait
 
@@ -1916,16 +1946,25 @@ test_delete_snapshot() {
 
         delete_snapshots
         mount_and_verify_hash "$hash_file3" "$file3"
-        verify_replica_restart_while_snap_deletion "$file2" "$hash_file2" "$file3" "$hash_file3"
-
-        rm -vrf "$file1" "$file2" "$file3"
-
         cleanup
 }
 
+test_replica_restart_while_snap_deletion() {
+        echo "------------Test replica restart while snap deletion---------------"
+        orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3")
+        replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+        replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+        replica3_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3")
+
+        verify_replica_cnt "3" "Three replica count test"
+        verify_replica_restart_while_snap_deletion "f1" "f2" "$replica3_id" "$REPLICA_IP3"
+        rm -vrf "f1" "f2" "f3"
+        cleanup
+}
 
 prepare_test_env
 test_delete_snapshot
+test_replica_restart_while_snap_deletion
 test_duplicate_data_delete
 test_single_replica_stop_start
 test_restart_during_prepare_rebuild
@@ -1938,7 +1977,6 @@ test_restart_during_prepare_rebuild
 test_preload
 test_replica_rpc_close
 test_controller_rpc_close
-test_single_replica_stop_start
 test_replication_factor
 #test_two_replica_delete
 test_replica_ip_change

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -115,6 +115,17 @@ func (c *ControllerClient) CreateQuorumReplica(address string) (*rest.Replica, e
 	return &resp, err
 }
 
+// DeleteSnapshot ...
+func (c *ControllerClient) DeleteSnapshot(name string) error {
+	volume, err := c.GetVolume()
+	if err != nil {
+		return err
+	}
+	return c.delete(volume.Actions["deleteSnapshot"], &rest.SnapshotInput{
+		Name: name,
+	}, nil)
+}
+
 func (c *ControllerClient) DeleteReplica(address string) (*rest.Replica, error) {
 	reps, err := c.ListReplicas()
 	if err != nil {
@@ -208,6 +219,10 @@ func (c *ControllerClient) post(path string, req, resp interface{}) error {
 
 func (c *ControllerClient) put(path string, req, resp interface{}) error {
 	return c.do("PUT", path, req, resp)
+}
+
+func (c *ControllerClient) delete(path string, req, resp interface{}) error {
+	return c.do("DELETE", path, req, resp)
 }
 
 func (c *ControllerClient) do(method, path string, req, resp interface{}) error {

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -37,7 +37,7 @@ func (c *Controller) getCurrentAndRWReplica(address string) (*types.Replica, *ty
 	}
 
 	for i := range c.replicas {
-		if c.replicas[i].Mode == types.RW && !c.replicas[i].SnapDeletionInProgress {
+		if c.replicas[i].Mode == types.RW {
 			rwReplica = &c.replicas[i]
 			break
 		}

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -23,9 +23,8 @@ type DeleteReplicaOutput struct {
 
 type Replica struct {
 	client.Resource
-	Address                string `json:"address"`
-	Mode                   string `json:"mode"`
-	SnapDeletionInProgress bool   `json:"snapDeletionInProgress"`
+	Address string `json:"address"`
+	Mode    string `json:"mode"`
 }
 
 type Volume struct {
@@ -157,9 +156,8 @@ func NewReplica(context *api.ApiContext, rep types.Replica) *Replica {
 			Type:    "replica",
 			Actions: map[string]string{},
 		},
-		Address:                rep.Address,
-		Mode:                   string(rep.Mode),
-		SnapDeletionInProgress: rep.SnapDeletionInProgress,
+		Address: rep.Address,
+		Mode:    string(rep.Mode),
 	}
 	r.Actions["preparerebuild"] = context.UrlBuilder.ActionLink(r.Resource, "preparerebuild")
 	r.Actions["verifyrebuild"] = context.UrlBuilder.ActionLink(r.Resource, "verifyrebuild")
@@ -244,8 +242,7 @@ func NewSchema() *client.Schemas {
 }
 
 type Server struct {
-	c                      *controller.Controller
-	snapDeletionInProgress bool
+	c *controller.Controller
 }
 
 func NewServer(c *controller.Controller) *Server {

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -119,6 +119,7 @@ type RegReplica struct {
 	UpTime   time.Duration `json:"UpTime"`
 }
 
+// NewVolume ...
 func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int) *Volume {
 	var ReadOnly string
 	if readOnly {
@@ -148,6 +149,7 @@ func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int
 	return v
 }
 
+// NewReplica ...
 func NewReplica(context *api.ApiContext, rep types.Replica) *Replica {
 	r := &Replica{
 		Resource: client.Resource{

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -53,7 +53,7 @@ func (s *Server) ListReplicas(rw http.ResponseWriter, req *http.Request) error {
 	resp := client.GenericCollection{}
 	s.c.Lock()
 	for _, r := range s.c.ListReplicas() {
-		resp.Data = append(resp.Data, NewReplica(apiContext, r.Address, r.Mode))
+		resp.Data = append(resp.Data, NewReplica(apiContext, r))
 	}
 	s.c.Unlock()
 
@@ -185,7 +185,7 @@ func (s *Server) getReplica(context *api.ApiContext, id string) *Replica {
 	defer s.c.Unlock()
 	for _, r := range s.c.ListReplicas() {
 		if r.Address == id {
-			return NewReplica(context, r.Address, r.Mode)
+			return NewReplica(context, r)
 		}
 	}
 	return nil
@@ -196,7 +196,7 @@ func (s *Server) getQuorumReplica(context *api.ApiContext, id string) *Replica {
 	defer s.c.Unlock()
 	for _, r := range s.c.ListQuorumReplicas() {
 		if r.Address == id {
-			return NewReplica(context, r.Address, r.Mode)
+			return NewReplica(context, r)
 		}
 	}
 	return nil

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -30,7 +30,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "snapshot").Handler(f(schemas, s.SnapshotVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "revert").Handler(f(schemas, s.RevertVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "resize").Handler(f(schemas, s.ResizeVolume))
-
+	router.Methods("DELETE").Path("/v1/volumes/{id}").Queries("action", "deleteSnapshot").Handler(f(schemas, s.DeleteSnapshot))
 	// Replicas
 	router.Methods("GET").Path("/v1/replicas").Handler(f(schemas, s.ListReplicas))
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -150,6 +150,9 @@ func (c *ReplicaClient) RemoveDisk(disk string) error {
 		logrus.Errorf("getReplica in removeDisk failed")
 		return err
 	}
+	if r.ReplicaMode != "RW" {
+		return fmt.Errorf("Replica %s mode is %s", c.address, r.ReplicaMode)
+	}
 
 	return c.post(r.Actions["removedisk"], &rest.RemoveDiskInput{
 		Name: disk,
@@ -160,6 +163,9 @@ func (c *ReplicaClient) ReplaceDisk(target, source string) error {
 	r, err := c.GetReplica()
 	if err != nil {
 		return err
+	}
+	if r.ReplicaMode != "RW" {
+		return fmt.Errorf("Replica %s mode is %s", c.address, r.ReplicaMode)
 	}
 
 	return c.post(r.Actions["replacedisk"], &rest.ReplaceDiskInput{
@@ -175,6 +181,9 @@ func (c *ReplicaClient) PrepareRemoveDisk(disk string) (rest.PrepareRemoveDiskOu
 		return output, err
 	}
 
+	if r.ReplicaMode != "RW" {
+		return output, fmt.Errorf("Replica %s mode is %s", c.address, r.ReplicaMode)
+	}
 	err = c.post(r.Actions["prepareremovedisk"], &rest.PrepareRemoveDiskInput{
 		Name: disk,
 	}, &output)

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -534,6 +534,10 @@ func (r *Replica) PrepareRemoveDisk(name string) ([]PrepareRemoveAction, error) 
 	r.Lock()
 	defer r.Unlock()
 
+	if r.mode != types.RW {
+		return nil, fmt.Errorf("Can not prepare remove disk, replica mode: %v", r.mode)
+	}
+
 	disk := name
 
 	data, exists := r.diskData[disk]

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -418,17 +418,6 @@ func (t *Task) getFromReplica() (rest.Replica, error) {
 		return rest.Replica{}, err
 	}
 
-	// We will not start rebuilding if snapshot deletion
-	// is in progress. Since it is sequential, we don't know
-	// when it will be completed. Choosing any other replica
-	// will also is not fruitful because that may be scheduled
-	// next for snapshot deletion.
-	for _, r := range replicas {
-		if r.SnapDeletionInProgress {
-			return rest.Replica{}, fmt.Errorf("Snapshot deletion is in progress in %v", r.Address)
-		}
-	}
-
 	for _, r := range replicas {
 		if r.Mode == "RW" {
 			return r, nil

--- a/types/types.go
+++ b/types/types.go
@@ -108,8 +108,9 @@ type Mode string
 type State string
 
 type Replica struct {
-	Address string `json:"Address"`
-	Mode    Mode   `json:"Mode"`
+	Address                string `json:"Address"`
+	Mode                   Mode   `json:"Mode"`
+	SnapDeletionInProgress bool   `json:"snapDeletionInProgress"`
 }
 
 type RegReplica struct {

--- a/types/types.go
+++ b/types/types.go
@@ -108,9 +108,8 @@ type Mode string
 type State string
 
 type Replica struct {
-	Address                string `json:"Address"`
-	Mode                   Mode   `json:"Mode"`
-	SnapDeletionInProgress bool   `json:"snapDeletionInProgress"`
+	Address string `json:"Address"`
+	Mode    Mode   `json:"Mode"`
 }
 
 type RegReplica struct {


### PR DESCRIPTION
This commit adds a new rest api to delete snapshot, following changes
has been done to honor snapshot deletion.
- Move all the snap delete related operations to `/controller/control.go`
- Validate if Replica count = Replication factor
- Don't add replica if snapshot deletion in progress.
- Validate if replica is in RW mode before replace operation
- Rename replicaCount to ReplicationFactor as it was creating confusion
since both are different

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>