### PR TITLE
cherry-pick(stats): add client status in target stats (#233)

### DIFF
--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -61,9 +61,10 @@ type SnapshotOutput struct {
 
 type VolumeStats struct {
 	client.Resource
-	RevisionCounter int64         `json:"RevisionCounter"`
-	ReplicaCounter  int           `json:"ReplicaCounter"`
-	SCSIIOCount     map[int]int64 `json:"SCSIIOCount"`
+	IsClientConnected bool          `json:"IsClientConnected"`
+	RevisionCounter   int64         `json:"RevisionCounter"`
+	ReplicaCounter    int           `json:"ReplicaCounter"`
+	SCSIIOCount       map[int]int64 `json:"SCSIIOCount"`
 
 	ReadIOPS            string `json:"ReadIOPS"`
 	TotalReadTime       string `json:"TotalReadTime"`

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -49,10 +49,11 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 	}
 
 	volumeStats := &VolumeStats{
-		Resource:        client.Resource{Type: "stats"},
-		RevisionCounter: stats.RevisionCounter,
-		ReplicaCounter:  len(replicas),
-		SCSIIOCount:     stats.SCSIIOCount,
+		Resource:          client.Resource{Type: "stats"},
+		RevisionCounter:   stats.RevisionCounter,
+		ReplicaCounter:    len(replicas),
+		SCSIIOCount:       stats.SCSIIOCount,
+		IsClientConnected: stats.IsClientConnected,
 
 		ReadIOPS:            strconv.FormatInt(stats.ReadIOPS, 10),
 		TotalReadTime:       strconv.FormatInt(stats.TotalReadTime, 10),

--- a/types/types.go
+++ b/types/types.go
@@ -128,9 +128,10 @@ type IOStats struct {
 }
 
 type Stats struct {
-	RevisionCounter int64
-	ReplicaCounter  int64
-	SCSIIOCount     map[int]int64
+	IsClientConnected bool
+	RevisionCounter   int64
+	ReplicaCounter    int64
+	SCSIIOCount       map[int]int64
 
 	ReadIOPS            int64
 	TotalReadTime       int64

--- a/vendor.conf
+++ b/vendor.conf
@@ -20,4 +20,4 @@ github.com/jmespath/go-jmespath         c01cf91b011868172fdcd9f41838e80c9d716264
 github.com/yasker/go-iscsi-helper       9910689ad7c88f650262e01557b16bdc0d5b6a94
 github.com/yasker/nsfilelock            90eff0ebb9e2e0ee2f22519cfb8404f9fdd9c008
 github.com/yasker/backupstore           39c822e19eb3d54eca4dc5f75205e426c8357ac1
-github.com/openebs/gotgt                8653e3186d7ba5145d02be27985ebef6d9e6c63c
+github.com/openebs/gotgt                da935fb60da752293d8af58414332f5dfa568369


### PR DESCRIPTION
This commit adds client status (iscsi initiator) in exiting
stats that we expose over rest api from jiva controller on `/v1/stats`
endpoint. It will help us in identifying whether a client is connected
to controller or not.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>