### PR TITLE
feat(jiva): add goroutine to delete autogenerated snapshot

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"strconv"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/cli"
@@ -60,33 +60,8 @@ func ControllerCmd() cli.Command {
 	}
 }
 
-func startController(c *cli.Context) error {
-	var frontendIP, clusterIP string
-	var controlListener string
-	if c.NArg() == 0 {
-		return errors.New("volume name is required")
-	}
-	name := c.Args()[0]
-	replicationFactor, _ := strconv.ParseInt(os.Getenv("REPLICATION_FACTOR"), 10, 32)
-	if replicationFactor == 0 {
-		logrus.Infof("REPLICATION_FACTOR env not set")
-	} else {
-		logrus.Infof("REPLICATION_FACTOR: %v", replicationFactor)
-	}
-
-	if !util.ValidVolumeName(name) {
-		return errors.New("invalid target name")
-	}
-
+func initializeBackend(c *cli.Context) map[string]types.BackendFactory {
 	backends := c.StringSlice("enable-backend")
-	replicas := c.StringSlice("replica")
-	frontendName := c.String("frontend")
-	if frontendName == "gotgt" {
-		frontendIP = c.String("frontendIP")
-		clusterIP = c.String("clusterIP")
-		logrus.Infof("Starting controller with frontendIP: %v, and clusterIP: %v", frontendIP, clusterIP)
-	}
-	controlListener = c.String("listen")
 	factories := map[string]types.BackendFactory{}
 	for _, backend := range backends {
 		switch backend {
@@ -98,19 +73,66 @@ func startController(c *cli.Context) error {
 			logrus.Fatalf("Unsupported backend: %s", backend)
 		}
 	}
+	return factories
+}
+
+func initializeFrontend(c *cli.Context) (types.Frontend, types.Target, error) {
+	var target types.Target
+	frontendName := c.String("frontend")
+	if frontendName == "gotgt" {
+		target = types.Target{
+			FrontendIP: c.String("frontendIP"),
+			ClusterIP:  c.String("clusterIP"),
+		}
+	}
 
 	var frontend types.Frontend
 	if frontendName != "" {
 		f, ok := frontends[frontendName]
 		if !ok {
-			return fmt.Errorf("Failed to find frontend: %s", frontendName)
+			return nil, types.Target{}, fmt.Errorf("Failed to find frontend: %s", frontendName)
 		}
 		frontend = f
 	}
+	return frontend, target, nil
+}
 
-	control := controller.NewController(name, frontendIP, clusterIP, dynamic.New(factories), frontend, int(replicationFactor))
+func startController(c *cli.Context) error {
+	if c.NArg() == 0 {
+		return errors.New("volume name is required")
+	}
+	name := c.Args()[0]
+	rf := util.CheckReplicationFactor()
+	logrus.Infof("REPLICATION_FACTOR: %v", rf)
+
+	if !util.ValidVolumeName(name) {
+		return errors.New("invalid target name")
+	}
+	controlListener := c.String("listen")
+	replicas := c.StringSlice("replica")
+	frontend, tgt, err := initializeFrontend(c)
+	if err != nil {
+		return err
+	}
+	logrus.Infof("Starting controller with frontendIP: %v, and clusterIP: %v", tgt.FrontendIP, tgt.ClusterIP)
+
+	startAutoSnapDeletion := make(chan bool)
+	control := controller.
+		NewController(
+			startAutoSnapDeletion,
+			controller.WithName(name),
+			controller.WithClusterIP(tgt.ClusterIP),
+			controller.WithBackend(dynamic.New(
+				initializeBackend(c))),
+			controller.WithFrontend(frontend, tgt.FrontendIP),
+			controller.WithRF(int(rf)))
 	server := rest.NewServer(control)
 	router := http.Handler(rest.NewRouter(server))
+	go func(c *controller.Controller) {
+		for <-startAutoSnapDeletion {
+			go autoDeleteSnapshot(c)
+		}
+	}(control)
 
 	router = util.FilteredLoggingHandler(map[string]struct{}{
 		"/v1/volumes":  {},
@@ -132,4 +154,96 @@ func startController(c *cli.Context) error {
 		control.Shutdown()
 	})
 	return http.ListenAndServe(controlListener, router)
+}
+
+func checkPrerequisites(c *controller.Controller, replicas []types.Replica) error {
+	if c.IsSnapDeletionInProgress {
+		return fmt.Errorf(
+			"Snapshot deletion is in progress, %s is getting deleted",
+			c.SnapshotName,
+		)
+	}
+
+	rf := c.ReplicationFactor
+	if len(replicas) != rf {
+		return fmt.Errorf(
+			"Can not remove a snapshot because, RF: %v, replica count: %v",
+			rf, len(replicas),
+		)
+	}
+
+	for _, rep := range replicas {
+		if rep.Mode != "RW" {
+			return fmt.Errorf(
+				"Can't delete snapshot, Replica %s mode is %s",
+				rep.Address, rep.Mode,
+			)
+		}
+	}
+	return nil
+}
+
+func listSnapshots(c *controller.Controller, replicas []rest.Replica) ([]string, error) {
+	snapshots, err := getCommonSnapshots(replicas)
+	if err != nil {
+		return nil, err
+	}
+	snaps := []string{}
+	for _, s := range snapshots {
+		s = strings.TrimSuffix(strings.TrimPrefix(s, "volume-snap-"), ".img")
+		snaps = append(snaps, s)
+	}
+
+	return snaps, nil
+}
+
+func autoDeleteSnapshot(c *controller.Controller) error {
+	c.Lock()
+	replicas := c.ListReplicas()
+	if err := checkPrerequisites(c, replicas); err != nil {
+		c.Unlock()
+		return err
+	}
+
+	// make copy of replicas
+	tmpReplicas := make([]types.Replica, len(replicas))
+	copy(tmpReplicas, replicas)
+	c.IsSnapDeletionInProgress = true
+	c.Unlock()
+	defer func() {
+		c.Lock()
+		c.IsSnapDeletionInProgress = false
+		c.Unlock()
+	}()
+	reps := []rest.Replica{}
+	for _, rep := range tmpReplicas {
+		r := rest.Replica{
+			Address: rep.Address,
+			Mode:    string(rep.Mode),
+		}
+		reps = append(reps, r)
+	}
+
+	snapshots, err := listSnapshots(c, reps)
+	if err != nil {
+		return err
+	}
+
+	if len(snapshots) < 10 {
+		return nil
+	}
+
+	c.SnapshotName = snapshots[len(snapshots)-1]
+	logrus.Infof("Delete snapshot: %v", c.SnapshotName)
+	if err := c.DeleteSnapshot(tmpReplicas); err != nil {
+		return err
+	}
+	logrus.Infof("Deleted snapshot: %v successfully", c.SnapshotName)
+
+	// Notify again to start snap deletion
+	// if no of snapshots are greater than 10
+	// this function will start deleting the snapshots
+	// but if it's less then 10 goroutine will be exited
+	c.StartAutoSnapDeletion <- true
+	return nil
 }

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -113,6 +113,7 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 		c.quorumReplicaCount = len(c.quorumReplicas)
 	}
 	c.UpdateVolStatus()
+	c.StartAutoSnapDeletion <- true
 	return nil
 }
 

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -242,7 +242,7 @@ func (s *Server) DeleteSnapshot(rw http.ResponseWriter, req *http.Request) error
 	}()
 
 	logrus.Infof("Delete snapshot: %s", input.Name)
-	err := s.c.DeleteSnapshot(rf, replicas)
+	err := s.c.DeleteSnapshot(replicas)
 	if err != nil {
 		return err
 	}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -342,6 +342,7 @@ func (t *Task) reloadAndVerify(address string, repClient *replicaClient.ReplicaC
 	if err = repClient.SetRebuilding(false); err != nil {
 		logrus.Errorf("Error in setRebuilding %s", address)
 	}
+
 	return err
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -161,6 +161,12 @@ type Frontend interface {
 	Resize(uint64) error
 }
 
+// Target ...
+type Target struct {
+	ClusterIP  string
+	FrontendIP string
+}
+
 type DataProcessor interface {
 	IOs
 	PingResponse() error


### PR DESCRIPTION
Replicas after getting attached to the controller create a
autogenerated snapshots and the maximum allowed autogenerated
snapshots are 512. So this goroutine will be triggered if no
of snapshots are more than 10 and delete the rest snapshots one
by one.

Note: Since snapshot deletion involves merging of data from it's
child to itself, so this may impact the ongoing io's.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>