### PR TITLE
Add ecode and some modification in log message for alert generation

### DIFF
--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -135,19 +135,21 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 func (s *Server) CreateReplica(rw http.ResponseWriter, req *http.Request) error {
 	var replica Replica
 	apiContext := api.GetApiContext(req)
+	logrusWithEcode := logrus.WithField("ecode", "jiva.create.replica.failed")
 	if err := apiContext.Read(&replica); err != nil {
-		logrus.Errorf("read in createReplica failed %v", err)
+		logrusWithEcode.Errorf("msg=\"read in createReplica failed\" reason=\"%v\"", err)
 		return err
 	}
 	logrus.Infof("Create Replica for address %v", replica.Address)
 
 	if err := s.c.AddReplica(replica.Address); err != nil {
+		logrusWithEcode.Errorf("msg=\"AddReplica in createReplica failed\" reason=\"%v\"", err)
 		return err
 	}
 
 	r := s.getReplica(apiContext, replica.Address)
 	if r == nil {
-		logrus.Errorf("createReplica failed for id %v", replica.Address)
+		logrusWithEcode.Errorf("msg=\"createReplica failed for id %v\" replica_address=\"%v\"", replica.Address, replica.Address)
 		return fmt.Errorf("createReplica failed while getting it")
 	}
 


### PR DESCRIPTION
- New Log format with key-value pairs
- Add ecode, reason, and msg for alert generation.

Sample Log:  
```
ERRO[0047] msg="AddReplica in createReplica failed" reason="can't add tcp://192.168.1.100:9502, error: REPLICATION_FACTOR not set"  ecode=jiva.create.replica.failed
```

Signed-off-by: Sumit Lalwani <sumit.lalwani97@gmail.com>