### PR TITLE
Add build for arm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-dist: xenial
+dist: xenial 
 sudo: required
 install: true
 services:
@@ -8,7 +8,7 @@ go:
   - 1.12.x
 env:
   global:
-    - GOARCH=amd64
+    - GOARCH=$(go env GOARCH)
     - GO_FOR_RELEASE=1.12
 
 addons:

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,20 @@ IS_DOCKER_INSTALLED       := $(shell which docker >> /dev/null 2>&1; echo $$?)
 
 TARGETS := $(shell ls scripts)
 
+# Determine the arch/os
+ifeq (${XC_OS}, )
+  XC_OS:=$(shell go env GOOS)
+endif
+export XC_OS
+
+ifeq (${XC_ARCH}, )
+  XC_ARCH:=$(shell go env GOARCH)
+endif
+export XC_ARCH
+
+ARCH:=${XC_OS}_${XC_ARCH}
+export ARCH
+
 help:
 	@echo ""
 	@echo "Usage:-"

--- a/package/Dockerfile_build_amd64
+++ b/package/Dockerfile_build_amd64
@@ -1,7 +1,4 @@
-FROM openebs/jiva:base-xenial-20190515
-#RUN apt-get update && apt-get install -y kmod curl nfs-common fuse \
-#        libibverbs1 librdmacm1 libconfig-general-perl libaio1 \
-#        && rm -rf /var/lib/apt/lists/*
+From openebs/jiva:base-xenial-20190515 
 RUN apt-get update && apt-get install -y curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/package/Dockerfile_build_arm64
+++ b/package/Dockerfile_build_arm64
@@ -1,0 +1,8 @@
+From arm64v8/ubuntu:18.04
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY longhorn jivactl launch copy-binary launch-with-vm-backing-file launch-simple-jiva /usr/local/bin/
+
+VOLUME /usr/local/bin
+CMD ["longhorn"]

--- a/scripts/package
+++ b/scripts/package
@@ -15,5 +15,12 @@ fi
 cp ../bin/longhorn* .
 cp ../bin/longhorn jivactl
 #cp /usr/src/tgt/pkg/tgt_*.deb .
-docker build -t ${REPO}/jiva:${TAG} .
-echo Built ${REPO}/jiva:${TAG}
+if [ ${ARCH} == "linux_arm64" ]
+then
+  DOCKERFILE=Dockerfile_build_arm64
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} .
+else
+  DOCKERFILE=Dockerfile_build_amd64
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .
+fi
+echo Built ${REPO}/jiva-${XC_ARCH}:${TAG}

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -14,5 +14,12 @@ fi
 
 cp ../bin/debug/longhorn* .
 #cp /usr/src/tgt/pkg/tgt_*.deb .
-docker build -t ${REPO}/jiva:${TAG} .
-echo Built ${REPO}/jiva:${TAG}
+if [ ${ARCH} == "linux_arm64" ]
+then
+  DOCKERFILE=Dockerfile_build_arm64
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} .
+else
+  DOCKERFILE=Dockerfile_build_amd64
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .
+fi
+echo Built ${REPO}/jiva-${XC_ARCH}:${TAG}

--- a/scripts/test
+++ b/scripts/test
@@ -9,5 +9,5 @@ PACKAGES="$(find . -name '*.go' | xargs -I{} dirname {} | sort -u | grep -Ev '(.
 
 echo Packages: ${PACKAGES}
 
-[ "${ARCH}" == "amd64" ] && RACE=-race
+[ "${ARCH}" == "linux_amd64" ] && RACE=-race
 go test ${RACE} -cover -tags="test qcow" ${PACKAGES}


### PR DESCRIPTION
Related to:
- openebs/openebs#1295

This PR modify the Makefile to determime the arch and os.
And add Dockerfile_build_arm64 and Dockerfile_build_amd64
to support build for arm64 arch.

Signed-off-by: wangzihao <wangzihao18@huawei.com>