### PR TITLE
feat(build): make arm64 base image configurable

### DIFF
--- a/package/Dockerfile_build_arm64
+++ b/package/Dockerfile_build_arm64
@@ -1,4 +1,9 @@
-From arm64v8/ubuntu:18.04
+#Make the base image configurable. If BASE IMAGES is not provided
+#docker command will fail
+ARG BASE_IMAGE=arm64v8/ubuntu:18.04
+
+FROM $BASE_IMAGE
+
 RUN apt-get update && apt-get install -y curl \
     && rm -rf /var/lib/apt/lists/*
 

--- a/scripts/package
+++ b/scripts/package
@@ -7,6 +7,7 @@ cd $(dirname $0)/../package
 
 TAG=${TAG:-${VERSION}}
 REPO=${REPO:-openebs}
+BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
 
 if [ ! -x ../bin/longhorn ]; then
     ../scripts/build_binaries
@@ -18,7 +19,7 @@ cp ../bin/longhorn jivactl
 if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} .
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
 else
   DOCKERFILE=Dockerfile_build_amd64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -7,6 +7,7 @@ cd $(dirname $0)/../package
 
 TAG=${TAG:-${VERSION}-DEBUG}
 REPO=${REPO:-openebs}
+BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
 
 if [ ! -x ../bin/debug/longhorn ]; then
     ../scripts/build_debug_binaries
@@ -17,7 +18,7 @@ cp ../bin/debug/longhorn* .
 if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} .
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
 else
   DOCKERFILE=Dockerfile_build_amd64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .


### PR DESCRIPTION
With this change, user can specify a custom
base OS image for arm64 binaries using the ENV
variable BASE_DOCKER_IMAGEARM64.

The default base image will be arm64v8/ubuntu:18.04

Usage:

```
export BASE_DOCKER_IMAGEARM64=arm64v8/ubuntu:16.04; make build
```

Signed-off-by: kmova <kiran.mova@mayadata.io>