### PR TITLE
Adds tests to `util` package

### DIFF
--- a/package/Dockerfile_tests
+++ b/package/Dockerfile_tests
@@ -1,0 +1,8 @@
+FROM golang:1.13-alpine
+
+WORKDIR /go/src/github.com/openebs/jiva
+COPY . .
+
+RUN apk add build-base
+
+CMD ["sh", "/go/src/github.com/openebs/jiva/scripts/test"]

--- a/scripts/ci
+++ b/scripts/ci
@@ -5,7 +5,7 @@ cd $(dirname $0)
 
 ./build_binaries
 ./build_debug_binaries
-./test
+./prepare_test
 ./validate
 ./package
 ./package_debug

--- a/scripts/prepare_test
+++ b/scripts/prepare_test
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+cd $(dirname $0)/..
+
+echo building image
+
+docker build -t jivatest -f package/Dockerfile_tests .
+
+docker run jivatest

--- a/util/util.go
+++ b/util/util.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -26,10 +26,10 @@ const (
 	BlockSizeLinux = 512
 )
 
-func ParseAddresses(name string) (string, string, string, error) {
-	matches := parsePattern.FindStringSubmatch(name)
+func ParseAddresses(address string) (string, string, string, error) {
+	matches := parsePattern.FindStringSubmatch(address)
 	if matches == nil {
-		return "", "", "", fmt.Errorf("Invalid address %s does not match pattern: %v", name, parsePattern)
+		return "", "", "", fmt.Errorf("Invalid address %s does not match pattern: %v", address, parsePattern)
 	}
 
 	host := matches[1]

--- a/util/util.go
+++ b/util/util.go
@@ -26,6 +26,7 @@ const (
 	BlockSizeLinux = 512
 )
 
+// ParseAddresses returns the base address and two with subsequent ports
 func ParseAddresses(address string) (string, string, string, error) {
 	matches := parsePattern.FindStringSubmatch(address)
 	if matches == nil {

--- a/util/util.go
+++ b/util/util.go
@@ -111,12 +111,13 @@ func mknod(device string, major, minor int) error {
 }
 
 func RemoveDevice(dev string) error {
-	if _, err := os.Stat(dev); err == nil {
-		if err := remove(dev); err != nil {
+	var err error
+	if _, err = os.Stat(dev); err == nil {
+		if err = remove(dev); err != nil {
 			return fmt.Errorf("Failed to removing device %s, %v", dev, err)
 		}
 	}
-	return nil
+	return err
 }
 
 func removeAsync(path string, done chan<- error) {

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -35,6 +35,7 @@ func TestParseAddresses(t *testing.T) {
 		{"correct address 3", "https://www.test.com:1234/status", "https://www.test.com:1234", "https://www.test.com:1235", "https://www.test.com:1236", false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			got, got1, got2, err := ParseAddresses(tt.address)
 			if (err != nil) != tt.wantErr {
@@ -128,6 +129,7 @@ func TestValidVolumeName(t *testing.T) {
 		{"invalid name", "My=Volume1", false},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.scenario, func(t *testing.T) {
 			if got := ValidVolumeName(tt.name); got != tt.want {
 				t.Errorf("ValidVolumeName() = %v, want %v", got, tt.want)
@@ -146,6 +148,7 @@ func TestVolume2ISCSIName(t *testing.T) {
 		{"with-replacement", "This_Is_A_Name", "This:Is:A:Name"},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.scenario, func(t *testing.T) {
 			if got := Volume2ISCSIName(tt.name); got != tt.want {
 				t.Errorf("Volume2ISCSIName() = %v, want %v", got, tt.want)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 )
 
@@ -14,4 +15,51 @@ func TestFilter(t *testing.T) {
 	})
 
 	fmt.Println(snapshots)
+}
+
+func TestParseAddresses(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    string
+		want1   string
+		want2   string
+		wantErr bool
+	}{
+		{"correct address", "localhost:1234", "localhost:1234", "localhost:1235", "localhost:1236", false},
+		{"correct address 2", "https://www.test.com:1234", "https://www.test.com:1234", "https://www.test.com:1235", "https://www.test.com:1236", false},
+		{"bad address", "https://www.test.com/1234", "", "", "", true},
+		{"correct address 3", "https://www.test.com:1234/status", "https://www.test.com:1234", "https://www.test.com:1235", "https://www.test.com:1236", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, got2, err := ParseAddresses(tt.address)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseAddresses() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseAddresses() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("ParseAddresses() got1 = %v, want %v", got1, tt.want1)
+			}
+			if got2 != tt.want2 {
+				t.Errorf("ParseAddresses() got2 = %v, want %v", got2, tt.want2)
+			}
+		})
+	}
+}
+
+func TestUUID(t *testing.T) {
+	uuidPattern := regexp.MustCompile(`^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-4[0-9A-Fa-f]{3}-[89ABab][0-9A-Fa-f]{3}-[0-9A-Fa-f]{12}$`)
+	for i := 0; i < 10; i++ {
+		t.Run(fmt.Sprintf("test No. %d", i+1), func(t *testing.T) {
+			got := UUID()
+			match := uuidPattern.MatchString(got)
+			if !match {
+				t.Errorf("UUID() returned an invalid UUID: %s", got)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Adds tests for most of the `util` package functions.

## Explanation:

- Adds test to most of the `util` package functions.

- This needed a little refactor in the way test are running, since we needed to test `devices`, so I created new script called `scripts/prepare_test` this builds and executes a `container image` based on this file `package/Dockerfile_tests`.

- Inside the container I still use the same `scripts/test` file to run the tests.

- I changed a parameter name to get a more semantic meaning

- I change a method that was not returning the error after failing to stat a file

Fixes https://github.com/openebs/openebs/issues/2776

