### PR TITLE
fix(replica): replica restart failure

### DIFF
--- a/replica/server.go
+++ b/replica/server.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	fibmap "github.com/frostschutz/go-fibmap"
 	"github.com/openebs/jiva/types"
 	"github.com/sirupsen/logrus"
 )
@@ -73,6 +74,52 @@ func (s *Server) getSize(size int64) int64 {
 	return size
 }
 
+func (s *Server) createTempFile(filePath string) (*os.File, error) {
+	var file *os.File
+	_, err := os.Stat(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			file, err = os.Create(filePath)
+			if err != nil {
+				return nil, err
+			}
+			return file, nil
+		}
+		return nil, err
+	}
+	// Open file in case file exists (not removed)
+	file, err = os.OpenFile(filePath, os.O_RDWR|os.O_SYNC, 0666)
+	if err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (s *Server) isExtentSupported() error {
+	filePath := s.dir + "/tmpFile.tmp"
+	file, err := s.createTempFile(filePath)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(filePath)
+	if _, err := file.WriteString("This is temp file\n"); err != nil {
+		return err
+	}
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+	fiemapFile := fibmap.NewFibmapFile(file)
+	if _, errno := fiemapFile.Fiemap(uint32(fileInfo.Size())); errno != 0 {
+		// verify is FIBMAP is supported incase FIEMAP failed
+		if _, err := fiemapFile.FibmapExtents(); err != 0 {
+			return fmt.Errorf("failed to find extents, error: %v", err.Error())
+		}
+		return errno
+	}
+	return file.Close()
+}
+
 func (s *Server) Create(size int64) error {
 	s.Lock()
 	defer s.Unlock()
@@ -80,7 +127,7 @@ func (s *Server) Create(size int64) error {
 		logrus.Errorf("failed to create directory: %s", s.dir)
 		return err
 	}
-	if err := isExtentSupported(s.dir); err != nil {
+	if err := s.isExtentSupported(); err != nil {
 		return err
 	}
 	state, _ := s.Status()

--- a/replica/server.go
+++ b/replica/server.go
@@ -88,7 +88,7 @@ func (s *Server) createTempFile(filePath string) (*os.File, error) {
 		return nil, err
 	}
 	// Open file in case file exists (not removed)
-	file, err = os.OpenFile(filePath, os.O_RDWR|os.O_SYNC, 0666)
+	file, err = os.OpenFile(filePath, os.O_RDWR|os.O_SYNC, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -101,10 +101,16 @@ func (s *Server) isExtentSupported() error {
 	if err != nil {
 		return err
 	}
-	defer os.Remove(filePath)
-	if _, err := file.WriteString("This is temp file\n"); err != nil {
+
+	defer func() {
+		_ = os.Remove(filePath)
+	}()
+
+	_, err = file.WriteString("This is temp file\n")
+	if err != nil {
 		return err
 	}
+
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
This commit fixes the issue where replica was not getting restarted
due to the missing corner case, where tmp file created for verifying
extent mapping support was not deleted due to some errors and we were
not opening the file again (restart case if file already exists) for further operations due to which file ref
was nil and it was giving "invalid argument" error.

fixes: openebs/openebs#2813

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>