### PR TITLE
fix(replica): optimize rebuild process

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1328,7 +1328,6 @@ test_upgrade() {
 	verify_replica_cnt "3" "Three replica count test in controller upgrade"
 	wait
 	test_data_integrity
-
 	cleanup
 }
 

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1879,6 +1879,7 @@ verify_replica_restart_while_snap_deletion() {
 
         # case 2: Replication factor is not met
         sudo docker stop "$3"
+				sleep 5
         verify_delete_snapshot_failure "$4" "false"
 
         # case 3: Coalesce failed or client timeout exceeded

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1879,7 +1879,7 @@ verify_replica_restart_while_snap_deletion() {
 
         # case 2: Replication factor is not met
         sudo docker stop "$3"
-				sleep 5
+        sleep 5
         verify_delete_snapshot_failure "$4" "false"
 
         # case 3: Coalesce failed or client timeout exceeded

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -440,7 +440,7 @@ get_replica_count() {
 #the replicas will not be deleted and error will be returned that replica
 #count is not equal to the RF.
 verify_delete_replica_unsuccess() {
-    expected_error="Error deleting replica" 
+    expected_error="Error deleting replica"
     error=$(curl -X "POST" http://$CONTROLLER_IP:9501/v1/delete | jq '.replicas[0].msg' | tr -d '"')
     if [ "$error" != "$expected_error" ]; then
                echo $2"  --failed"
@@ -643,7 +643,7 @@ test_controller_rpc_close() {
 
 	curl -k --data "{ \"rpcPingTimeout\":\"0\" }" -H "Content-Type:application/json" -XPOST $CONTROLLER_IP:9501/timeout
 	verify_replica_cnt "1" "One replica count test1"
-    
+
 	cleanup
 }
 
@@ -1333,7 +1333,7 @@ test_upgrade() {
 }
 
 test_upgrades() {
-       test_upgrade "openebs/jiva:1.0.0" "replica-controller"
+       test_upgrade "openebs/jiva:1.4.0" "replica-controller"
 }
 
 di_test_on_raw_disk() {

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -107,7 +107,7 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 	if err := c.backend.SetRevisionCounter(address, counter); err != nil {
 		return fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
 	}
-	logrus.Debugf("WO replica %v's chain verified, update mode to RW", address)
+	logrus.Infof("WO replica %v's chain verified, update replica mode to RW", address)
 	c.setReplicaModeNoLock(address, types.RW)
 	if len(c.quorumReplicas) > c.quorumReplicaCount {
 		c.quorumReplicaCount = len(c.quorumReplicas)

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -213,11 +213,12 @@ func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	return replica, err
 }
 
-func (c *ReplicaClient) UpdateCloneInfo(snapName string) (rest.Replica, error) {
+func (c *ReplicaClient) UpdateCloneInfo(snapName string, revCount string) (rest.Replica, error) {
 	var replica rest.Replica
 
 	input := &rest.CloneUpdateInput{
-		SnapName: snapName,
+		SnapName:      snapName,
+		RevisionCount: revCount,
 	}
 
 	err := c.post(c.address+"/replicas/1?action=updatecloneinfo", input, &replica)

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -213,7 +213,8 @@ func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	return replica, err
 }
 
-func (c *ReplicaClient) UpdateCloneInfo(snapName string, revCount string) (rest.Replica, error) {
+// UpdateCloneInfo update the snapname and revision count
+func (c *ReplicaClient) UpdateCloneInfo(snapName, revCount string) (rest.Replica, error) {
 	var replica rest.Replica
 
 	input := &rest.CloneUpdateInput{

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -774,11 +774,12 @@ func (r *Replica) createNewHead(oldHead, parent, created string) (types.DiffDisk
 	}
 
 	newDisk := disk{
-		Parent:      parent,
-		Name:        newHeadName,
-		Removed:     false,
-		UserCreated: false,
-		Created:     created,
+		Parent:          parent,
+		Name:            newHeadName,
+		Removed:         false,
+		UserCreated:     false,
+		Created:         created,
+		RevisionCounter: r.GetRevisionCounter(),
 	}
 	err = r.encodeToFile(&newDisk, newHeadName+metadataSuffix)
 	return f, newDisk, err

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -195,15 +195,15 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 	}
 	r.volume.sectorSize = defaultSectorSize
 
+	if err := r.initRevisionCounter(); err != nil {
+		return nil, err
+	}
+
 	// Scan all the disks to build the disk map
 	exists, err := r.readMetadata()
 	if err != nil {
 		return nil, err
 	}
-	if err := r.initRevisionCounter(); err != nil {
-		return nil, err
-	}
-
 	// Reference r.info.Size because it may have changed from reading
 	// metadata
 	locationSize := r.info.Size / r.volume.sectorSize

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1074,6 +1074,12 @@ func (r *Replica) readDiskData(file string) error {
 	name := file[:len(file)-len(metadataSuffix)]
 	data.Name = name
 	r.diskData[name] = &data
+	// we are updating the revision count of snapshot with the latest
+	// revision count. This is done to know how many io's have been served
+	// if replica has been restarted multiple times and new snapshots have
+	// been created with no data.
+	// This is compared with 1 since revision.counter is initialized
+	// with 1 initially.
 	if r.diskData[name].RevisionCounter <= 1 {
 		r.diskData[name].RevisionCounter = r.GetRevisionCounter()
 		if err := r.encodeToFile(r.diskData[name], name+metadataSuffix); err != nil {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -89,11 +89,12 @@ type Info struct {
 }
 
 type disk struct {
-	Name        string
-	Parent      string
-	Removed     bool
-	UserCreated bool
-	Created     string
+	Name            string
+	Parent          string
+	Removed         bool
+	UserCreated     bool
+	Created         string
+	RevisionCounter int64
 }
 
 type BackingFile struct {
@@ -110,13 +111,14 @@ type PrepareRemoveAction struct {
 }
 
 type DiskInfo struct {
-	Name        string   `json:"name"`
-	Parent      string   `json:"parent"`
-	Children    []string `json:"children"`
-	Removed     bool     `json:"removed"`
-	UserCreated bool     `json:"usercreated"`
-	Created     string   `json:"created"`
-	Size        string   `json:"size"`
+	Name            string   `json:"name"`
+	Parent          string   `json:"parent"`
+	Children        []string `json:"children"`
+	Removed         bool     `json:"removed"`
+	UserCreated     bool     `json:"usercreated"`
+	Created         string   `json:"created"`
+	Size            string   `json:"size"`
+	RevisionCounter int64    `json:"revisionCount"`
 }
 
 const (
@@ -918,6 +920,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string) erro
 		r.diskData[newSnapName] = r.diskData[oldHead]
 		r.diskData[newSnapName].UserCreated = userCreated
 		r.diskData[newSnapName].Created = created
+		r.diskData[newSnapName].RevisionCounter = r.GetRevisionCounter()
 		if err := r.encodeToFile(r.diskData[newSnapName], newSnapName+metadataSuffix); err != nil {
 			return err
 		}
@@ -1225,12 +1228,13 @@ func (r *Replica) ListDisks() map[string]DiskInfo {
 	for _, disk := range r.diskData {
 		diskSize := strconv.FormatInt(r.getDiskSize(disk.Name), 10)
 		diskInfo := DiskInfo{
-			Name:        disk.Name,
-			Parent:      disk.Parent,
-			Removed:     disk.Removed,
-			UserCreated: disk.UserCreated,
-			Created:     disk.Created,
-			Size:        diskSize,
+			Name:            disk.Name,
+			Parent:          disk.Parent,
+			Removed:         disk.Removed,
+			UserCreated:     disk.UserCreated,
+			Created:         disk.Created,
+			Size:            diskSize,
+			RevisionCounter: disk.RevisionCounter,
 		}
 		children := []string{}
 		for child := range r.diskChildrenMap[disk.Name] {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1074,6 +1074,12 @@ func (r *Replica) readDiskData(file string) error {
 	name := file[:len(file)-len(metadataSuffix)]
 	data.Name = name
 	r.diskData[name] = &data
+	if r.diskData[name].RevisionCounter == 0 || r.diskData[name].RevisionCounter == -1 {
+		r.diskData[name].RevisionCounter = r.GetRevisionCounter()
+		if err := r.encodeToFile(r.diskData[name], name+metadataSuffix); err != nil {
+			return err
+		}
+	}
 	if data.Parent != "" {
 		r.addChildDisk(data.Parent, data.Name)
 	}

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1074,7 +1074,7 @@ func (r *Replica) readDiskData(file string) error {
 	name := file[:len(file)-len(metadataSuffix)]
 	data.Name = name
 	r.diskData[name] = &data
-	if r.diskData[name].RevisionCounter == 0 || r.diskData[name].RevisionCounter == -1 {
+	if r.diskData[name].RevisionCounter <= 1 {
 		r.diskData[name].RevisionCounter = r.GetRevisionCounter()
 		if err := r.encodeToFile(r.diskData[name], name+metadataSuffix); err != nil {
 			return err

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -352,6 +352,11 @@ func (r *Replica) UpdateCloneInfo(snapName string) error {
 	if err := r.encodeToFile(&r.info, volumeMetaData); err != nil {
 		return err
 	}
+
+	revisionCount := r.diskData[r.info.Parent].RevisionCounter
+	if err := r.SetRevisionCounter(revisionCount); err != nil {
+		return err
+	}
 	r.diskData[r.info.Head].Parent = r.info.Parent
 	return r.encodeToFile(r.diskData[r.info.Head], r.info.Head+metadataSuffix)
 }

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -61,9 +61,11 @@ type SnapshotInput struct {
 	Created     string `json:"created"`
 }
 
+// CloneUpdateInput is input to update clone info of cloned replica
 type CloneUpdateInput struct {
 	client.Resource
-	SnapName string `json:"snapname"`
+	SnapName      string `json:"snapname"`
+	RevisionCount string `json:"revisioncounter"`
 }
 
 type RemoveDiskInput struct {

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -261,7 +261,7 @@ func (s *Server) UpdateCloneInfo(rw http.ResponseWriter, req *http.Request) erro
 		return err
 	}
 	logrus.Infof("Update Clone Info for snap %v", input.SnapName)
-	return s.doOp(req, s.s.UpdateCloneInfo(input.SnapName))
+	return s.doOp(req, s.s.UpdateCloneInfo(input.SnapName, input.RevisionCount))
 }
 
 func (s *Server) CloseReplica(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -2,11 +2,12 @@ package replica
 
 import (
 	"fmt"
-	"github.com/openebs/jiva/types"
 	"io"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/openebs/jiva/types"
 
 	"github.com/longhorn/sparse-tools/sparse"
 	"github.com/sirupsen/logrus"
@@ -46,6 +47,7 @@ func (r *Replica) writeRevisionCounter(counter int64) error {
 	if err != nil {
 		return fmt.Errorf("fail to write to revision counter file: %v", err)
 	}
+
 	return nil
 }
 

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -106,6 +106,19 @@ func (r *Replica) GetRevisionCounter() int64 {
 	return counter
 }
 
+// SetRevisionCounterCloneReplica set revision counter for clone replica
+func (r *Replica) SetRevisionCounterCloneReplica(counter int64) error {
+	r.revisionLock.Lock()
+	defer r.revisionLock.Unlock()
+
+	if err := r.writeRevisionCounter(counter); err != nil {
+		return err
+	}
+
+	r.revisionCache = counter
+	return nil
+}
+
 func (r *Replica) SetRevisionCounter(counter int64) error {
 	r.Lock()
 	if r.mode != types.RW {

--- a/replica/server.go
+++ b/replica/server.go
@@ -200,7 +200,7 @@ func (s *Server) Reload() error {
 	return nil
 }
 
-func (s *Server) UpdateCloneInfo(snapName string) error {
+func (s *Server) UpdateCloneInfo(snapName, revCount string) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -209,7 +209,7 @@ func (s *Server) UpdateCloneInfo(snapName string) error {
 	}
 
 	logrus.Infof("Update Clone Info")
-	return s.r.UpdateCloneInfo(snapName)
+	return s.r.UpdateCloneInfo(snapName, revCount)
 }
 
 func (s *Server) Status() (State, Info) {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -358,6 +358,10 @@ func isRevisionCountSame(fromClient, toClient *replicaClient.ReplicaClient, disk
 		return false, fmt.Errorf("Failed to verify isRevisionCountSame, err: %v", err)
 	}
 
+	if rwReplica.Disks[disk].RevisionCounter == 0 {
+		return false, nil
+	}
+
 	curReplica, err := toClient.GetReplica()
 	if err != nil {
 		return false, fmt.Errorf("Failed to verify isRevisionCountSame, err: %v", err)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 import (
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -166,7 +167,7 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 			continue
 		}
 
-		_, err = toClient.UpdateCloneInfo(snapName, repl.RevisionCounter)
+		_, err = toClient.UpdateCloneInfo(snapName, strconv.FormatInt(repl.Disks[snapshotName].RevisionCounter, 10))
 		if err != nil {
 			return fmt.Errorf("Failed to update clone info, err: %v", err)
 		}
@@ -363,9 +364,10 @@ func isRevisionCountSame(fromClient, toClient *replicaClient.ReplicaClient, disk
 
 	}
 
+	logrus.Infof("Cur replica: %v, rw Replica: %v", curReplica, rwReplica)
 	if rwReplica.Disks[disk].RevisionCounter != curReplica.Disks[disk].RevisionCounter {
 		logrus.Warningf("Revision count not same for snap: %v, cur: %v, RW: %v",
-			disk, rwReplica.Disks[disk].RevisionCounter, curReplica.Disks[disk].RevisionCounter)
+			disk, curReplica.Disks[disk].RevisionCounter, rwReplica.Disks[disk].RevisionCounter)
 		return false, nil
 	}
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -146,8 +146,9 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 		if err != nil {
 			return fmt.Errorf("Failed to create client of the clone replica, error: %s", err.Error())
 		}
+		snapshotName := "volume-snap-" + snapName + ".img"
 		for i, name := range chain {
-			if name == "volume-snap-"+snapName+".img" {
+			if name == snapshotName {
 				snapFound = true
 				chain = chain[i:]
 				break
@@ -164,8 +165,10 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 			time.Sleep(2 * time.Second)
 			continue
 		}
-		toClient.UpdateCloneInfo(snapName)
 
+		if _, err := toClient.UpdateCloneInfo(snapName, repl.RevisionCounter); err != nil {
+			return fmt.Errorf("Failed to update clone info, err: %v", err)
+		}
 		_, err = toClient.ReloadReplica()
 		if err != nil {
 			return fmt.Errorf("Failed to reload clone replica, error: %s", err.Error())

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -364,7 +364,6 @@ func isRevisionCountSame(fromClient, toClient *replicaClient.ReplicaClient, disk
 
 	}
 
-	logrus.Infof("Cur replica: %v, rw Replica: %v", curReplica, rwReplica)
 	if rwReplica.Disks[disk].RevisionCounter != curReplica.Disks[disk].RevisionCounter {
 		logrus.Warningf("Revision count not same for snap: %v, cur: %v, RW: %v",
 			disk, curReplica.Disks[disk].RevisionCounter, rwReplica.Disks[disk].RevisionCounter)

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -346,21 +346,45 @@ func (t *Task) reloadAndVerify(address string, repClient *replicaClient.ReplicaC
 	return err
 }
 
-func (t *Task) syncFiles(fromClient *replicaClient.ReplicaClient, toClient *replicaClient.ReplicaClient, disks []string) error {
+func isRevisionCountSame(fromClient, toClient *replicaClient.ReplicaClient, disk string) (bool, error) {
+	rwReplica, err := fromClient.GetReplica()
+	if err != nil {
+		return false, err
+	}
+
+	curReplica, err := toClient.GetReplica()
+	if err != nil {
+		return false, err
+	}
+
+	if rwReplica.Disks[disk].RevisionCounter != curReplica.Disks[disk].RevisionCounter {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (t *Task) syncFiles(fromClient, toClient *replicaClient.ReplicaClient, disks []string) error {
 	for i := range disks {
 		//We are syncing from the oldest snapshots to newer ones
 		disk := disks[len(disks)-1-i]
 		if strings.Contains(disk, "volume-head") {
 			return fmt.Errorf("Disk list shouldn't contain volume-head")
 		}
-		if err := t.syncFile(disk, "", fromClient, toClient); err != nil {
+
+		ok, err := isRevisionCountSame(fromClient, toClient, disk)
+		if err != nil {
 			return err
 		}
 
+		if !ok {
+			if err := t.syncFile(disk, "", fromClient, toClient); err != nil {
+				return err
+			}
+		}
 		if err := t.syncFile(disk+".meta", "", fromClient, toClient); err != nil {
 			return err
 		}
-
 	}
 
 	return nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -166,7 +166,8 @@ func (t *Task) CloneReplica(url string, address string, cloneIP string, snapName
 			continue
 		}
 
-		if _, err := toClient.UpdateCloneInfo(snapName, repl.RevisionCounter); err != nil {
+		_, err = toClient.UpdateCloneInfo(snapName, repl.RevisionCounter)
+		if err != nil {
 			return fmt.Errorf("Failed to update clone info, err: %v", err)
 		}
 		_, err = toClient.ReloadReplica()

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -299,6 +299,7 @@ func (t *Task) isRevisionCountAndChainSame(fromClient, toClient *replicaClient.R
 		// ignoring Chain[0] since it's head file and it is opened for writing the latest data.
 		if !reflect.DeepEqual(rwReplica.Chain[1:], curReplica.Chain[1:]) {
 			logrus.Warningf("Replica %v's chain not equal to RW replica %v's chain", toClient.GetAddress(), fromClient.GetAddress())
+			logrus.Warningf("RW replica chain: %v, cur replica chain: %v", rwReplica.Chain, curReplica.Chain)
 			return false, nil
 		}
 		return true, nil
@@ -349,15 +350,18 @@ func (t *Task) reloadAndVerify(address string, repClient *replicaClient.ReplicaC
 func isRevisionCountSame(fromClient, toClient *replicaClient.ReplicaClient, disk string) (bool, error) {
 	rwReplica, err := fromClient.GetReplica()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("Failed to verify isRevisionCountSame, err: %v", err)
 	}
 
 	curReplica, err := toClient.GetReplica()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("Failed to verify isRevisionCountSame, err: %v", err)
+
 	}
 
 	if rwReplica.Disks[disk].RevisionCounter != curReplica.Disks[disk].RevisionCounter {
+		logrus.Warningf("Revision count not same for snap: %v, cur: %v, RW: %v",
+			disk, rwReplica.Disks[disk].RevisionCounter, curReplica.Disks[disk].RevisionCounter)
 		return false, nil
 	}
 


### PR DESCRIPTION
- This commit optimize the rebuild process by comparing the io numbers of the
  autogenerated snapshots.

- Now only those snapshots will be synced which have less no of IO's as compared
  to healthy replicas.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>