### PR TITLE
feat(jiva): add options to enable buffered io in replica

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ env:
   global:
     - GOARCH=$(go env GOARCH)
     - GO_FOR_RELEASE=1.13
-
+  matrix:
+    # tags are mainly in ascending order
+    - JIVA_BUILD_TAGS=0
+    - JIVA_BUILD_TAGS=1
 addons:
   apt:
     update: true
@@ -21,7 +24,13 @@ before_install:
   - go env && pwd
   - mkdir -p $HOME/gopath/bin
 script:
-  - make build
+  - >
+    if [ $JIVA_BUILD_TAGS = 0 ];
+    then
+      make build;
+    else
+      make build_buf;
+    fi;
 notifications:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ _run_ci:
 	@echo "INFO:\tRun ci over jiva image"
 	sudo bash ./ci/start_init_test.sh
 
+_run_ci_buf:
+	@echo "INFO:\tRun ci over jiva image with buffered-io enabled"
+	sudo bash ./ci/start_init_test.sh --buffered-io=true
+
 build_image:
 	@echo "INFO:\tRun unit tests and build image"
 	bash ./scripts/ci
@@ -90,6 +94,7 @@ endif
 	$(shell golint $(shell find . -maxdepth 1 -type d \( ! -iname ".git" ! -iname "vendor" \)) )
 
 build: deps build_image _run_ci _push_image
+build_buf: deps build_image _run_ci_buf
 build_gitlab: deps build_image _push_image
 
 #

--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+
 	"github.com/openebs/jiva/alertlog"
 
 	"github.com/openebs/jiva/replica"
@@ -29,13 +30,13 @@ func addReplica(c *cli.Context) error {
 	replica := c.Args()[0]
 
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, c.Bool("buffered-io"))
 	return task.AddReplica(replica, nil)
 }
 func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replicaType string) error {
 	var err error
 	url := "http://" + frontendIP + ":9501"
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, s.Bufio)
 	if replicaType == "quorum" {
 		err = task.AddQuorumReplica(replica, s)
 	} else {

--- a/app/backup.go
+++ b/app/backup.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	"github.com/openebs/jiva/alertlog"
 
 	"github.com/openebs/jiva/sync"
@@ -92,7 +93,7 @@ func BackupListCmd() cli.Command {
 
 func createBackup(c *cli.Context) error {
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 
 	dest := c.String("dest")
 	if dest == "" {
@@ -126,7 +127,7 @@ func createBackup(c *cli.Context) error {
 
 func rmBackup(c *cli.Context) error {
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 
 	backup := c.Args().First()
 	if backup == "" {
@@ -153,7 +154,7 @@ func rmBackup(c *cli.Context) error {
 
 func restoreBackup(c *cli.Context) error {
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 
 	backup := c.Args().First()
 	if backup == "" {
@@ -179,7 +180,7 @@ func restoreBackup(c *cli.Context) error {
 
 func inspectBackup(c *cli.Context) error {
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 
 	backup := c.Args().First()
 	if backup == "" {
@@ -197,7 +198,7 @@ func inspectBackup(c *cli.Context) error {
 
 func listBackup(c *cli.Context) error {
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 
 	destURL := c.Args().First()
 	if destURL == "" {

--- a/app/snapshot.go
+++ b/app/snapshot.go
@@ -3,10 +3,11 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openebs/jiva/alertlog"
 	"os"
 	"strings"
 	"text/tabwriter"
+
+	"github.com/openebs/jiva/alertlog"
 
 	"github.com/openebs/jiva/controller/rest"
 	"github.com/openebs/jiva/replica"
@@ -172,7 +173,7 @@ func revertSnapshot(c *cli.Context) error {
 func rmSnapshot(c *cli.Context) error {
 	var lastErr error
 	url := c.GlobalString("url")
-	task := sync.NewTask(url)
+	task := sync.NewTask(url, false)
 	if len(c.Args()) < 1 {
 		return fmt.Errorf("snapshot name is empty")
 	}

--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -64,6 +64,10 @@ func (f *Wrapper) SetRevisionCounter(counter int64) error {
 	return nil
 }
 
+func (f *Wrapper) SetSyncCounter(counter int64) error {
+	return nil
+}
+
 func (f *Wrapper) SetRebuilding(rebuilding bool) error {
 	return nil
 }

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -24,6 +24,8 @@ var (
 	requestBuffer = 1024
 )
 
+var _ types.Backend = (*Remote)(nil)
+
 func New() types.BackendFactory {
 	return &Factory{}
 }
@@ -210,6 +212,13 @@ func (r *Remote) SetRevisionCounter(counter int64) error {
 	logrus.Infof("Set revision counter of %s to : %v", r.Name, counter)
 	localRevCount := strconv.FormatInt(counter, 10)
 	return r.doAction("setrevisioncounter", &map[string]string{"counter": localRevCount})
+}
+
+// SetSyncCounter set the sync count of the replica
+func (r *Remote) SetSyncCounter(counter int64) error {
+	logrus.Infof("Set sync counter of %s to : %v", r.Name, counter)
+	localSyncCount := strconv.FormatInt(counter, 10)
+	return r.doAction("setsynccounter", &map[string]string{"counter": localSyncCount})
 }
 
 func (r *Remote) info() (rest.Replica, error) {

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -104,9 +104,17 @@ func (c *Controller) VerifyRebuildReplica(address string) error {
 	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
 		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
 	}
+
 	if err := c.backend.SetRevisionCounter(address, counter); err != nil {
 		return fmt.Errorf("Fail to set revision counter for %v: %v", address, err)
 	}
+
+	if c.Bufio {
+		if err := c.backend.SetSyncCounter(address, counter); err != nil {
+			return fmt.Errorf("Fail to set sync counter for %v: %v", address, err)
+		}
+	}
+
 	logrus.Infof("WO replica %v's chain verified, update replica mode to RW", address)
 	c.setReplicaModeNoLock(address, types.RW)
 	if len(c.quorumReplicas) > c.quorumReplicaCount {

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -458,6 +458,21 @@ func (r *replicator) SetRevisionCounter(address string, counter int64) error {
 	return nil
 }
 
+func (r *replicator) SetSyncCounter(address string, counter int64) error {
+	backend, ok := r.backends[address]
+	if !ok {
+		return fmt.Errorf("Cannot find backend %v", address)
+	}
+
+	if err := backend.backend.SetSyncCounter(counter); err != nil {
+		return err
+	}
+
+	logrus.Infof("Set backend %s sync counter to %v", address, counter)
+
+	return nil
+}
+
 func (r *replicator) SetQuorumRevisionCounter(address string, counter int64) error {
 	backend, ok := r.quorumBackends[address]
 	if !ok {

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -222,13 +222,14 @@ func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	return replica, err
 }
 
-// UpdateCloneInfo update the snapname and revision count
-func (c *ReplicaClient) UpdateCloneInfo(snapName, revCount string) (rest.Replica, error) {
+// UpdateCloneInfo update the snapname, revision count, sync count
+func (c *ReplicaClient) UpdateCloneInfo(snapName, revCount, syncCount string) (rest.Replica, error) {
 	var replica rest.Replica
 
 	input := &rest.CloneUpdateInput{
 		SnapName:      snapName,
 		RevisionCount: revCount,
+		SyncCount:     syncCount,
 	}
 
 	err := c.post(c.address+"/replicas/1?action=updatecloneinfo", input, &replica)

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -30,7 +30,13 @@ func (s *TestSuite) TestCreate(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -48,7 +54,13 @@ func (s *TestSuite) TestSnapshot(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -131,7 +143,13 @@ func (s *TestSuite) TestRevert(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -245,7 +263,13 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -326,7 +350,13 @@ func (s *TestSuite) TestRemoveLast(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -375,7 +405,13 @@ func (s *TestSuite) TestRemoveMiddle(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -425,7 +461,13 @@ func (s *TestSuite) TestRemoveFirst(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{
+		size:        9,
+		sectorSize:  3,
+		dir:         dir,
+		backingFile: nil,
+		replicaType: "Backend",
+	})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -459,7 +501,7 @@ func (s *TestSuite) TestRemoveOutOfChain(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{size: 9, sectorSize: 3, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -538,7 +580,7 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9, 3, dir, nil, "Backend")
+	r, err := New(options{size: 9, sectorSize: 3, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -679,7 +721,7 @@ func (s *TestSuite) TestRead(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9*b, b, dir, nil, "Backend")
+	r, err := New(options{size: 9 * b, sectorSize: b, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -696,7 +738,7 @@ func (s *TestSuite) TestWrite(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(9*b, b, dir, nil, "Backend")
+	r, err := New(options{size: 9 * b, sectorSize: b, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -720,7 +762,7 @@ func (s *TestSuite) TestSnapshotReadWrite(c *C) {
 	c.Assert(err, IsNil)
 	defer os.RemoveAll(dir)
 
-	r, err := New(3*b, b, dir, nil, "Backend")
+	r, err := New(options{size: 3 * b, sectorSize: b, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -782,7 +824,7 @@ func (s *TestSuite) TestBackingFile(c *C) {
 		Disk: f,
 	}
 
-	r, err := New(3*b, b, dir, backing, "Backend")
+	r, err := New(options{size: 3 * b, sectorSize: b, dir: dir, backingFile: backing, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -817,7 +859,7 @@ func (s *TestSuite) partialWriteRead(c *C, totalLength, writeLength, writeOffset
 	buf := make([]byte, totalLength)
 	fill(buf, 3)
 
-	r, err := New(totalLength, b, dir, nil, "Backend")
+	r, err := New(options{size: totalLength, sectorSize: b, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")
@@ -867,7 +909,7 @@ func (s *TestSuite) testPartialRead(c *C, totalLength int64, readBuf []byte, off
 	buf := make([]byte, totalLength)
 	fill(buf, 3)
 
-	r, err := New(totalLength, b, dir, nil, "Backend")
+	r, err := New(options{size: totalLength, sectorSize: b, dir: dir, backingFile: nil, replicaType: "Backend"})
 	c.Assert(err, IsNil)
 	defer r.Close()
 	err = r.SetReplicaMode("RW")

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -22,6 +22,7 @@ type Replica struct {
 	RemainSnapshots   int                         `json:"remainsnapshots"`
 	ReplicaMode       string                      `json:"replicamode"`
 	RevisionCounter   string                      `json:"revisioncounter"`
+	SyncCounter       string                      `json:"syncCounter"`
 	ReplicaCounter    int64                       `json:"replicacounter"`
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
@@ -66,6 +67,7 @@ type CloneUpdateInput struct {
 	client.Resource
 	SnapName      string `json:"snapname"`
 	RevisionCount string `json:"revisioncounter"`
+	SyncCount     string `json:"synccounter"`
 }
 
 type RemoveDiskInput struct {
@@ -114,6 +116,12 @@ type RevisionCounter struct {
 	Counter string `json:"counter"`
 }
 
+// SyncCounter is the count of sync operation done on replica from the target
+type SyncCounter struct {
+	client.Resource
+	Counter string `json:"counter"`
+}
+
 type ReplicaCounter struct {
 	client.Resource
 	Counter int64 `json:"counter"`
@@ -158,6 +166,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["prepareremovedisk"] = true
 		actions["setreplicamode"] = true
 		actions["setrevisioncounter"] = true
+		actions["setsynccounter"] = true
 		actions["updatecloneinfo"] = true
 		actions["setreplicacounter"] = true
 	case replica.Closed:
@@ -194,6 +203,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["reload"] = true
 		actions["setreplicamode"] = true
 		actions["setrevisioncounter"] = true
+		actions["setsynccounter"] = true
 		actions["setreplicacounter"] = true
 		actions["updatecloneinfo"] = true
 	case replica.Error:
@@ -210,11 +220,13 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 	r.SectorSize = info.SectorSize
 	r.Size = strconv.FormatInt(info.Size, 10)
 	r.RevisionCounter = strconv.FormatInt(info.RevisionCounter, 10)
+	r.SyncCounter = strconv.FormatInt(info.SyncCounter, 10)
 	if rep != nil {
 		r.Chain, _ = rep.DisplayChain()
 		r.Disks = rep.ListDisks()
 		r.RemainSnapshots = rep.GetRemainSnapshotCounts()
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
+		r.SyncCounter = strconv.FormatInt(info.SyncCounter, 10)
 		r.ReplicaMode = rep.GetReplicaMode()
 		r.CloneStatus = rep.GetCloneStatus()
 	}
@@ -262,6 +274,9 @@ func setReplicaResourceActions(replica *client.Schema) {
 		"setrevisioncounter": {
 			Input: "revisionCounter",
 		},
+		"setsynccounter": {
+			Input: "syncCounter",
+		},
 		"setreplicacounter": {
 			Input: "replicaCounter",
 		},
@@ -287,6 +302,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("prepareRemoveDiskOutput", PrepareRemoveDiskOutput{})
 	schemas.AddType("replicaMode", ReplicaMode{})
 	schemas.AddType("revisionCounter", RevisionCounter{})
+	schemas.AddType("syncCounter", SyncCounter{})
 	schemas.AddType("replicaCounter", ReplicaCounter{})
 	schemas.AddType("replacediskInput", ReplaceDiskInput{})
 

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -73,6 +73,7 @@ func NewRouter(s *Server) *mux.Router {
 		"revert":             s.RevertReplica,
 		"prepareremovedisk":  s.PrepareRemoveDisk,
 		"setrevisioncounter": s.SetRevisionCounter,
+		"setsynccounter":     s.SetSyncCounter,
 		"setreplicamode":     s.SetReplicaMode,
 	}
 

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -119,6 +119,19 @@ func (r *Replica) SetRevisionCounterCloneReplica(counter int64) error {
 	return nil
 }
 
+// SetSyncCounterCloneReplica set revision counter for clone replica
+func (r *Replica) SetSyncCounterCloneReplica(counter int64) error {
+	r.syncLock.Lock()
+	defer r.syncLock.Unlock()
+
+	if err := r.writeSyncCounter(counter); err != nil {
+		return err
+	}
+
+	r.syncCache = counter
+	return nil
+}
+
 func (r *Replica) SetRevisionCounter(counter int64) error {
 	r.Lock()
 	if r.mode != types.RW {

--- a/replica/sync_counter.go
+++ b/replica/sync_counter.go
@@ -1,0 +1,137 @@
+package replica
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/openebs/jiva/types"
+
+	"github.com/longhorn/sparse-tools/sparse"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	syncCounterFile             = "sync.counter"
+	syncFileMode    os.FileMode = 0600
+	syncBlockSize               = 4096
+)
+
+func (r *Replica) readSyncCounter() (int64, error) {
+	if r.syncFile == nil {
+		return 0, fmt.Errorf("BUG: sync file wasn't initialized")
+	}
+
+	buf := make([]byte, syncBlockSize)
+	_, err := r.syncFile.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		return 0, fmt.Errorf("fail to read from sync counter file: %v", err)
+	}
+	counter, err := strconv.ParseInt(strings.Trim(string(buf), "\x00"), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("fail to parse sync counter file: %v", err)
+	}
+	return counter, nil
+}
+
+func (r *Replica) writeSyncCounter(counter int64) error {
+	if r.syncFile == nil {
+		return fmt.Errorf("BUG: sync file wasn't initialized")
+	}
+
+	buf := make([]byte, syncBlockSize)
+	copy(buf, []byte(strconv.FormatInt(counter, 10)))
+	_, err := r.syncFile.WriteAt(buf, 0)
+	if err != nil {
+		return fmt.Errorf("fail to write to sync counter file: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Replica) openSyncFile(isCreate bool) error {
+	var err error
+	r.syncFile, err = sparse.NewDirectFileIoProcessor(r.diskPath(syncCounterFile), os.O_RDWR, syncFileMode, isCreate)
+	return err
+}
+
+func (r *Replica) initSyncCounter() error {
+	r.syncLock.Lock()
+	defer r.syncLock.Unlock()
+
+	if _, err := os.Stat(r.diskPath(syncCounterFile)); err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		// file doesn't exist yet
+		if err := r.openSyncFile(true); err != nil {
+			logrus.Errorf("failed to open sync counter file")
+			return err
+		}
+		if err := r.writeSyncCounter(1); err != nil {
+			logrus.Errorf("failed to update sync counter")
+			return err
+		}
+	} else if err := r.openSyncFile(false); err != nil {
+		logrus.Errorf("open existing sync counter file failed")
+		return err
+	}
+
+	counter, err := r.readSyncCounter()
+	if err != nil {
+		logrus.Errorf("failed to read sync counter")
+		return err
+	}
+	// Don't use r.syncCache directly
+	// r.syncCache is an internal cache, to avoid read from disk
+	// everytime when counter needs to be updated.
+	// And it's protected by syncLock
+	r.syncCache = counter
+	return nil
+}
+
+func (r *Replica) GetSyncCounter() int64 {
+	r.syncLock.Lock()
+	defer r.syncLock.Unlock()
+
+	counter, err := r.readSyncCounter()
+	if err != nil {
+		logrus.Error("Fail to get sync counter: ", err)
+		// -1 will result in the replica to be discarded
+		return -1
+	}
+	r.syncCache = counter
+	return counter
+}
+
+func (r *Replica) SetSyncCounter(counter int64) error {
+	r.Lock()
+	if r.mode != types.RW {
+		r.Unlock()
+		return fmt.Errorf("setting synccounter during %v mode is invalid", r.mode)
+	}
+	r.Unlock()
+	r.syncLock.Lock()
+	defer r.syncLock.Unlock()
+
+	if err := r.writeSyncCounter(counter); err != nil {
+		return err
+	}
+
+	r.syncCache = counter
+	return nil
+}
+
+func (r *Replica) increaseSyncCounter() error {
+	r.syncLock.Lock()
+	defer r.syncLock.Unlock()
+
+	if err := r.writeSyncCounter(r.syncCache + 1); err != nil {
+		return err
+	}
+
+	r.syncCache++
+	return nil
+}

--- a/types/types.go
+++ b/types/types.go
@@ -72,6 +72,7 @@ type Backend interface {
 	GetVolUsage() (VolUsage, error)
 	SetReplicaMode(mode Mode) error
 	SetRevisionCounter(counter int64) error
+	SetSyncCounter(counter int64) error
 	SetRebuilding(rebuilding bool) error
 	GetMonitorChannel() MonitorChannel
 	StopMonitoring()
@@ -113,11 +114,12 @@ type Replica struct {
 }
 
 type RegReplica struct {
-	Address  string
-	UpTime   time.Duration
-	RevCount int64
-	RepType  string
-	RepState string
+	Address   string
+	UpTime    time.Duration
+	RevCount  int64
+	RepType   string
+	RepState  string
+	SyncCount int64
 }
 
 type IOStats struct {


### PR DESCRIPTION
This commit adds a flag in replicas and controller to enable buffered io. This improves the read/write performance significantly and recommended for the databases which send the sync periodically.
To enable the buffered io's one needs to pass following flag in the deployment of controller and replica.
`./jiva replica --buffered-io --frontendIP 127.0.0.1 --listen 127.0.0.1:9502 --size 2G vol1`
`./jiva controller --buffered-io --frontend gotgt --frontendIP 127.0.0.1 store1`

Limitations

- O_DIRECT does not guarantee that the data is written to the disk and the same is true for the alternative approach.
- Revision count will be increased immediately even though the data is not reached to the disk.
- Abrupt shutdown of the node may lead to partial data loss. It can be a few ms to seconds worth of the data (This scenario is not tested yet).
- Since we do PUNCH_HOLE on the files in case of overwrites in the background, replicas will be punching holes in the older snapshots even though the writes haven’t been successful in the latest file.
- May degrade the performance when heavy IO’s are being performed on the disk as hit ratio may go down so an additional overhead of querying io will be added to read from the page cache first and if not found then go back to the disk to read. Same is true for the write io’s as I/O wait might increase as well.
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>