### PR TITLE
refact(controller): generate url for resize action on volume

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1429,8 +1429,8 @@ test_volume_resize() {
 	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
 	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
 	verify_rw_rep_count "2"
-	id=$(curl http://$CONTROLLER_IP:9501/v1/volumes | jq '.data[0].id' |  tr -d '"')
-	curl -H "Content-Type: application/json" -X POST -d '{"name":"store1", "size": "10G"}' http://$CONTROLLER_IP:9501/v1/volumes/$id?action=resize
+	resizeUrl=$(curl http://$CONTROLLER_IP:9501/v1/volumes | jq '.data[0].actions.resize' |  tr -d '"')
+	curl -H "Content-Type: application/json" -X POST -d '{"name":"store1", "size":"10G"}' "$resizeUrl"
 
 	upgraded_size=$((10*1024*1024*1024))
 	size=$(curl http://$REPLICA_IP1:9502/v1/replicas/1 | jq '.size' | tr -d '"')

--- a/controller/control.go
+++ b/controller/control.go
@@ -508,13 +508,13 @@ func (c *Controller) Resize(name string, size string) error {
 	}
 	err = c.handleErrorNoLock(c.backend.Resize(name, size))
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to resize replica, err: %v", err)
 	}
 
 	if c.frontend != nil {
 		err = c.frontend.Resize(uint64(sizeInBytes))
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed to resize from frontend, err: %v", err)
 		}
 	}
 	c.size = sizeInBytes

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -145,6 +145,7 @@ func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int
 		v.Actions["snapshot"] = context.UrlBuilder.ActionLink(v.Resource, "snapshot")
 		v.Actions["revert"] = context.UrlBuilder.ActionLink(v.Resource, "revert")
 		v.Actions["deleteSnapshot"] = context.UrlBuilder.ActionLink(v.Resource, "deleteSnapshot")
+		v.Actions["resize"] = context.UrlBuilder.ActionLink(v.Resource, "resize")
 	}
 	return v
 }

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -130,7 +130,9 @@ func (s *Server) ResizeVolume(rw http.ResponseWriter, req *http.Request) error {
 		return err
 	}
 
+	logrus.Infof("Resize volume to %s", input.Size)
 	if err := s.c.Resize(input.Name, input.Size); err != nil {
+		logrus.Error(err)
 		return err
 	}
 


### PR DESCRIPTION
With the earlier approach user needs to fetch the volume id from
`/v1/volumes` endpoint of controller and then generate the resize
url manually.

This commit add action resize to generates the URL for resize operation which
can be used for the REST API calls.
Improve test to verify the same
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>