### PR TITLE
[WIP] fix(replica): persist last IO offset and size

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1357,7 +1357,7 @@ test_upgrade() {
 }
 
 test_upgrades() {
-	test_upgrade "openebs/jiva:1.4.0" "replica-controller"
+	test_upgrade "openebs/jiva:1.6.0" "replica-controller"
 }
 
 di_test_on_raw_disk() {

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1457,7 +1457,6 @@ create_auto_generated_snapshot() {
 
 	# This will create an auto generated snapshot(Snap1) with the above data
 	docker stop $replica1_id
-	verify_rw_rep_count "2"
 	docker start $replica1_id
 	verify_rw_rep_count "3"
 	snaplist_final=`ls /tmp/vol1 | grep .img | grep -v meta | grep  -v head`

--- a/controller/control.go
+++ b/controller/control.go
@@ -939,7 +939,7 @@ func (c *Controller) Start(addresses ...string) error {
 // on the app.
 func (c *Controller) WriteAt(b []byte, off int64) (int, error) {
 	c.Lock()
-	if c.ReadOnly == true && !c.logged {
+	if c.ReadOnly && !c.logged {
 		c.logged = true
 		err := fmt.Errorf("Mode: ReadOnly")
 		c.Unlock()

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -178,5 +178,5 @@ func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
 		return nil, err
 	}
 
-	return rwChain[1:], nil
+	return rwChain, nil
 }

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -10,6 +10,11 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
+const (
+	// VolumeVersion is the version of the volume
+	VolumeVersion = 1
+)
+
 type Timeout struct {
 	client.Resource
 	Timeout        string `json:"timeout"`
@@ -32,6 +37,7 @@ type Volume struct {
 	Name         string `json:"name"`
 	ReplicaCount int    `json:"replicaCount"`
 	ReadOnly     string `json:"readOnly"`
+	Version      int    `json:"version"`
 }
 
 type VolumeCollection struct {
@@ -136,6 +142,7 @@ func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int
 		Name:         name,
 		ReplicaCount: replicas,
 		ReadOnly:     ReadOnly,
+		Version:      VolumeVersion,
 	}
 
 	if replicas == 0 {

--- a/error-inject/default.go
+++ b/error-inject/default.go
@@ -14,6 +14,9 @@ func AddPreloadTimeout() {}
 // AddPunchHoleTimeout add delay in while punching hole
 func AddPunchHoleTimeout() {}
 
+// AddWriteTimeout add delay in while writing
+func AddWriteTimeout() {}
+
 // DisablePunchHoles is used for disabling punch holes
 func DisablePunchHoles() bool { return false }
 

--- a/error-inject/inject.go
+++ b/error-inject/inject.go
@@ -62,3 +62,10 @@ func AddPunchHoleTimeout() {
 	logrus.Infof("Add punch hole timeout of %vs for debug build", timeout)
 	time.Sleep(time.Duration(timeout) * time.Second)
 }
+
+// AddWriteTimeout add delay in while writing
+func AddWriteTimeout() {
+	timeout, _ := strconv.Atoi(os.Getenv("WRITE_TIMEOUT"))
+	logrus.Infof("Write timeout of %vs for debug build", timeout)
+	time.Sleep(time.Duration(timeout) * time.Second)
+}

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -215,6 +215,12 @@ func (c *ReplicaClient) GetReplica() (rest.Replica, error) {
 	return replica, err
 }
 
+func (c *ReplicaClient) GetLastIO() (*rest.LastIO, error) {
+	var lastIO rest.LastIO
+	err := c.get(c.address+"/readlastio", &lastIO)
+	return &lastIO, err
+}
+
 func (c *ReplicaClient) ReloadReplica() (rest.Replica, error) {
 	var replica rest.Replica
 

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -215,6 +215,7 @@ func (c *ReplicaClient) GetReplica() (rest.Replica, error) {
 	return replica, err
 }
 
+// GetLastIO get the last IO data over REST call
 func (c *ReplicaClient) GetLastIO() (*rest.LastIO, error) {
 	var lastIO rest.LastIO
 	err := c.get(c.address+"/readlastio", &lastIO)

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -359,6 +359,7 @@ func (r *Replica) Reload() (*Replica, error) {
 	}
 	newReplica.mode = r.mode
 	newReplica.info.Dirty = r.info.Dirty
+	newReplica.lastIO = r.lastIO
 	return newReplica, nil
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -40,16 +40,19 @@ var (
 	diskPattern = regexp.MustCompile(`volume-head-(\d)+.img`)
 )
 
+// LastIO holds the info of last processed IO
 type LastIO struct {
 	Offset string `json:"offset"`
 	Size   int    `json:"size"`
 }
 
+// Data holds the data and metadata of Last IO
 type Data struct {
 	LastIO LastIO `json:"lio"`
 	Buffer []byte `json:"buffer"`
 }
 
+// Replica holds the fields related to replica
 type Replica struct {
 	sync.RWMutex
 	volume           diffDisk

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -8,6 +8,11 @@ import (
 	"github.com/rancher/go-rancher/client"
 )
 
+const (
+	// ReplicaVersion is the version of replica
+	ReplicaVersion = 1
+)
+
 type Replica struct {
 	client.Resource
 	Dirty             bool                        `json:"dirty"`
@@ -26,6 +31,7 @@ type Replica struct {
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
 	CloneStatus       string                      `json:"clonestatus"`
+	Version           int                         `json:"version"`
 }
 
 // LastIO holds the data of last IO
@@ -137,6 +143,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 			Id:      "1",
 			Actions: map[string]string{},
 		},
+		Version: ReplicaVersion,
 	}
 
 	r.State = string(state)

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -28,6 +28,11 @@ type Replica struct {
 	CloneStatus       string                      `json:"clonestatus"`
 }
 
+type LastIO struct {
+	client.Resource
+	Data replica.Data `json:"data"`
+}
+
 type DeleteReplicaOutput struct {
 	client.Resource
 }
@@ -289,7 +294,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("revisionCounter", RevisionCounter{})
 	schemas.AddType("replicaCounter", ReplicaCounter{})
 	schemas.AddType("replacediskInput", ReplaceDiskInput{})
-
+	schemas.AddType("readlastio", LastIO{})
 	delete := schemas.AddType("delete", DeleteReplicaOutput{})
 	delete.ResourceMethods = []string{"DELETE"}
 

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -28,6 +28,7 @@ type Replica struct {
 	CloneStatus       string                      `json:"clonestatus"`
 }
 
+// LastIO holds the data of last IO
 type LastIO struct {
 	client.Resource
 	Data replica.Data `json:"data"`

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -57,6 +57,7 @@ func (s *Server) GetUsage(apiContext *api.ApiContext) (*types.VolUsage, error) {
 	return s.s.GetUsage()
 }
 
+// GetLastIO reads the data of last IO from file
 func (s *Server) GetLastIO(rw http.ResponseWriter, req *http.Request) error {
 	var (
 		lio *replica.Data

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
@@ -54,6 +55,31 @@ func (s *Server) GetUsage(apiContext *api.ApiContext) (*types.VolUsage, error) {
 	s.s.RLock()
 	defer s.s.RUnlock()
 	return s.s.GetUsage()
+}
+
+func (s *Server) GetLastIO(rw http.ResponseWriter, req *http.Request) error {
+	var (
+		lio *replica.Data
+		err error
+	)
+
+	apiContext := api.GetApiContext(req)
+	lio, err = s.s.GetLastIOData()
+	if err != nil {
+		return fmt.Errorf("fail to get last io data, err: %v", err)
+	}
+
+	resp := &LastIO{
+		Resource: client.Resource{
+			Type:    "readlastio",
+			Id:      "1",
+			Actions: map[string]string{},
+			Links:   map[string]string{},
+		},
+		Data: *lio,
+	}
+	apiContext.Write(resp)
+	return nil
 }
 
 func (s *Server) GetStats(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -52,6 +52,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("GET").Path("/v1/replicas").Handler(f(schemas, s.ListReplicas))
 	router.Methods("GET").Path("/v1/replicas/{id}").Handler(f(schemas, s.GetReplica))
 	router.Methods("GET").Path("/v1/replicas/{id}/volusage").Handler(f(schemas, s.GetVolUsage))
+	router.Methods("GET").Path("/v1/readlastio").Handler(f(schemas, s.GetLastIO))
 	router.Methods("DELETE").Path("/v1/replicas/{id}").Handler(f(schemas, s.DeleteReplica))
 
 	router.Methods("DELETE").Path("/v1/delete").Handler(f(schemas, s.DeleteVolume))

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -29,11 +29,47 @@ func (r *Replica) readRevisionCounter() (int64, error) {
 	if err != nil && err != io.EOF {
 		return 0, fmt.Errorf("fail to read from revision counter file: %v", err)
 	}
-	counter, err := strconv.ParseInt(strings.Trim(string(buf), "\x00"), 10, 64)
+
+	str := strings.Trim(string(buf), "\x00")
+	list := strings.Split(str, ",")
+	counter, err := strconv.ParseInt(list[0], 10, 64)
 	if err != nil {
 		return 0, fmt.Errorf("fail to parse revision counter file: %v", err)
 	}
+
 	return counter, nil
+}
+
+func (r *Replica) readLastIO() (LastIO, error) {
+	var (
+		size int
+	)
+	if r.revisionFile == nil {
+		return LastIO{}, fmt.Errorf("BUG: revision file wasn't initialized")
+	}
+
+	buf := make([]byte, revisionBlockSize)
+	_, err := r.revisionFile.ReadAt(buf, 0)
+	if err != nil && err != io.EOF {
+		return LastIO{}, fmt.Errorf("fail to read from revision counter file: %v", err)
+	}
+
+	str := strings.Trim(string(buf), "\x00")
+	list := strings.Split(str, ",")
+	if len(list) < 3 {
+		// upgrade case where revision.counter doesn't have last IO info
+		return LastIO{}, nil
+	}
+
+	size, err = strconv.Atoi(list[2])
+	if err != nil {
+		return LastIO{}, fmt.Errorf("fail to parse size: %v, err: %v", list[2], err)
+	}
+
+	return LastIO{
+		Offset: list[1],
+		Size:   size,
+	}, nil
 }
 
 func (r *Replica) writeRevisionCounter(counter int64) error {
@@ -42,7 +78,8 @@ func (r *Replica) writeRevisionCounter(counter int64) error {
 	}
 
 	buf := make([]byte, revisionBlockSize)
-	copy(buf, []byte(strconv.FormatInt(counter, 10)))
+	str := strconv.FormatInt(counter, 10) + "," + r.lastIO.Offset + "," + strconv.Itoa(r.lastIO.Size)
+	copy(buf, []byte(str))
 	_, err := r.revisionFile.WriteAt(buf, 0)
 	if err != nil {
 		return fmt.Errorf("fail to write to revision counter file: %v", err)
@@ -81,14 +118,18 @@ func (r *Replica) initRevisionCounter() error {
 
 	counter, err := r.readRevisionCounter()
 	if err != nil {
-		logrus.Errorf("failed to read revision counter")
-		return err
+		return fmt.Errorf("failed to read revision counter, err: %v", err)
 	}
 	// Don't use r.revisionCache directly
 	// r.revisionCache is an internal cache, to avoid read from disk
 	// everytime when counter needs to be updated.
 	// And it's protected by revisionLock
 	r.revisionCache = counter
+	r.lastIO, err = r.readLastIO()
+	if err != nil {
+		return fmt.Errorf("failed to read last IO info, err: %v", err)
+	}
+
 	return nil
 }
 
@@ -104,6 +145,20 @@ func (r *Replica) GetRevisionCounter() int64 {
 	}
 	r.revisionCache = counter
 	return counter
+}
+
+func (r *Replica) GetLastIO() LastIO {
+	r.revisionLock.Lock()
+	defer r.revisionLock.Unlock()
+
+	lastIO, err := r.readLastIO()
+	if err != nil {
+		logrus.Error("Fail to get last IO info: ", err)
+		// -1 will result in the replica to be discarded
+		return LastIO{}
+	}
+	r.lastIO = lastIO
+	return r.lastIO
 }
 
 // SetRevisionCounterCloneReplica set revision counter for clone replica

--- a/replica/revision_counter.go
+++ b/replica/revision_counter.go
@@ -58,21 +58,15 @@ func (r *Replica) readLastIO() (LastIO, error) {
 	list := strings.Split(str, ",")
 	if len(list) < 3 {
 		// upgrade case where revision.counter doesn't have last IO info
-		return LastIO{}, nil
+		return LastIO{Offset: "0"}, nil
 	}
-
 	size, err = strconv.Atoi(list[2])
 	if err != nil {
 		return LastIO{}, fmt.Errorf("fail to parse size: %v, err: %v", list[2], err)
 	}
 
-	offset := list[1]
-	if offset == "" {
-		offset = "0"
-	}
-
 	return LastIO{
-		Offset: offset,
+		Offset: list[1],
 		Size:   size,
 	}, nil
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	fibmap "github.com/frostschutz/go-fibmap"
+	inject "github.com/openebs/jiva/error-inject"
 	"github.com/openebs/jiva/types"
 	"github.com/sirupsen/logrus"
 )
@@ -517,6 +518,7 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	if s.r == nil {
 		return 0, fmt.Errorf("Volume no longer exist")
 	}
+	inject.AddWriteTimeout()
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -207,7 +207,7 @@ func (c *Client) operation(op uint32, buf []byte, offset int64, length int64) (i
 					err = ErrPingTimeout
 				}
 				c.SetError(err)
-				//journal.PrintLimited(1000) //flush automatically upon timeout
+				journal.PrintLimited(1000) //flush automatically upon timeout
 				return 0, err
 			}
 		}

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -441,10 +441,6 @@ func (t *Task) syncFiles(fromClient, toClient *replicaClient.ReplicaClient, disk
 	for i := range disks {
 		//We are syncing from the oldest snapshots to newer ones
 		disk := disks[len(disks)-1-i]
-		if strings.Contains(disk, "volume-head") {
-			return fmt.Errorf("Disk list shouldn't contain volume-head")
-		}
-
 		ok, err := isRevisionCountSame(fromClient, toClient, disk)
 		if err != nil {
 			return err

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -279,9 +279,20 @@ Register:
 	}
 
 	if !ok {
+		volume, err := t.client.GetVolume()
+		if err != nil {
+			return fmt.Errorf("failed to get volume info, error: %s", err.Error())
+		}
+
 		logrus.Infof("syncFiles from:%v to:%v", fromClient, toClient)
-		if err = t.syncFiles(fromClient, toClient, output.Disks); err != nil {
-			return err
+		if volume.ReadOnly == "true" {
+			if err = t.syncFiles(fromClient, toClient, output.Disks); err != nil {
+				return err
+			}
+		} else {
+			if err = t.syncFiles(fromClient, toClient, output.Disks[1:]); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit fixes/improves following:
- WO replica was going for full rebuild in case if there is only one missing IO
  by persisting the offset and size of the last IO so that we can sync the last
  I/O during initializing the replica.

- Create autogenerated snapshots only when volume is in RW mode, since it
  doesnot make any sense to create a new snapshot even when volume is in RO,
  this was also making the resync of last missing IO bit complex, since new
  snapshots were created due to which the need of persisting file name was
  arising and again this name was getting changed after generating new snapshot.

- sync head file as well when volume is in RO mode

- Fixes recurring ReadOnly logs

Design Link: https://docs.google.com/document/d/1DzjIB2Fu_EvNZ4VpeWCUjaa37MEWZztbFXpaw9yYjUQ/edit

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>