### PR TITLE
feat(jiva): add version compatibility framework

### DIFF
--- a/app/add_replica.go
+++ b/app/add_replica.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"errors"
+
 	"github.com/openebs/jiva/alertlog"
 
 	"github.com/openebs/jiva/replica"
@@ -36,11 +37,7 @@ func AutoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	if replicaType == "quorum" {
-		err = task.AddQuorumReplica(replica, s)
-	} else {
-		err = task.AddReplica(replica, s)
-	}
+	err = task.AddReplica(replica, s)
 	if err != nil {
 		alertlog.Logger.Errorw("",
 			"eventcode", "jiva.volume.replica.add.failure",

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -1345,6 +1345,13 @@ test_upgrade() {
 	JI=$UPGRADED_JI
 	if [ "$2" == "controller-replica" ]; then
 		upgrade_controller
+		sleep 5
+		count=$(docker logs $orig_controller_id 2>&1 | grep -c "Can't register replica:")
+		if [ "$count" -eq 0  ]; then
+			echo "upgrade controller-replica test failed"
+			collect_logs_and_exit
+		fi
+
 		upgrade_replicas
 	else
 		upgrade_replicas
@@ -1357,6 +1364,7 @@ test_upgrade() {
 }
 
 test_upgrades() {
+	test_upgrade "openebs/jiva:1.4.0" "controller-replica"
 	test_upgrade "openebs/jiva:1.4.0" "replica-controller"
 }
 
@@ -2002,6 +2010,7 @@ test_replica_restart_optimization() {
 }
 
 prepare_test_env
+test_upgrades
 test_volume_resize
 test_replica_restart_optimization
 test_delete_snapshot
@@ -2026,6 +2035,5 @@ run_data_integrity_test_with_fs_creation
 test_clone_feature
 test_duplicate_snapshot_failure
 #test_extent_support_file_system
-test_upgrades
 run_vdbench_test_on_volume
 run_libiscsi_test_suite

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strconv"
 	"strings"
-	"time"
 
 	"github.com/openebs/jiva/controller/rest"
 	"github.com/sirupsen/logrus"
@@ -202,14 +200,8 @@ func (c *ControllerClient) GetVolume() (*rest.Volume, error) {
 	return &volumes.Data[0], nil
 }
 
-func (c *ControllerClient) Register(address string, revisionCount int64, replicaType string, upTime time.Duration, state string) error {
-	err := c.post("/register", &rest.RegReplica{
-		Address:  address,
-		RevCount: strconv.FormatInt(revisionCount, 10),
-		RepType:  replicaType,
-		UpTime:   upTime,
-		RepState: state,
-	}, nil)
+func (c *ControllerClient) Register(rep *rest.RegReplica) error {
+	err := c.post("/register", &rep, nil)
 	return err
 }
 

--- a/controller/control.go
+++ b/controller/control.go
@@ -357,9 +357,7 @@ func (c *Controller) registerReplica(register types.RegReplica) error {
 	logrus.Infof("Register Replica, %+v", register)
 
 	if register.Version < types.ReplicaVersion {
-		msg := fmt.Sprintf("Can't register replica: %v with version: %v, supported version must be > %v", register.Address, register.Version, types.ReplicaVersion)
-		logrus.Error(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("Can't register replica: %v with version: %v, supported version must be > %v", register.Address, register.Version, types.ReplicaVersion)
 	}
 
 	_, ok := c.RegisteredReplicas[register.Address]

--- a/controller/control.go
+++ b/controller/control.go
@@ -354,8 +354,13 @@ func (c *Controller) signalToAdd() {
 func (c *Controller) registerReplica(register types.RegReplica) error {
 	c.Lock()
 	defer c.Unlock()
-	logrus.Infof("Register Replica, Address: %v Uptime: %v State: %v Type: %v RevisionCount: %v",
-		register.Address, register.UpTime, register.RepState, register.RepType, register.RevCount)
+	logrus.Infof("Register Replica, %+v", register)
+
+	if register.Version < types.ReplicaVersion {
+		msg := fmt.Sprintf("Can't register replica: %v with version: %v, supported version must be > %v", register.Address, register.Version, types.ReplicaVersion)
+		logrus.Error(msg)
+		return fmt.Errorf(msg)
+	}
 
 	_, ok := c.RegisteredReplicas[register.Address]
 	if !ok {

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -32,6 +32,7 @@ type Volume struct {
 	Name         string `json:"name"`
 	ReplicaCount int    `json:"replicaCount"`
 	ReadOnly     string `json:"readOnly"`
+	Version      int    `json:"version"`
 }
 
 type VolumeCollection struct {
@@ -110,6 +111,7 @@ type PrepareRebuildOutput struct {
 	Disks []string `json:"disks"`
 }
 
+// RegReplica holds the field for registration of replica
 type RegReplica struct {
 	client.Resource
 	Address  string        `json:"Address"`
@@ -117,6 +119,7 @@ type RegReplica struct {
 	RepType  string        `json:"RepType"`
 	RepState string        `json:"RepState"`
 	UpTime   time.Duration `json:"UpTime"`
+	Version  int           `json:"version"`
 }
 
 // NewVolume ...
@@ -136,6 +139,7 @@ func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int
 		Name:         name,
 		ReplicaCount: replicas,
 		ReadOnly:     ReadOnly,
+		Version:      types.ControllerVersion,
 	}
 
 	if replicas == 0 {

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -110,6 +110,7 @@ func (s *Server) RegisterReplica(rw http.ResponseWriter, req *http.Request) erro
 		RepType:  regReplica.RepType,
 		UpTime:   regReplica.UpTime,
 		RepState: regReplica.RepState,
+		Version:  regReplica.Version,
 	}
 	code = http.StatusOK
 	rw.WriteHeader(code)

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/openebs/jiva/replica"
+	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
@@ -26,6 +27,7 @@ type Replica struct {
 	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
 	UsedBlocks        string                      `json:"usedblocks"`
 	CloneStatus       string                      `json:"clonestatus"`
+	Version           int                         `json:"version"`
 }
 
 type DeleteReplicaOutput struct {
@@ -131,6 +133,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 			Id:      "1",
 			Actions: map[string]string{},
 		},
+		Version: types.ReplicaVersion,
 	}
 
 	r.State = string(state)

--- a/types/types.go
+++ b/types/types.go
@@ -12,8 +12,10 @@ const (
 	INIT   = Mode("INIT")
 	CLOSED = Mode("CLOSED")
 
-	StateUp   = State("Up")
-	StateDown = State("Down")
+	StateUp           = State("Up")
+	StateDown         = State("Down")
+	ReplicaVersion    = 1
+	ControllerVersion = 1
 )
 
 const (
@@ -118,6 +120,7 @@ type RegReplica struct {
 	RevCount int64
 	RepType  string
 	RepState string
+	Version  int
 }
 
 type IOStats struct {


### PR DESCRIPTION
This commit adds version compatibility framework for adding replica to
controller and vice-versa.
From now on we will only allow upgrades in Replica -> Controller order else controller or replica will reject the requests.
replica will only allow controller with old or same version whereas controller will only allow replica with latest or same version.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>