### PR TITLE
fix(jiva): make read and write timeouts configurable

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/openebs/jiva/backend/dynamic"
@@ -14,6 +15,7 @@ import (
 	"github.com/openebs/jiva/backend/remote"
 	"github.com/openebs/jiva/controller"
 	"github.com/openebs/jiva/controller/rest"
+	"github.com/openebs/jiva/rpc"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
@@ -107,7 +109,10 @@ func startController(c *cli.Context) error {
 	}
 	name := c.Args()[0]
 	rf := util.CheckReplicationFactor()
-	logrus.Infof("REPLICATION_FACTOR: %v", rf)
+	types.RPCReadTimeout = util.GetReadTimeout() * time.Second
+	types.RPCWriteTimeout = util.GetWriteTimeout() * time.Second
+	logrus.Infof("REPLICATION_FACTOR: %v, RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", rf, types.RPCReadTimeout, types.RPCWriteTimeout)
+	rpc.SetRPCTimeout()
 
 	if !util.ValidVolumeName(name) {
 		return errors.New("invalid target name")

--- a/app/controller.go
+++ b/app/controller.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/gorilla/handlers"
 	"github.com/openebs/jiva/backend/dynamic"
@@ -109,10 +108,10 @@ func startController(c *cli.Context) error {
 	}
 	name := c.Args()[0]
 	rf := util.CheckReplicationFactor()
-	types.RPCReadTimeout = util.GetReadTimeout() * time.Second
-	types.RPCWriteTimeout = util.GetWriteTimeout() * time.Second
-	logrus.Infof("REPLICATION_FACTOR: %v, RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", rf, types.RPCReadTimeout, types.RPCWriteTimeout)
+	types.RPCReadTimeout = util.GetReadTimeout()
+	types.RPCWriteTimeout = util.GetWriteTimeout()
 	rpc.SetRPCTimeout()
+	logrus.Infof("REPLICATION_FACTOR: %v, RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", rf, types.RPCReadTimeout, types.RPCWriteTimeout)
 
 	if !util.ValidVolumeName(name) {
 		return errors.New("invalid target name")

--- a/app/replica.go
+++ b/app/replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"github.com/openebs/jiva/alertlog"
 	"net"
 	"net/http"
 	"os"
@@ -13,6 +12,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openebs/jiva/alertlog"
+
 	"github.com/openebs/jiva/types"
 
 	"github.com/docker/go-units"
@@ -20,6 +21,7 @@ import (
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/replica/rpc"
+	dataconn "github.com/openebs/jiva/rpc"
 	"github.com/openebs/jiva/sync"
 	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
@@ -173,6 +175,10 @@ func startReplica(c *cli.Context) error {
 	} else {
 		logrus.Infof("MAX_CHAIN_LENGTH: %v", types.MaxChainLength)
 	}
+	types.RPCReadTimeout = util.GetReadTimeout() * time.Second
+	types.RPCWriteTimeout = util.GetWriteTimeout() * time.Second
+	logrus.Infof("RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", types.RPCReadTimeout, types.RPCWriteTimeout)
+	dataconn.SetRPCTimeout()
 
 	dir := c.Args()[0]
 	replicaType := c.String("type")

--- a/app/replica.go
+++ b/app/replica.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/replica/rpc"
-	dataconn "github.com/openebs/jiva/rpc"
 	"github.com/openebs/jiva/sync"
 	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
@@ -175,10 +174,6 @@ func startReplica(c *cli.Context) error {
 	} else {
 		logrus.Infof("MAX_CHAIN_LENGTH: %v", types.MaxChainLength)
 	}
-	types.RPCReadTimeout = util.GetReadTimeout() * time.Second
-	types.RPCWriteTimeout = util.GetWriteTimeout() * time.Second
-	logrus.Infof("RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", types.RPCReadTimeout, types.RPCWriteTimeout)
-	dataconn.SetRPCTimeout()
 
 	dir := c.Args()[0]
 	replicaType := c.String("type")

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -84,7 +84,6 @@ cleanup() {
 	rm -rfv /mnt/logs
 	docker stop $(docker ps -aq)
 	docker rm $(docker ps -aq)
-	logout_of_volume
 }
 
 prepare_test_env() {
@@ -2032,6 +2031,7 @@ test_write_io_timeout() {
                 echo "Unable to detect iSCSI device during test_restart_add_replica"; collect_logs_and_exit
         fi
         verify_rw_rep_count "3"
+        verify_replica_cnt "3" "write io timeout test passed"
         logout_of_volume
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -238,8 +238,8 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
-	inject.AddPreloadTimeout()
 	logrus.Info("Start reading extents")
+	inject.AddPreloadTimeout()
 	if err := PreloadLunMap(&r.volume); err != nil {
 		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
 	}

--- a/replica/server.go
+++ b/replica/server.go
@@ -486,6 +486,7 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	if s.r == nil {
 		return 0, fmt.Errorf("Volume no longer exist")
 	}
+	time.Sleep(10 * time.Second)
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
 }

--- a/replica/server.go
+++ b/replica/server.go
@@ -486,7 +486,6 @@ func (s *Server) WriteAt(buf []byte, offset int64) (int, error) {
 	if s.r == nil {
 		return 0, fmt.Errorf("Volume no longer exist")
 	}
-	time.Sleep(10 * time.Second)
 	i, err := s.r.WriteAt(buf, offset)
 	return i, err
 }

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -8,6 +8,7 @@ import (
 
 	journal "github.com/longhorn/sparse-tools/stats"
 	inject "github.com/openebs/jiva/error-inject"
+	"github.com/openebs/jiva/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -24,6 +25,16 @@ var (
 	opPingTimeout   = 40 * time.Second
 	opUpdateTimeout = 15 * time.Second // client update
 )
+
+// SetRPCTimeout is used to custom timeouts for read and write
+func SetRPCTimeout() {
+	if types.RPCReadTimeout != 0 {
+		opReadTimeout = types.RPCReadTimeout
+	}
+	if types.RPCWriteTimeout != 0 {
+		opWriteTimeout = types.RPCWriteTimeout
+	}
+}
 
 //SampleOp operation
 type SampleOp int

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -18,8 +18,8 @@ var (
 	ErrPingTimeout = errors.New("Ping timeout")
 	//Retries are not required as the reader on msg->complete has already exited
 	opRetries       = 0
-	opReadTimeout   = 15 * time.Second // client read
-	opWriteTimeout  = 15 * time.Second // client write
+	opReadTimeout   = 30 * time.Second // client read
+	opWriteTimeout  = 30 * time.Second // client write
 	opSyncTimeout   = 30 * time.Second // client sync
 	opUnmapTimeout  = 30 * time.Second // client unmap
 	opPingTimeout   = 40 * time.Second

--- a/types/types.go
+++ b/types/types.go
@@ -16,6 +16,13 @@ const (
 	StateDown = State("Down")
 )
 
+var (
+	// RPCReadTimeout ...
+	RPCReadTimeout time.Duration
+	// RPCWriteTimeout ...
+	RPCWriteTimeout time.Duration
+)
+
 const (
 	// DrainStart flag is used to notify CreateHoles goroutine
 	// for draining the data in HoleCreatorChan

--- a/util/util.go
+++ b/util/util.go
@@ -176,20 +176,22 @@ func CheckReplicationFactor() int {
 	return int(replicationFactor)
 }
 
+// GetReadTimeout gets the read timeout value from the env
 func GetReadTimeout() time.Duration {
 	readTimeout, _ := strconv.ParseInt(os.Getenv("RPC_READ_TIMEOUT"), 10, 64)
 	if readTimeout == 0 {
-		logrus.Infof("WRITE_READ_TIMEOUT env not set")
+		logrus.Infof("RPC_READ_TIMEOUT env not set")
 		return time.Duration(readTimeout)
 	}
-	return time.Duration(readTimeout)
+	return time.Duration(readTimeout) * time.Second
 }
 
+// GetWriteTimeout gets the write timeout value from the env
 func GetWriteTimeout() time.Duration {
 	writeTimeout, _ := strconv.ParseInt(os.Getenv("RPC_WRITE_TIMEOUT"), 10, 64)
 	if writeTimeout == 0 {
 		logrus.Infof("RPC_WRITE_TIMEOUT env not set")
 		return time.Duration(writeTimeout)
 	}
-	return time.Duration(writeTimeout)
+	return time.Duration(writeTimeout) * time.Second
 }

--- a/util/util.go
+++ b/util/util.go
@@ -175,3 +175,21 @@ func CheckReplicationFactor() int {
 	}
 	return int(replicationFactor)
 }
+
+func GetReadTimeout() time.Duration {
+	readTimeout, _ := strconv.ParseInt(os.Getenv("RPC_READ_TIMEOUT"), 10, 64)
+	if readTimeout == 0 {
+		logrus.Infof("WRITE_READ_TIMEOUT env not set")
+		return time.Duration(readTimeout)
+	}
+	return time.Duration(readTimeout)
+}
+
+func GetWriteTimeout() time.Duration {
+	writeTimeout, _ := strconv.ParseInt(os.Getenv("RPC_WRITE_TIMEOUT"), 10, 64)
+	if writeTimeout == 0 {
+		logrus.Infof("RPC_WRITE_TIMEOUT env not set")
+		return time.Duration(writeTimeout)
+	}
+	return time.Duration(writeTimeout)
+}


### PR DESCRIPTION
commits adds RPC_READ_TIMEOUT and RPC_WRITE_TIMEOUT env
to configure read and write timeouts values.

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>