### PR TITLE
fix(jiva): make read and write timeouts configurable (#272)

### DIFF
--- a/app/controller.go
+++ b/app/controller.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openebs/jiva/backend/remote"
 	"github.com/openebs/jiva/controller"
 	"github.com/openebs/jiva/controller/rest"
+	"github.com/openebs/jiva/rpc"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
@@ -107,7 +108,10 @@ func startController(c *cli.Context) error {
 	}
 	name := c.Args()[0]
 	rf := util.CheckReplicationFactor()
-	logrus.Infof("REPLICATION_FACTOR: %v", rf)
+	types.RPCReadTimeout = util.GetReadTimeout()
+	types.RPCWriteTimeout = util.GetWriteTimeout()
+	rpc.SetRPCTimeout()
+	logrus.Infof("REPLICATION_FACTOR: %v, RPC_READ_TIMEOUT: %v, RPC_WRITE_TIMEOUT: %v", rf, types.RPCReadTimeout, types.RPCWriteTimeout)
 
 	if !util.ValidVolumeName(name) {
 		return errors.New("invalid target name")

--- a/app/replica.go
+++ b/app/replica.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"errors"
-	"github.com/openebs/jiva/alertlog"
 	"net"
 	"net/http"
 	"os"
@@ -12,6 +11,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/openebs/jiva/alertlog"
 
 	"github.com/openebs/jiva/types"
 

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -398,7 +398,8 @@ verify_controller_rep_state() {
 # start_controller CONTROLLER_IP
 start_controller() {
 	controller_id=$(docker run -d --net stg-net --ip $1 -P --expose 3260 --expose 9501 --expose 9502-9504 $JI \
-			env REPLICATION_FACTOR="$3" launch controller --frontend gotgt --frontendIP "$1" "$2")
+          env REPLICATION_FACTOR="$3" RPC_WRITE_TIMEOUT="$4" launch controller --frontend gotgt --frontendIP "$1" "$2")
+
 	echo "$controller_id"
 }
 
@@ -1997,7 +1998,79 @@ test_replica_restart_optimization() {
         cleanup
 }
 
+test_write_io_timeout() {
+        orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3")
+        replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+        replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+        verify_rw_rep_count "2"
+        verify_replica_cnt "2" "initial check for write io timeout passed"
+        login_to_volume "$CONTROLLER_IP:3260"
+        debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3" "PRELOAD_TIMEOUT" "25")
+        sleep 5
+        get_scsi_disk
+        if [ "$device_name"!="" ]; then
+                preload_success=0
+                iter=0
+                while [ "$preload_success" -lt 3 ]; do
+                        preload_success=`docker logs $debug_replica_id 2>&1 | grep -c "Start reading extents"`
+                        if [ "$iter" == 100 ]; then
+                                collect_logs_and_exit
+                        fi
+                        let iter=iter+1
+                        sleep 2
+                done
+                dd if=/dev/urandom of=/dev/$device_name bs=4K count=1000
+                if [ $? -eq 0 ]; then echo "IOs were written successfully while running 3 replicas stop/start test"
+                else
+                        echo "IOs errored out while running 3 replicas stop/start test"; collect_logs_and_exit
+                fi
+        else
+                echo "Unable to detect iSCSI device during test_restart_add_replica"; collect_logs_and_exit
+        fi
+        verify_rw_rep_count "3"
+        verify_replica_cnt "3" "write io timeout test passed"
+        logout_of_volume
+        cleanup
+}
+
+test_write_io_timeout_with_readwrite_env() {
+        orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "3" "15")
+        replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+        replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+        verify_rw_rep_count "2"
+        verify_replica_cnt "2" "initial check for write io timeout ENV passed"
+        login_to_volume "$CONTROLLER_IP:3260"
+        debug_replica_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP3" "vol3" "PRELOAD_TIMEOUT" "25")
+        sleep 5
+        get_scsi_disk
+        if [ "$device_name"!="" ]; then
+                preload_success=0
+                iter=0
+                while [ "$preload_success" -lt 3 ]; do
+                        preload_success=`docker logs $debug_replica_id 2>&1 | grep -c "Start reading extents"`
+                        if [ "$iter" == 100 ]; then
+                                collect_logs_and_exit
+                        fi
+                        let iter=iter+1
+                        sleep 2
+                done
+                dd if=/dev/urandom of=/dev/$device_name bs=4K count=1000
+                if [ $? -eq 0 ]; then echo "IOs were written successfully while running 3 replicas stop/start test"
+                else
+                        echo "IOs errored out while running 3 replicas stop/start test"; collect_logs_and_exit
+                fi
+        else
+                echo "Unable to detect iSCSI device during test_restart_add_replica"; collect_logs_and_exit
+        fi
+        verify_rw_rep_count "2"
+        verify_replica_cnt "2" "write io timeout ENV test passed"
+        logout_of_volume
+        cleanup
+}
+
 prepare_test_env
+test_write_io_timeout
+test_write_io_timeout_with_readwrite_env
 test_replica_restart_optimization
 test_delete_snapshot
 test_replica_restart_while_snap_deletion

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -238,8 +238,8 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 
 	r.insertBackingFile()
 	r.ReplicaType = replicaType
-	inject.AddPreloadTimeout()
 	logrus.Info("Start reading extents")
+	inject.AddPreloadTimeout()
 	if err := PreloadLunMap(&r.volume); err != nil {
 		return r, fmt.Errorf("failed to load Lun map, error: %v", err)
 	}

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -8,6 +8,7 @@ import (
 
 	journal "github.com/longhorn/sparse-tools/stats"
 	inject "github.com/openebs/jiva/error-inject"
+	"github.com/openebs/jiva/types"
 	"github.com/sirupsen/logrus"
 )
 
@@ -17,13 +18,23 @@ var (
 	ErrPingTimeout = errors.New("Ping timeout")
 	//Retries are not required as the reader on msg->complete has already exited
 	opRetries       = 0
-	opReadTimeout   = 15 * time.Second // client read
-	opWriteTimeout  = 15 * time.Second // client write
+	opReadTimeout   = 30 * time.Second // client read
+	opWriteTimeout  = 30 * time.Second // client write
 	opSyncTimeout   = 30 * time.Second // client sync
 	opUnmapTimeout  = 30 * time.Second // client unmap
 	opPingTimeout   = 40 * time.Second
 	opUpdateTimeout = 15 * time.Second // client update
 )
+
+// SetRPCTimeout is used to custom timeouts for read and write
+func SetRPCTimeout() {
+	if types.RPCReadTimeout != 0 {
+		opReadTimeout = types.RPCReadTimeout
+	}
+	if types.RPCWriteTimeout != 0 {
+		opWriteTimeout = types.RPCWriteTimeout
+	}
+}
 
 //SampleOp operation
 type SampleOp int

--- a/types/types.go
+++ b/types/types.go
@@ -16,6 +16,13 @@ const (
 	StateDown = State("Down")
 )
 
+var (
+	// RPCReadTimeout ...
+	RPCReadTimeout time.Duration
+	// RPCWriteTimeout ...
+	RPCWriteTimeout time.Duration
+)
+
 const (
 	// DrainStart flag is used to notify CreateHoles goroutine
 	// for draining the data in HoleCreatorChan

--- a/util/util.go
+++ b/util/util.go
@@ -175,3 +175,23 @@ func CheckReplicationFactor() int {
 	}
 	return int(replicationFactor)
 }
+
+// GetReadTimeout gets the read timeout value from the env
+func GetReadTimeout() time.Duration {
+	readTimeout, _ := strconv.ParseInt(os.Getenv("RPC_READ_TIMEOUT"), 10, 64)
+	if readTimeout == 0 {
+		logrus.Infof("RPC_READ_TIMEOUT env not set")
+		return time.Duration(readTimeout)
+	}
+	return time.Duration(readTimeout) * time.Second
+}
+
+// GetWriteTimeout gets the write timeout value from the env
+func GetWriteTimeout() time.Duration {
+	writeTimeout, _ := strconv.ParseInt(os.Getenv("RPC_WRITE_TIMEOUT"), 10, 64)
+	if writeTimeout == 0 {
+		logrus.Infof("RPC_WRITE_TIMEOUT env not set")
+		return time.Duration(writeTimeout)
+	}
+	return time.Duration(writeTimeout) * time.Second
+}


### PR DESCRIPTION
commits adds 
- RPC_READ_TIMEOUT and RPC_WRITE_TIMEOUT env to configure read and write timeouts values
- update the default timeouts to 30 secs

cherry-pick https://github.com/openebs/jiva/pull/272

Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>