### PR TITLE
fix(build):arm images to be pushed to jiva-arm64

### DIFF
--- a/scripts/push
+++ b/scripts/push
@@ -8,10 +8,11 @@ then
 fi
 
 source "$(dirname $0)/version"
-if [ "$XC_ARCH" == "amd64" ]; then
-  IMAGEID=$( docker images -q openebs/jiva:${VERSION} )
-else 
+if [ ${ARCH} == "linux_arm64" ]; then
   IMAGEID=$( docker images -q openebs/jiva-${XC_ARCH}:${VERSION} )
+  IMAGE_REPO="openebs/jiva-${XC_ARCH}"
+else 
+  IMAGEID=$( docker images -q openebs/jiva:${VERSION} )
 fi
 
 echo $IMAGEID 
@@ -41,6 +42,7 @@ if [ ${CURRENT_BRANCH} = "master" ]; then
   CI_TAG="ci"
 fi
 
+echo "Set the image repo as: ${IMAGE_REPO}"
 echo "Set the fixed ci image tag as: ${CI_TAG}"
 echo "Set the build/unique image tag as: ${BUILD_TAG}"
 


### PR DESCRIPTION
Fixes an issue with https://github.com/openebs/jiva/pull/275

The images should be pushed to jiva-arm64. 

Signed-off-by: kmova <kiran.mova@mayadata.io>