### PR TITLE
Adding build for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ jobs:
       arch: amd64
     - os: linux
       arch: arm64
+    - os: linux
+      arch: ppc64le
 
 addons:
   apt:

--- a/package/Dockerfile_build_ppc64le
+++ b/package/Dockerfile_build_ppc64le
@@ -1,0 +1,13 @@
+#Make the base image configurable. If BASE IMAGES is not provided
+#docker command will fail
+ARG BASE_IMAGE=ubuntu:18.04
+
+FROM $BASE_IMAGE
+
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY longhorn jivactl launch copy-binary launch-with-vm-backing-file launch-simple-jiva /usr/local/bin/
+
+VOLUME /usr/local/bin
+CMD ["longhorn"]

--- a/scripts/package
+++ b/scripts/package
@@ -8,6 +8,7 @@ cd $(dirname $0)/../package
 TAG=${TAG:-${VERSION}}
 REPO=${REPO:-openebs}
 BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
+BASE_DOCKER_IMAGEPPC64LE=${BASE_DOCKER_IMAGEPPC64LE:-ubuntu:18.04}
 
 if [ ! -x ../bin/longhorn ]; then
     ../scripts/build_binaries
@@ -20,6 +21,10 @@ if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
+elif [ ${ARCH} == "linux_ppc64le" ]
+then
+  DOCKERFILE=Dockerfile_build_ppc64le
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -8,6 +8,7 @@ cd $(dirname $0)/../package
 TAG=${TAG:-${VERSION}-DEBUG}
 REPO=${REPO:-openebs}
 BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
+BASE_DOCKER_IMAGEPPC64LE=${BASE_DOCKER_IMAGEPPC64LE:-ubuntu:18.04}
 
 if [ ! -x ../bin/debug/longhorn ]; then
     ../scripts/build_debug_binaries
@@ -19,6 +20,10 @@ if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
+elif [ ${ARCH} == "linux_ppc64le" ]
+then
+  DOCKERFILE=Dockerfile_build_ppc64le
+  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
   docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .

--- a/scripts/push
+++ b/scripts/push
@@ -8,7 +8,7 @@ then
 fi
 
 source "$(dirname $0)/version"
-if [ ${ARCH} == "linux_arm64" ]; then
+if [ ${ARCH} != "linux_amd64" ]; then
   IMAGEID=$( docker images -q openebs/jiva-${XC_ARCH}:${VERSION} )
   IMAGE_REPO="openebs/jiva-${XC_ARCH}"
 else 


### PR DESCRIPTION
This PR adds builds for jiva on ppc64le. Based on #275. 

- Add auto builds for ppc64le builds.
- Ubuntu:18.04 is a multi arch image, so it can be used directly.
- Dockerfile_build_ppc64le can be used to build on ppc64le env.
- Not running the test on ppc64le.