### PR TITLE
fix(replica): update snapshot name in metafile

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -933,6 +933,7 @@ func (r *Replica) createDisk(name string, userCreated bool, created string) erro
 	if newSnapName != "" {
 		r.addChildDisk(newSnapName, newHeadDisk.Name)
 		r.diskData[newSnapName] = r.diskData[oldHead]
+		r.diskData[newSnapName].Name = newSnapName
 		r.diskData[newSnapName].UserCreated = userCreated
 		r.diskData[newSnapName].Created = created
 		r.diskData[newSnapName].RevisionCounter = r.GetRevisionCounter()


### PR DESCRIPTION
This commit fixes the issue where snapshot name in meta file was not
updated after the hardlink. So head file name was seen in the replicas
in the meta files of snapshots but due to recent change in #260 we were
updating the metadata again with the latest revision count during reload
operation if revision count less than or equal to 1. So in some of the replicas
it was not updated since reload not occured or revision count was > 1.

This can be understood with the following example.

- Lets consider R1 comes up and creates H0 (revision count = 1)
- R2 comes up creates H1 and renames H0->S0 (metafiles will have H0 as name in
  S0 snapshot file) (revision count = 1)
- R2 completes sync from R1 and does reload
- During reload R2 founds revision count =1 thus it updates the metadata with
  latest revision count and write to the file hence the actual name is written
  to meta file of that snapshot.
- Since R1 was not reloaded it's snapshot's meta file was still showing H0 as
  name.
- Now let's consider the case if revision count was > 1 in that case it will not
  update the metafile but snapshot name will be similar to the other replica's
  snapshot name because of sync of metafile.
- Since the replica from where WO replica was syncing doesnot reload it won't update the name.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>