### PR TITLE
fix(replica): get usedlogical size info from healthy replica

### DIFF
--- a/app/snapshot.go
+++ b/app/snapshot.go
@@ -3,15 +3,16 @@ package app
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/openebs/jiva/alertlog"
 	"os"
 	"strings"
 	"text/tabwriter"
 
+	"github.com/openebs/jiva/alertlog"
 	"github.com/openebs/jiva/controller/rest"
 	"github.com/openebs/jiva/replica"
 	replicaClient "github.com/openebs/jiva/replica/client"
 	"github.com/openebs/jiva/sync"
+	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
@@ -262,7 +263,7 @@ func lsSnapshot(c *cli.Context) error {
 func infoSnapshot(c *cli.Context) error {
 	var output []byte
 
-	outputDisks := make(map[string]replica.DiskInfo)
+	outputDisks := make(map[string]types.DiskInfo)
 	cli := getCli(c)
 
 	replicas, err := cli.ListReplicas()
@@ -311,14 +312,15 @@ func infoSnapshot(c *cli.Context) error {
 					return err
 				}
 			}
-			info := replica.DiskInfo{
-				Name:        snapshot,
-				Parent:      parent,
-				Removed:     disk.Removed,
-				UserCreated: disk.UserCreated,
-				Children:    children,
-				Created:     disk.Created,
-				Size:        disk.Size,
+			info := types.DiskInfo{
+				Name:            snapshot,
+				Parent:          parent,
+				Removed:         disk.Removed,
+				UserCreated:     disk.UserCreated,
+				Children:        children,
+				Created:         disk.Created,
+				Size:            disk.Size,
+				RevisionCounter: disk.RevisionCounter,
 			}
 			if _, exists := outputDisks[snapshot]; !exists {
 				outputDisks[snapshot] = info
@@ -346,7 +348,7 @@ func infoSnapshot(c *cli.Context) error {
 	return nil
 }
 
-func getDisks(address string) (map[string]replica.DiskInfo, error) {
+func getDisks(address string) (map[string]types.DiskInfo, error) {
 	repClient, err := replicaClient.NewReplicaClient(address)
 	if err != nil {
 		return nil, err

--- a/controller/replicator.go
+++ b/controller/replicator.go
@@ -384,13 +384,12 @@ func (r *replicator) GetVolUsage() (types.VolUsage, error) {
 		volUsage types.VolUsage
 	)
 	for _, backend := range r.backends {
-		if backend.mode == types.ERR {
-			continue
+		if backend.mode == types.RW {
+			if volUsage, err = backend.backend.GetVolUsage(); err != nil {
+				continue
+			}
+			return volUsage, err
 		}
-		if volUsage, err = backend.backend.GetVolUsage(); err != nil {
-			continue
-		}
-		return volUsage, err
 	}
 	return types.VolUsage{}, err
 }

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -74,14 +74,15 @@ type VolumeStats struct {
 	TotalWriteTime       string `json:"TotalWriteTime"`
 	TotalWriteBlockCount string `json:"TotalWriteBlockCount"`
 
-	UsedLogicalBlocks string          `json:"UsedLogicalBlocks"`
-	UsedBlocks        string          `json:"UsedBlocks"`
-	SectorSize        string          `json:"SectorSize"`
-	Size              string          `json:"Size"`
-	UpTime            string          `json:"UpTime"`
-	Name              string          `json:"Name"`
-	Replica           []types.Replica `json:"Replicas"`
-	ControllerStatus  string          `json:"Status"`
+	UsedLogicalBlocks string              `json:"UsedLogicalBlocks"`
+	UsedBlocks        string              `json:"UsedBlocks"`
+	SectorSize        string              `json:"SectorSize"`
+	Size              string              `json:"Size"`
+	UpTime            string              `json:"UpTime"`
+	Name              string              `json:"Name"`
+	Replica           []types.Replica     `json:"Replicas"`
+	ReplicaInfo       []types.ReplicaInfo `json:"ReplicaInfo"`
+	ControllerStatus  string              `json:"Status"`
 }
 
 type SnapshotInput struct {

--- a/controller/rest/replica.go
+++ b/controller/rest/replica.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/openebs/jiva/types"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -41,11 +41,16 @@ func (s *Server) GetVolume(rw http.ResponseWriter, req *http.Request) error {
 
 func (s *Server) GetReplicaInfo() []types.ReplicaInfo {
 	var (
-		info []types.ReplicaInfo
-		wg   sync.WaitGroup
+		info     []types.ReplicaInfo
+		replicas []types.Replica
+		wg       sync.WaitGroup
 	)
 	infoLock := &sync.Mutex{}
-	replicas := s.c.ListReplicas()
+	s.c.RLock()
+	for _, rep := range s.c.ListReplicas() {
+		replicas = append(replicas, rep)
+	}
+	s.c.RUnlock()
 	wg.Add(len(replicas))
 	for _, replica := range replicas {
 		addr := replica.Address

--- a/controller/rest/volume.go
+++ b/controller/rest/volume.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
+	replicaClient "github.com/openebs/jiva/replica/client"
+	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/sirupsen/logrus"
@@ -36,6 +39,37 @@ func (s *Server) GetVolume(rw http.ResponseWriter, req *http.Request) error {
 	return nil
 }
 
+func (s *Server) GetReplicaInfo() []types.ReplicaInfo {
+	var (
+		info []types.ReplicaInfo
+		wg   sync.WaitGroup
+	)
+	infoLock := &sync.Mutex{}
+	replicas := s.c.ListReplicas()
+	wg.Add(len(replicas))
+	for _, replica := range replicas {
+		addr := replica.Address
+		go func(addr string) {
+			defer wg.Done()
+			repClient, err := replicaClient.NewReplicaClient(addr)
+			if err != nil {
+				return
+			}
+			repClient.SetTimeout(5 * time.Second)
+			repInfo, err := repClient.GetReplica()
+			if err != nil {
+				logrus.Infof("Error in getting info of replica: %v , error %v", addr, err)
+				return
+			}
+			infoLock.Lock()
+			info = append(info, repInfo.ReplicaInfo)
+			infoLock.Unlock()
+		}(addr)
+	}
+	wg.Wait()
+	return info
+}
+
 func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error {
 	var status string
 	apiContext := api.GetApiContext(req)
@@ -47,6 +81,8 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 	} else {
 		status = "RW"
 	}
+
+	replicaInfo := s.GetReplicaInfo()
 
 	volumeStats := &VolumeStats{
 		Resource:          client.Resource{Type: "stats"},
@@ -70,6 +106,7 @@ func (s *Server) GetVolumeStats(rw http.ResponseWriter, req *http.Request) error
 		UpTime:            fmt.Sprintf("%f", time.Since(s.c.StartTime).Seconds()),
 		Name:              s.c.Name,
 		Replica:           replicas,
+		ReplicaInfo:       replicaInfo,
 		ControllerStatus:  status,
 	}
 	apiContext.Write(volumeStats)

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1075,7 +1075,7 @@ func (r *Replica) readMetadata() (bool, error) {
 		}
 	}
 
-	r.volume.UsedBlocks += 1 // for revision.counter file while is of 4k
+	r.volume.UsedBlocks++ // for revision.counter file which is of 4k
 
 	return len(r.diskData) > 0, nil
 }

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -1075,7 +1075,7 @@ func (r *Replica) readMetadata() (bool, error) {
 		}
 	}
 
-	r.volume.UsedBlocks += 2 // One each for peer.details and revision.counter
+	r.volume.UsedBlocks += 1 // for revision.counter file while is of 4k
 
 	return len(r.diskData) > 0, nil
 }
@@ -1249,14 +1249,26 @@ func (r *Replica) ReadAt(buf []byte, offset int64) (int, error) {
 	return c, err
 }
 
-func (r *Replica) ListDisks() map[string]DiskInfo {
+func (r *Replica) GetUsedBlocks() string {
+	r.RLock()
+	defer r.RUnlock()
+	return strconv.FormatInt(r.volume.UsedBlocks, 10)
+}
+
+func (r *Replica) GetUsedLogicalBlocks() string {
+	r.RLock()
+	defer r.RUnlock()
+	return strconv.FormatInt(r.volume.UsedLogicalBlocks, 10)
+}
+
+func (r *Replica) ListDisks() map[string]types.DiskInfo {
 	r.RLock()
 	defer r.RUnlock()
 
-	result := map[string]DiskInfo{}
+	result := map[string]types.DiskInfo{}
 	for _, disk := range r.diskData {
 		diskSize := strconv.FormatInt(r.getDiskSize(disk.Name), 10)
-		diskInfo := DiskInfo{
+		diskInfo := types.DiskInfo{
 			Name:            disk.Name,
 			Parent:          disk.Parent,
 			Removed:         disk.Removed,

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -4,28 +4,14 @@ import (
 	"strconv"
 
 	"github.com/openebs/jiva/replica"
+	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
 
 type Replica struct {
 	client.Resource
-	Dirty             bool                        `json:"dirty"`
-	Rebuilding        bool                        `json:"rebuilding"`
-	Head              string                      `json:"head"`
-	Parent            string                      `json:"parent"`
-	Size              string                      `json:"size"`
-	SectorSize        int64                       `json:"sectorSize"`
-	State             string                      `json:"state"`
-	Chain             []string                    `json:"chain"`
-	Disks             map[string]replica.DiskInfo `json:"disks"`
-	RemainSnapshots   int                         `json:"remainsnapshots"`
-	ReplicaMode       string                      `json:"replicamode"`
-	RevisionCounter   string                      `json:"revisioncounter"`
-	ReplicaCounter    int64                       `json:"replicacounter"`
-	UsedLogicalBlocks string                      `json:"usedlogicalblocks"`
-	UsedBlocks        string                      `json:"usedblocks"`
-	CloneStatus       string                      `json:"clonestatus"`
+	types.ReplicaInfo
 }
 
 type DeleteReplicaOutput struct {
@@ -210,6 +196,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 	r.SectorSize = info.SectorSize
 	r.Size = strconv.FormatInt(info.Size, 10)
 	r.RevisionCounter = strconv.FormatInt(info.RevisionCounter, 10)
+	r.UsedBlocks, r.UsedLogicalBlocks = "0", "0" // replica must be initializing
 	if rep != nil {
 		r.Chain, _ = rep.DisplayChain()
 		r.Disks = rep.ListDisks()
@@ -217,6 +204,8 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		r.RevisionCounter = strconv.FormatInt(rep.GetRevisionCounter(), 10)
 		r.ReplicaMode = rep.GetReplicaMode()
 		r.CloneStatus = rep.GetCloneStatus()
+		r.UsedBlocks = rep.GetUsedBlocks()
+		r.UsedLogicalBlocks = rep.GetUsedLogicalBlocks()
 	}
 	return r
 }

--- a/types/types.go
+++ b/types/types.go
@@ -114,6 +114,35 @@ type Mode string
 
 type State string
 
+type DiskInfo struct {
+	Name            string   `json:"name"`
+	Parent          string   `json:"parent"`
+	Children        []string `json:"children"`
+	Removed         bool     `json:"removed"`
+	UserCreated     bool     `json:"usercreated"`
+	Created         string   `json:"created"`
+	Size            string   `json:"size"`
+	RevisionCounter int64    `json:"revisionCount"`
+}
+
+type ReplicaInfo struct {
+	Dirty             bool                `json:"dirty"`
+	Rebuilding        bool                `json:"rebuilding"`
+	Head              string              `json:"head"`
+	Parent            string              `json:"parent"`
+	Size              string              `json:"size"`
+	SectorSize        int64               `json:"sectorSize"`
+	State             string              `json:"state"`
+	Chain             []string            `json:"chain"`
+	Disks             map[string]DiskInfo `json:"disks"`
+	RemainSnapshots   int                 `json:"remainsnapshots"`
+	ReplicaMode       string              `json:"replicamode"`
+	RevisionCounter   string              `json:"revisioncounter"`
+	UsedLogicalBlocks string              `json:"usedlogicalblocks"`
+	UsedBlocks        string              `json:"usedblocks"`
+	CloneStatus       string              `json:"clonestatus"`
+}
+
 type Replica struct {
 	Address string `json:"Address"`
 	Mode    Mode   `json:"Mode"`


### PR DESCRIPTION
- This commit improves the logic to only get the usedlogical size from RW
  replica and additionally adds following info into stats
  * Chain info
  * UsedSize of snapshots
  * Detailed Snapshot info
- Fix the issue where revision count was showing as zero for the `jivactl
snapshot info` command.
- Move DiskInfo and ReplicaInfo to types.go as it is common across replica and controller
  for REST API calls.

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>