### PR TITLE
feat(replica): add option to flush log to file

### DIFF
--- a/app/log.go
+++ b/app/log.go
@@ -1,0 +1,71 @@
+package app
+
+import (
+	"github.com/openebs/jiva/util"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+)
+
+func LogCmd() cli.Command {
+	return cli.Command{
+		Name: "logtofile",
+		Subcommands: []cli.Command{
+			LogEnable(),
+			LogDisable(),
+		},
+		Action: func(c *cli.Context) {
+		},
+	}
+}
+
+func LogEnable() cli.Command {
+	return cli.Command{
+		Name: "enable",
+		Flags: []cli.Flag{
+			cli.IntFlag{
+				Name:  retentionPeriod,
+				Usage: "Retention period of log file in days",
+				Value: defaultRetentionPeriod,
+			},
+			cli.IntFlag{
+				Name:  maxLogFileSize,
+				Usage: "Max size of log file in mb",
+				Value: defaultLogFileSize,
+			},
+			cli.IntFlag{
+				Name:  maxBackups,
+				Usage: "Max number of log files to keep while creating new log file once size of log exceeds to maxLogFileSize",
+				Value: defaultMaxBackups,
+			},
+		},
+		Action: func(c *cli.Context) {
+			if err := setLogs(c, true); err != nil {
+				logrus.Fatalf("Fail to enable logs, err: %v", err)
+			}
+		},
+	}
+}
+
+func LogDisable() cli.Command {
+	return cli.Command{
+		Name: "disable",
+		Action: func(c *cli.Context) {
+			if err := setLogs(c, false); err != nil {
+				logrus.Fatalf("Fail to enable logs, err: %v", err)
+			}
+		},
+	}
+}
+
+func setLogs(c *cli.Context, enable bool) error {
+	cli := getCli(c)
+	if err := cli.SetLogging(util.LogToFile{
+		Enable:          enable,
+		MaxLogFileSize:  c.Int(maxLogFileSize),
+		MaxBackups:      c.Int(maxBackups),
+		RetentionPeriod: c.Int(retentionPeriod),
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/controller/client/controller_client.go
+++ b/controller/client/controller_client.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/openebs/jiva/controller/rest"
+	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -113,6 +114,17 @@ func (c *ControllerClient) CreateQuorumReplica(address string) (*rest.Replica, e
 		Address: address,
 	}, &resp)
 	return &resp, err
+}
+
+// SetLogging ...
+func (c *ControllerClient) SetLogging(lf util.LogToFile) error {
+	volume, err := c.GetVolume()
+	if err != nil {
+		return err
+	}
+	return c.post(volume.Actions["setlogging"], &rest.LoggingInput{
+		LogToFile: lf,
+	}, nil)
 }
 
 // DeleteSnapshot ...

--- a/controller/rest/model.go
+++ b/controller/rest/model.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/openebs/jiva/controller"
 	"github.com/openebs/jiva/types"
+	"github.com/openebs/jiva/util"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
@@ -101,6 +102,11 @@ type ResizeInput struct {
 	Size string `json:"size"`
 }
 
+type LoggingInput struct {
+	client.Resource
+	LogToFile util.LogToFile `json:"logtofile"`
+}
+
 type JournalInput struct {
 	client.Resource
 	Limit int `json:"limit"`
@@ -147,6 +153,7 @@ func NewVolume(context *api.ApiContext, name string, readOnly bool, replicas int
 		v.Actions["revert"] = context.UrlBuilder.ActionLink(v.Resource, "revert")
 		v.Actions["deleteSnapshot"] = context.UrlBuilder.ActionLink(v.Resource, "deleteSnapshot")
 		v.Actions["resize"] = context.UrlBuilder.ActionLink(v.Resource, "resize")
+		v.Actions["setlogging"] = context.UrlBuilder.ActionLink(v.Resource, "setlogging")
 	}
 	return v
 }
@@ -188,6 +195,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("startInput", StartInput{})
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("snapshotOutput", SnapshotOutput{})
+	schemas.AddType("setlogging", LoggingInput{})
 	schemas.AddType("revertInput", RevertInput{})
 	schemas.AddType("journalInput", JournalInput{})
 	schemas.AddType("prepareRebuildOutput", PrepareRebuildOutput{})
@@ -233,6 +241,9 @@ func NewSchema() *client.Schemas {
 		},
 		"deleteSnapshot": {
 			Input: "snapshotInput",
+		},
+		"setlogging": {
+			Input: "loggingInput",
 		},
 	}
 

--- a/controller/rest/router.go
+++ b/controller/rest/router.go
@@ -30,6 +30,7 @@ func NewRouter(s *Server) *mux.Router {
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "snapshot").Handler(f(schemas, s.SnapshotVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "revert").Handler(f(schemas, s.RevertVolume))
 	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "resize").Handler(f(schemas, s.ResizeVolume))
+	router.Methods("POST").Path("/v1/volumes/{id}").Queries("action", "setlogging").Handler(f(schemas, s.SetLogging))
 	router.Methods("DELETE").Path("/v1/volumes/{id}").Queries("action", "deleteSnapshot").Handler(f(schemas, s.DeleteSnapshot))
 	// Replicas
 	router.Methods("GET").Path("/v1/replicas").Handler(f(schemas, s.ListReplicas))

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/gostor/gotgt v0.1.1-0.20191128095459-2f1d32710a93
+	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b
 	github.com/prometheus/client_golang v1.5.1
@@ -21,6 +22,7 @@ require (
 	go.uber.org/zap v1.14.1
 	golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
 
 replace github.com/frostschutz/go-fibmap => github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
+github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b h1:yULW07dZXT8MhMg6U4BPJQ0vlylLAM23juksiZTX5LU=
@@ -159,6 +161,8 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func longhornCli() {
 		app.LsReplicaCmd(),
 		app.RmReplicaCmd(),
 		app.SnapshotCmd(),
+		app.LogCmd(),
 		app.BackupCmd(),
 		app.Journal(),
 	}

--- a/replica/client/client.go
+++ b/replica/client/client.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/openebs/jiva/replica/rest"
 	"github.com/openebs/jiva/sync/agent"
+	"github.com/openebs/jiva/util"
 	"github.com/sirupsen/logrus"
 )
 
@@ -128,6 +129,16 @@ func (c *ReplicaClient) Revert(name, created string) error {
 	return c.post(r.Actions["revert"], rest.RevertInput{
 		Name:    name,
 		Created: created,
+	}, nil)
+}
+
+func (c *ReplicaClient) SetLogging(lf util.LogToFile) error {
+	r, err := c.GetReplica()
+	if err != nil {
+		return err
+	}
+	return c.post(r.Actions["setlogging"], rest.LoggingInput{
+		LogToFile: lf,
 	}, nil)
 }
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -786,20 +786,8 @@ func (r *Replica) openFile(name string, flag int) (types.DiffDisk, error) {
 	return sparse.NewDirectFileIoProcessor(r.diskPath(name), os.O_RDWR|flag, 06666, true)
 }
 
-// after creating or deleting the file the directory also needs to be synced
-// in order to guarantee the file is visible across system crashes. See man
-// page of fsync for more details.
 func (r *Replica) syncDir() error {
-	f, err := os.Open(r.dir)
-	if err != nil {
-		return err
-	}
-	err = f.Sync()
-	closeErr := f.Close()
-	if err != nil {
-		return err
-	}
-	return closeErr
+	return util.SyncDir(r.dir)
 }
 
 func (r *Replica) createNewHead(oldHead, parent, created string) (types.DiffDisk, disk, error) {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -26,6 +26,7 @@ const (
 	metadataSuffix     = ".meta"
 	imgSuffix          = ".img"
 	volumeMetaData     = "volume.meta"
+	logMeta            = "log.meta"
 	defaultSectorSize  = 4096
 	headPrefix         = "volume-head-"
 	headSuffix         = ".img"

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/types"
+	"github.com/openebs/jiva/util"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 )
@@ -38,6 +39,11 @@ type RevertInput struct {
 type RebuildingInput struct {
 	client.Resource
 	Rebuilding bool `json:"rebuilding"`
+}
+
+type LoggingInput struct {
+	client.Resource
+	LogToFile util.LogToFile `json:"logtofile"`
 }
 
 type SnapshotInput struct {
@@ -136,6 +142,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["updatediskmode"] = true
 		actions["resize"] = true
 		actions["setrebuilding"] = true
+		actions["setlogging"] = true
 		actions["snapshot"] = true
 		actions["reload"] = true
 		actions["removedisk"] = true
@@ -160,6 +167,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["start"] = true
 		actions["resize"] = true
 		actions["setrebuilding"] = true
+		actions["setlogging"] = true
 		actions["close"] = true
 		actions["snapshot"] = true
 		actions["reload"] = true
@@ -176,6 +184,7 @@ func NewReplica(context *api.ApiContext, state replica.State, info replica.Info,
 		actions["resize"] = true
 		actions["snapshot"] = true
 		actions["setrebuilding"] = true
+		actions["setlogging"] = true
 		actions["close"] = true
 		actions["reload"] = true
 		actions["setreplicamode"] = true
@@ -233,6 +242,10 @@ func setReplicaResourceActions(replica *client.Schema) {
 			Input:  "rebuildingInput",
 			Output: "replica",
 		},
+		"setlogging": {
+			Input:  "loggingInput",
+			Output: "replica",
+		},
 		"create": {
 			Input:  "createInput",
 			Output: "replica",
@@ -269,6 +282,7 @@ func NewSchema() *client.Schemas {
 	schemas.AddType("schema", client.Schema{})
 	schemas.AddType("createInput", CreateInput{})
 	schemas.AddType("rebuildingInput", RebuildingInput{})
+	schemas.AddType("LoggerInput", LoggingInput{})
 	schemas.AddType("snapshotInput", SnapshotInput{})
 	schemas.AddType("removediskInput", RemoveDiskInput{})
 	schemas.AddType("revertInput", RevertInput{})

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -7,7 +7,9 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/types"
+	"github.com/openebs/jiva/util"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/sirupsen/logrus"
@@ -104,6 +106,18 @@ func (s *Server) doOp(req *http.Request, err error) error {
 	apiContext := api.GetApiContext(req)
 	apiContext.Write(s.Replica(apiContext))
 	return nil
+}
+
+func (s *Server) SetLogging(rw http.ResponseWriter, req *http.Request) error {
+	var input LoggingInput
+	apiContext := api.GetApiContext(req)
+	if err := apiContext.Read(&input); err != nil && err != io.EOF {
+		logrus.Errorf("Err %v in reading for setLogging", err)
+		return err
+	}
+	logrus.Infof("SetLogging to %v", input.LogToFile)
+
+	return s.doOp(req, util.SetLogging(replica.Dir, input.LogToFile))
 }
 
 func (s *Server) SetRebuilding(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/rest/router.go
+++ b/replica/rest/router.go
@@ -69,6 +69,7 @@ func NewRouter(s *Server) *mux.Router {
 		"removedisk":         s.RemoveDisk,
 		"replacedisk":        s.ReplaceDisk,
 		"setrebuilding":      s.SetRebuilding,
+		"setlogging":         s.SetLogging,
 		"create":             s.Create,
 		"revert":             s.RevertReplica,
 		"prepareremovedisk":  s.PrepareRemoveDisk,

--- a/replica/server.go
+++ b/replica/server.go
@@ -131,10 +131,6 @@ func (s *Server) isExtentSupported() error {
 func (s *Server) Create(size int64) error {
 	s.Lock()
 	defer s.Unlock()
-	if err := os.Mkdir(s.dir, 0700); err != nil && !os.IsExist(err) {
-		logrus.Errorf("failed to create directory: %s", s.dir)
-		return err
-	}
 	if err := s.isExtentSupported(); err != nil {
 		return err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
+	"github.com/natefinch/lumberjack"
 	uuid "github.com/satori/go.uuid"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
@@ -20,11 +22,97 @@ import (
 var (
 	MaximumVolumeNameSize = 64
 	parsePattern          = regexp.MustCompile(`(.*):(\d+)`)
+	Logrotator            *lumberjack.Logger
 )
 
 const (
+	LogInfo        = "log.info"
 	BlockSizeLinux = 512
+
+	MaxLogFileSize         = "maxLogFileSize"
+	RetentionPeriod        = "retentionPeriod"
+	MaxBackups             = "maxBackups"
+	DefaultLogFileSize     = 100
+	DefaultRetentionPeriod = 180
+	DefaultMaxBackups      = 5
 )
+
+type LogToFile struct {
+	Enable          bool `json:"enable"`
+	MaxLogFileSize  int  `json:"maxlogfilesize"`
+	RetentionPeriod int  `json:"retentionperiod"`
+	MaxBackups      int  `json:"maxbackups"`
+}
+
+func StartLoggingToFile(dir string, lf LogToFile) error {
+	fileName := dir + "/replica.log"
+	Logrotator = &lumberjack.Logger{
+		Filename:   fileName,
+		MaxSize:    lf.MaxLogFileSize,
+		MaxAge:     lf.RetentionPeriod,
+		MaxBackups: lf.MaxBackups,
+		LocalTime:  true,
+	}
+	logrus.SetOutput(io.MultiWriter(os.Stderr, Logrotator))
+	if err := WriteLogInfo(dir, lf); err != nil {
+		return err
+	}
+	logrus.Infof("Configured logging with retentionPeriod: %v, maxLogFileSize: %v, maxBackups: %v",
+		lf.RetentionPeriod, lf.MaxLogFileSize, lf.MaxBackups)
+	return nil
+}
+
+func ReadLogInfo(dir string) (LogToFile, error) {
+	lf := &LogToFile{}
+	p := dir + "/" + LogInfo
+	f, err := os.Open(p)
+	if err != nil {
+		return LogToFile{}, err
+	}
+	defer f.Close()
+
+	err = json.NewDecoder(f).Decode(lf)
+	return *lf, err
+}
+
+func WriteLogInfo(dir string, lf LogToFile) error {
+	path := dir + "/" + LogInfo
+	f, err := os.Create(path + ".tmp")
+	if err != nil {
+		logrus.Errorf("failed to create temp file: %s while WriteLogInfo", LogInfo)
+		return err
+	}
+	defer f.Close()
+
+	if err := json.NewEncoder(f).Encode(&lf); err != nil {
+		logrus.Errorf("failed to encode the data to file: %s", f.Name())
+		return err
+	}
+
+	if err := f.Close(); err != nil {
+		logrus.Errorf("failed to close file after encoding to file: %s", f.Name())
+		return err
+	}
+
+	return os.Rename(path+".tmp", path)
+}
+
+func SetLogging(dir string, lf LogToFile) error {
+	if !lf.Enable {
+		logrus.Infof("Disable logging to file")
+		if Logrotator != nil {
+			if err := Logrotator.Close(); err != nil {
+				return err
+			}
+		}
+		return WriteLogInfo(dir, lf)
+	}
+	return StartLoggingToFile(dir, lf)
+}
+
+func LogRotate(dir string) error {
+	return Logrotator.Rotate()
+}
 
 // ParseAddresses returns the base address and two with subsequent ports
 func ParseAddresses(address string) (string, string, string, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -98,13 +98,15 @@ func WriteLogInfo(dir string, lf LogToFile) error {
 }
 
 func SetLogging(dir string, lf LogToFile) error {
+	// close existing one if already configured
+	if Logrotator != nil {
+		if err := Logrotator.Close(); err != nil {
+			return err
+		}
+	}
+
 	if !lf.Enable {
 		logrus.Infof("Disable logging to file")
-		if Logrotator != nil {
-			if err := Logrotator.Close(); err != nil {
-				return err
-			}
-		}
 		return WriteLogInfo(dir, lf)
 	}
 	return StartLoggingToFile(dir, lf)


### PR DESCRIPTION
This commit add an option to enable persisting logs to a file. Following
options can be passed to configure log files:
- maxLogFileSize: It is the max size of log that can be hold by a file
  in megabites before rotation. Default is 100mb.
  If a write would cause the log file to be larger than MaxSize,
  the file is closed, renamed to include a timestamp of the current time,
  and a new log file is created using the original log file name.
  If the length of the write is greater than MaxSize, an error is returned.

- retentionPeriod: It is the max no of days to retain the old files.
  Default is 180 days.

- maxBackups: It is the maximum number of old log files to retain.
  Default is 5 log files.
- Added command to configure via `jivactl`

For example:
- `./jivactl replica --frontendIP 127.0.0.1 --listen :9502 --size 10g --logtofile=true --maxLogFileSize 1 --retentionPeriod 2 --maxBackups 4 vol1` (while starting replica)
- `jivactl logtofile enable --maxLogFileSize 1 --retentionPeriod 2 --maxBackups 4` on running volumes from controller 

Fixes: https://github.com/openebs/openebs/issues/2964

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>