### PR TITLE
fix(replica): rm headfile if already exists

### DIFF
--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -779,6 +779,8 @@ test_two_replica_stop_start() {
 	verify_vol_status "RO" "When there are 2 replicas and one is stopped"
 	verify_controller_rep_state "$REPLICA_IP2" "RW" "Replica2 status after stopping replica1 in 2 replicas case"
 
+    # recover replica in case of head file already exists due to
+    # ungraceful cleanup upon any error
 	local head=""
 	local newIndx=""
 	local newFile=""
@@ -790,7 +792,7 @@ test_two_replica_stop_start() {
     
 	docker start $replica1_id
 	verify_replica_cnt "2" "Two replica count test2"
-	file_exists=`docker logs $replica2_id 2>&1 | grep -c "Head file: $newFile already exists, removing"`
+	file_exists=`docker logs $replica2_id 2>&1 | grep -c "Head file: $newFile already exists"`
 	if [ "$file_exists" -eq 0 ]; then
 		collect_logs_and_exit
 	fi
@@ -810,6 +812,7 @@ test_two_replica_stop_start() {
 		verify_rep_state 1 "Replica1 status after restarting it, and stopping other one in 2 replicas case" "$REPLICA_IP1" "RW"
 
 		docker start $replica2_id
+		wait
 		verify_replica_cnt "2" "Two replica count test3"
 		verify_vol_status "RW" "when there are 2 replicas and replicas restarted multiple times"
 
@@ -1917,7 +1920,7 @@ verify_replica_restart_while_snap_deletion() {
 	sudo docker start "$3"
 	verify_replica_cnt "3" "Three replica count test"
 	verify_rw_rep_count "3"
-	verify_delete_snapshot_failure "$4" & "false"
+	verify_delete_snapshot_failure "$4" "false" &
 	sleep 2
 	sudo docker stop "$3"
 	wait

--- a/ci/start_init_test.sh
+++ b/ci/start_init_test.sh
@@ -779,8 +779,21 @@ test_two_replica_stop_start() {
 	verify_vol_status "RO" "When there are 2 replicas and one is stopped"
 	verify_controller_rep_state "$REPLICA_IP2" "RW" "Replica2 status after stopping replica1 in 2 replicas case"
 
+	local head=""
+	local newIndx=""
+	local newFile=""
+	head=$(cat /tmp/vol2/volume.meta | jq '.Head')
+	newIndx=$(echo ${head:15:1})
+	let newIndx=newIndx+1
+	newFile="volume-head-00$newIndx.img"
+	sudo truncate -s 2g /tmp/vol2/$newFile
+    
 	docker start $replica1_id
 	verify_replica_cnt "2" "Two replica count test2"
+	file_exists=`docker logs $replica2_id 2>&1 | grep -c "Head file: $newFile already exists, removing"`
+	if [ "$file_exists" -eq 0 ]; then
+		collect_logs_and_exit
+	fi
 
 	verify_controller_quorum "2" "when there are 2 replicas and one is restarted"
 	verify_vol_status "RW" "when there are 2 replicas and one is restarted"
@@ -813,10 +826,11 @@ test_two_replica_stop_start() {
 	docker start $replica1_id
 	verify_vol_status "RO" "when there are 2 replicas and are brought down. Then, only one started"
 	verify_rep_state 1 "Replica1 status after stopping both, and starting it" "$REPLICA_IP1" "NA"
-
+    
 	docker start $replica2_id
 	verify_vol_status "RW" "when there are 2 replicas and are brought down. Then, both are started"
 	verify_replica_cnt "2" "when there are 2 replicas and are brought down. Then, both are started"
+
 
 	reader_exit=`docker logs $orig_controller_id 2>&1 | grep "Exiting rpc reader" | wc -l`
 	writer_exit=`docker logs $orig_controller_id 2>&1 | grep "Exiting rpc writer" | wc -l`

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -849,6 +849,11 @@ func (r *Replica) linkDisk(oldname, newname string) error {
 		return fmt.Errorf("Old file :%v already exists", newname)
 	}
 
+	metaDest := r.diskPath(newname + metadataSuffix)
+	if _, err := os.Stat(metaDest); err == nil {
+		return fmt.Errorf("Old file :%v already exists", newname+metadataSuffix)
+	}
+
 	if err := os.Link(r.diskPath(oldname), dest); err != nil {
 		return err
 	}
@@ -880,11 +885,11 @@ func (r *Replica) rmDisk(name string) error {
 		return nil
 	}
 
-	if err := os.Remove(r.diskPath(name)); err != nil {
+	if err := os.Remove(r.diskPath(name)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	if err := os.Remove(r.diskPath(name + metadataSuffix)); err != nil {
+	if err := os.Remove(r.diskPath(name + metadataSuffix)); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -808,7 +808,10 @@ func (r *Replica) createNewHead(oldHead, parent, created string) (types.DiffDisk
 	}
 
 	if _, err := os.Stat(r.diskPath(newHeadName)); err == nil {
-		logrus.Warningf("Head file: %v already exists, removing", newHeadName)
+		logrus.Warningf("Head file: %v already exists", newHeadName)
+		if r.getDiskSize(newHeadName) > 0 {
+			return nil, disk{}, fmt.Errorf("Can't remove head file %v as it contains some data", newHeadName)
+		}
 		if err = r.rmDisk(newHeadName); err != nil {
 			logrus.Errorf("Fail to remove disk, err: %v", err)
 		}


### PR DESCRIPTION
- This commit fix the issue where replica is not able to recover on
restart if new headfile created with the same name already exists.
- Add a test case to verify the same.

Fixes: https://github.com/openebs/openebs/issues/2907

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>