### PR TITLE
fix(replica): Fix issues with snapshot sync

### DIFF
--- a/backend/file/file.go
+++ b/backend/file/file.go
@@ -23,7 +23,7 @@ func (f *Wrapper) Close() error {
 	return f.File.Close()
 }
 
-func (f *Wrapper) Snapshot(name string, userCreated bool, created string) error {
+func (f *Wrapper) Snapshot(name, newHead string, userCreated bool, created string) error {
 	return nil
 }
 
@@ -43,8 +43,8 @@ func (f *Wrapper) SectorSize() (int64, error) {
 	return 4096, nil
 }
 
-func (f *Wrapper) RemainSnapshots() (int, error) {
-	return 1, nil
+func (f *Wrapper) RemainSnapshots() (int, string, error) {
+	return 1, "", nil
 }
 
 func (f *Wrapper) GetRevisionCounter() (int64, error) {

--- a/backend/remote/remote.go
+++ b/backend/remote/remote.go
@@ -53,12 +53,13 @@ func (r *Remote) open() error {
 	return r.doAction("open", nil)
 }
 
-func (r *Remote) Snapshot(name string, userCreated bool, created string) error {
+func (r *Remote) Snapshot(name, newHead string, userCreated bool, created string) error {
 	logrus.Infof("Snapshot: %s %s UserCreated %v Created at %v",
 		r.Name, name, userCreated, created)
 	return r.doAction("snapshot",
 		&map[string]interface{}{
 			"name":        name,
+			"newhead":     newHead,
 			"usercreated": userCreated,
 			"created":     created,
 		})
@@ -137,15 +138,15 @@ func (r *Remote) SectorSize() (int64, error) {
 	return replica.SectorSize, nil
 }
 
-func (r *Remote) RemainSnapshots() (int, error) {
+func (r *Remote) RemainSnapshots() (int, string, error) {
 	replica, err := r.info()
 	if err != nil {
-		return 0, err
+		return 0, "", err
 	}
 	if replica.State != "open" && replica.State != "dirty" && replica.State != "rebuilding" {
-		return 0, fmt.Errorf("Invalid state %v for counting snapshots", replica.State)
+		return 0, "", fmt.Errorf("Invalid state %v for counting snapshots", replica.State)
 	}
-	return replica.RemainSnapshots, nil
+	return replica.RemainSnapshots, replica.Head, nil
 }
 
 func (r *Remote) GetRevisionCounter() (int64, error) {

--- a/controller/control.go
+++ b/controller/control.go
@@ -458,7 +458,7 @@ var (
 	headPrefix  = "volume-head-"
 	headSuffix  = ".img"
 	headName    = headPrefix + "%03d" + headSuffix
-	diskPattern = regexp.MustCompile(`volume-head-(\d)+.img`)
+	diskPattern = regexp.MustCompile(`volume-head-(\d+).img`)
 )
 
 func nextHead(parsePattern *regexp.Regexp, pattern, oldHead string) (string, error) {

--- a/controller/control.go
+++ b/controller/control.go
@@ -438,16 +438,16 @@ func (c *Controller) signalReplica() error {
 // IsSnapShotExist verifies whether snapshot with the given name
 // already exists in the given replica.
 func IsSnapShotExist(snapName string, addr string) (bool, error) {
-	chain, err := getReplicaChain(addr)
+	disks, err := getReplicaDiskInfo(addr)
 	if err != nil {
 		return false, fmt.Errorf("Failed to get replica chain, error: %v", err)
 	}
-	if len(chain) == 0 {
+	if len(disks) == 0 {
 		return false, fmt.Errorf("No chain list found in replica")
 	}
 	snapshot := fmt.Sprintf("volume-snap-%s.img", snapName)
-	for _, val := range chain {
-		if val == snapshot {
+	for _, disk := range disks {
+		if disk.Name == snapshot {
 			return true, nil
 		}
 	}

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -24,6 +24,21 @@ func getReplicaChain(address string) ([]string, error) {
 	return rep.Chain, nil
 }
 
+func getReplicaDiskInfo(address string) (map[string]types.DiskInfo, error) {
+	repClient, err := client.NewReplicaClient(address)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get replica client for %v: %v",
+			address, err)
+	}
+
+	rep, err := repClient.GetReplica()
+	if err != nil {
+		return nil, fmt.Errorf("Cannot get replica for %v: %v",
+			address, err)
+	}
+	return rep.Disks, nil
+}
+
 func (c *Controller) getCurrentAndRWReplica(address string) (*types.Replica, *types.Replica, error) {
 	var (
 		current, rwReplica *types.Replica

--- a/controller/rebuild.go
+++ b/controller/rebuild.go
@@ -166,17 +166,5 @@ func (c *Controller) PrepareRebuildReplica(address string) ([]string, error) {
 		return nil, err
 	}
 
-	fromHead := rwChain[0]
-
-	chain, err := getReplicaChain(address)
-	if err != nil {
-		return nil, err
-	}
-	toHead := chain[0]
-
-	if err := syncFile(fromHead+".meta", toHead+".meta", rwReplica, replica); err != nil {
-		return nil, err
-	}
-
-	return rwChain[1:], nil
+	return rwChain, nil
 }

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -37,7 +37,7 @@ const (
 )
 
 var (
-	diskPattern = regexp.MustCompile(`volume-head-(\d)+.img`)
+	diskPattern = regexp.MustCompile(`volume-head-(\d+).img`)
 )
 
 type Replica struct {

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -248,6 +248,10 @@ func construct(readonly bool, size, sectorSize int64, dir, head string, backingF
 }
 
 func GenerateSnapshotDiskName(name string) string {
+	return fmt.Sprintf(diskName, name)
+}
+
+func GenerateSnapshotDiskNameFromHeadName(name string) string {
 	return strings.Replace(name, headPrefix, diskPrefix, 1)
 }
 
@@ -891,7 +895,11 @@ func (r *Replica) revertDisk(parent, created string) (*Replica, error) {
 	}
 
 	oldHead := r.info.Head
-	f, newHeadDisk, err := r.createNewHead(oldHead, parent, created)
+	newHeadName, err := r.nextFile(diskPattern, headName, oldHead)
+	if err != nil {
+		return nil, err
+	}
+	f, newHeadDisk, err := r.createNewHead(newHeadName, parent, created)
 	if err != nil {
 		return nil, err
 	}
@@ -933,8 +941,7 @@ func (r *Replica) createDisk(name, newHead string, userCreated bool, created str
 
 	done := false
 	oldHead := r.info.Head
-	logrus.Infof("NAME: %v: %v", oldHead, newHead)
-	newSnapName := GenerateSnapshotDiskName(oldHead)
+	newSnapName := GenerateSnapshotDiskNameFromHeadName(oldHead)
 
 	if oldHead == "" {
 		newSnapName = ""

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -56,11 +56,11 @@ func (s *TestSuite) TestSnapshot(c *C) {
 
 	createdTime0 := getNow()
 
-	err = r.Snapshot("000", true, createdTime0)
+	err = r.Snapshot("000", "volume-head-001.img", true, createdTime0)
 	c.Assert(err, IsNil)
 
 	createdTime1 := getNow()
-	err = r.Snapshot("001", true, createdTime1)
+	err = r.Snapshot("001", "volume-head-002.img", true, createdTime1)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -138,11 +138,11 @@ func (s *TestSuite) TestRevert(c *C) {
 	c.Assert(err, IsNil)
 
 	createdTime0 := getNow()
-	err = r.Snapshot("000", true, createdTime0)
+	err = r.Snapshot("000", "volume-head-001.img", true, createdTime0)
 	c.Assert(err, IsNil)
 
 	createdTime1 := getNow()
-	err = r.Snapshot("001", true, createdTime1)
+	err = r.Snapshot("001", "volume-head-002.img", true, createdTime1)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -180,7 +180,7 @@ func (s *TestSuite) TestRevert(c *C) {
 	c.Assert(r.diskChildrenMap["volume-head-003.img"], IsNil)
 
 	createdTime3 := getNow()
-	err = r.Snapshot("003", true, createdTime3)
+	err = r.Snapshot("003", "volume-head-004.img", true, createdTime3)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.diskData), Equals, 4)
@@ -252,13 +252,13 @@ func (s *TestSuite) TestRemoveLeafNode(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("002", true, now)
+	err = r.Snapshot("002", "volume-head-003.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 5)
@@ -333,10 +333,10 @@ func (s *TestSuite) TestRemoveLast(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -382,10 +382,10 @@ func (s *TestSuite) TestRemoveMiddle(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -432,10 +432,10 @@ func (s *TestSuite) TestRemoveFirst(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -466,13 +466,13 @@ func (s *TestSuite) TestRemoveOutOfChain(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("002", true, now)
+	err = r.Snapshot("002", "volume-head-003.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 5)
@@ -545,10 +545,10 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(err, IsNil)
 
 	now := getNow()
-	err = r.Snapshot("000", true, now)
+	err = r.Snapshot("000", "volume-head-001.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("001", true, now)
+	err = r.Snapshot("001", "volume-head-002.img", true, now)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(r.activeDiskData), Equals, 4)
@@ -576,7 +576,7 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 	c.Assert(actions[1].Target, Equals, "volume-snap-001.img")
 	c.Assert(r.activeDiskData[1].Removed, Equals, true)
 
-	err = r.Snapshot("002", true, now)
+	err = r.Snapshot("002", "volume-head-003.img", true, now)
 	c.Assert(err, IsNil)
 
 	/*
@@ -600,10 +600,10 @@ func (s *TestSuite) TestPrepareRemove(c *C) {
 		c.Assert(actions[1].Source, Equals, "volume-snap-001.img")
 		c.Assert(actions[1].Target, Equals, "volume-snap-002.img")
 	*/
-	err = r.Snapshot("003", true, now)
+	err = r.Snapshot("003", "volume-head-004.img", true, now)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("004", true, now)
+	err = r.Snapshot("004", "volume-head-005.img", true, now)
 	c.Assert(err, IsNil)
 
 	/*
@@ -731,19 +731,19 @@ func (s *TestSuite) TestSnapshotReadWrite(c *C) {
 	count, err := r.WriteAt(buf, 0)
 	c.Assert(err, IsNil)
 	c.Assert(count, Equals, 3*b)
-	err = r.Snapshot("000", true, getNow())
+	err = r.Snapshot("000", "volume-head-001.img", true, getNow())
 	c.Assert(err, IsNil)
 
 	fill(buf[b:2*b], 2)
 	count, err = r.WriteAt(buf[b:2*b], b)
 	c.Assert(count, Equals, b)
-	err = r.Snapshot("001", true, getNow())
+	err = r.Snapshot("001", "volume-head-002.img", true, getNow())
 	c.Assert(err, IsNil)
 
 	fill(buf[:b], 1)
 	count, err = r.WriteAt(buf[:b], 0)
 	c.Assert(count, Equals, b)
-	err = r.Snapshot("002", true, getNow())
+	err = r.Snapshot("002", "volume-head-003.img", true, getNow())
 	c.Assert(err, IsNil)
 
 	readBuf := make([]byte, 3*b)
@@ -826,7 +826,7 @@ func (s *TestSuite) partialWriteRead(c *C, totalLength, writeLength, writeOffset
 	_, err = r.WriteAt(buf, 0)
 	c.Assert(err, IsNil)
 
-	err = r.Snapshot("000", true, getNow())
+	err = r.Snapshot("000", "volume-head-001.img", true, getNow())
 	c.Assert(err, IsNil)
 
 	buf = make([]byte, writeLength)
@@ -876,7 +876,7 @@ func (s *TestSuite) testPartialRead(c *C, totalLength int64, readBuf []byte, off
 	for i := int64(0); i < totalLength; i += b {
 		buf := make([]byte, totalLength-i)
 		fill(buf, byte(i/b+1))
-		err := r.Snapshot(strconv.Itoa(int(i)), true, getNow())
+		err := r.Snapshot(strconv.Itoa(int(i)), fmt.Sprintf("volume-head-%03d.img", i+1), true, getNow())
 		c.Assert(err, IsNil)
 		_, err = r.WriteAt(buf, i)
 		c.Assert(err, IsNil)

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -43,7 +43,7 @@ type RebuildingInput struct {
 type SnapshotInput struct {
 	client.Resource
 	Name        string `json:"name"`
-	NewHead     string `json: "newhead"`
+	NewHead     string `json:"newhead"`
 	UserCreated bool   `json:"usercreated"`
 	Created     string `json:"created"`
 }

--- a/replica/rest/model.go
+++ b/replica/rest/model.go
@@ -43,6 +43,7 @@ type RebuildingInput struct {
 type SnapshotInput struct {
 	client.Resource
 	Name        string `json:"name"`
+	NewHead     string `json: "newhead"`
 	UserCreated bool   `json:"usercreated"`
 	Created     string `json:"created"`
 }

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -212,16 +212,16 @@ func (s *Server) SnapshotReplica(rw http.ResponseWriter, req *http.Request) erro
 		return err
 	}
 
-	if input.Name == "" {
-		return fmt.Errorf("Cannot accept empty snapshot name")
+	if input.NewHead == "" {
+		return fmt.Errorf("Cannot accept empty head name")
 	}
 
 	if input.Created == "" {
 		return fmt.Errorf("Need to specific created time")
 	}
-	logrus.Infof("SnapshotReplica name: %v created: %v", input.Name, input.Created)
+	logrus.Infof("SnapshotReplica name: %v NewHead: %v created: %v", input.Name, input.NewHead, input.Created)
 
-	return s.doOp(req, s.s.Snapshot(input.Name, input.UserCreated, input.Created))
+	return s.doOp(req, s.s.Snapshot(input.Name, input.NewHead, input.UserCreated, input.Created))
 }
 
 func (s *Server) RevertReplica(rw http.ResponseWriter, req *http.Request) error {

--- a/replica/server.go
+++ b/replica/server.go
@@ -364,7 +364,7 @@ func (s *Server) Revert(name, created string) error {
 	return nil
 }
 
-func (s *Server) Snapshot(name string, userCreated bool, createdTime string) error {
+func (s *Server) Snapshot(name, newHead string, userCreated bool, createdTime string) error {
 	s.Lock()
 	defer s.Unlock()
 
@@ -373,9 +373,9 @@ func (s *Server) Snapshot(name string, userCreated bool, createdTime string) err
 		return nil
 	}
 
-	logrus.Infof("Snapshotting [%s] volume, user created %v, created time %v",
-		name, userCreated, createdTime)
-	return s.r.Snapshot(name, userCreated, createdTime)
+	logrus.Infof("Snapshotting [%s] volume, newHead %v, user created %v, created time %v",
+		name, newHead, userCreated, createdTime)
+	return s.r.Snapshot(name, newHead, userCreated, createdTime)
 }
 
 func (s *Server) RemoveDiffDisk(name string) error {

--- a/types/types.go
+++ b/types/types.go
@@ -69,11 +69,11 @@ var (
 
 type Backend interface {
 	IOs
-	Snapshot(name string, userCreated bool, created string) error
+	Snapshot(name, newHead string, userCreated bool, created string) error
 	Resize(name string, size string) error
 	Size() (int64, error)
 	SectorSize() (int64, error)
-	RemainSnapshots() (int, error)
+	RemainSnapshots() (int, string, error)
 	GetRevisionCounter() (int64, error)
 	GetCloneStatus() (string, error)
 	GetVolUsage() (VolUsage, error)


### PR DESCRIPTION
Fixes: https://github.com/openebs/openebs/issues/2999

```
Problem Description:
According to current implementation:

R1          R2              R3
H1(s1)      H1(S1)          H1(S2)
H2(S2)      H2(S2)          H2 
H3          H3              

When R1, R2 and R3 are in sync, all of them have H1 as head file. Sequence of events that trigger rebuild time:

1. R3 gets disconnected
2. R2 gets disconnected
3. R2 comes back up again, therefore internal snapshot(S1) is created, and H1 is converted to S1 at R1 and R2. A new head(H2) is also created at R1 and R2.
4. R3 comes back up. A new snapshot S2 is created. H2 at R1 and R2 is converted to S2. And H1 at R3 is converted to S2.
5. Now data from S2 in R1 is copied to S2 in R3. And since there is no S1 in R3, S1 is also copied from R1 to R3.

Post fix scenario:
After this fix, problem reported in step 4 and 5 is fixed as described below.
When R3 comes up, a new snapshot is created. H2 at R1 and R2 is converted to S2. And H1 at R3 is converted to S1. Now data from S1 in R1 is synced with S1 in R3. And since there is no S2 in R3, S3 is copied from R1 to R3.

Proposed changes:
1. No snapshot name should be passed to replicas while creating auto snapshots.
- Previously a randomly generated name was passed.
After this change:
volume-head-000.img converts to volume-snap-000.img
volume-head-101.img converts to volume-snap-101.img
- This ensures that snapshot files at all the replicas have been created by renaming the same head file. This case was not always valid earlier as demonstrated above.

2. New head name should be passed while creating the snapshot. This head name is created by increasing the current head fetched from healthy replica by 1.
- This again ensures that all the head files being written to at the replicas are same. When converting this head file to snap, snapnames will be consistent at all the replicas.

After applying above 2 proposed changes:

R1          R2              R3
H1(s1)      H1(S1)          H1(S1)
H2(S2)      H2(S2)          
H3          H3              H3
	   
3. Sync head metadata file after syncing all the other snapshots at replica.
- Previously head metadata file was being synced by controller before starting the sync process in prepareRebuild function. That was not a valid approach, since if replica crashes after this step, chain should have been broken. But was not a problem since latest snapshot names were same at all the replicas. Head metadata file points to latest snapshot as that is its parent.

4. There was a bug in increasing the numbers in head file name which caused the numbers to circle after 10.
- After volume-head-010.img, the new head which was being created was volume-head-001.img instead of volume-head-011.img.

5. For manually created snapshots, snapshot name is passed by controller to replica but the image file name will still be corresponding to the head name as described above. But the name inside the corresponding metadata file will be same as snapshot name given by the user for revert, clone and snapshot delete purposes.

Upgrade Instructions:
Head metadata file is now being synced by replica, therefore we need to upgrade replicas before controller. If controller is upgraded before replica, head metadata file might not be synced before making replica to RW.

```
Signed-off-by: Payes <payes.anand@mayadata.io>