### PR TITLE
refact(build): make the docker images configurable

### DIFF
--- a/package/Dockerfile_build_amd64
+++ b/package/Dockerfile_build_amd64
@@ -4,5 +4,17 @@ RUN apt-get update && apt-get install -y curl \
 
 COPY longhorn jivactl launch copy-binary launch-with-vm-backing-file launch-simple-jiva /usr/local/bin/
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="jiva"
+LABEL org.label-schema.description="OpenEBS Jiva"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 VOLUME /usr/local/bin
 CMD ["longhorn"]

--- a/package/Dockerfile_build_arm64
+++ b/package/Dockerfile_build_arm64
@@ -9,5 +9,17 @@ RUN apt-get update && apt-get install -y curl \
 
 COPY longhorn jivactl launch copy-binary launch-with-vm-backing-file launch-simple-jiva /usr/local/bin/
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="jiva"
+LABEL org.label-schema.description="OpenEBS Jiva"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 VOLUME /usr/local/bin
 CMD ["longhorn"]

--- a/package/Dockerfile_build_ppc64le
+++ b/package/Dockerfile_build_ppc64le
@@ -9,5 +9,17 @@ RUN apt-get update && apt-get install -y curl \
 
 COPY longhorn jivactl launch copy-binary launch-with-vm-backing-file launch-simple-jiva /usr/local/bin/
 
+ARG ARCH
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="jiva"
+LABEL org.label-schema.description="OpenEBS Jiva"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
 VOLUME /usr/local/bin
 CMD ["longhorn"]

--- a/scripts/package
+++ b/scripts/package
@@ -6,9 +6,29 @@ source $(dirname $0)/version
 cd $(dirname $0)/../package
 
 TAG=${TAG:-${VERSION}}
-REPO=${REPO:-openebs}
+
+# IMAGE_ORG can be used to customize the organization 
+# under which images should be pushed. 
+# By default the organization name is `openebs`. 
+IMAGE_ORG=${IMAGE_ORG:-openebs}
+
 BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
 BASE_DOCKER_IMAGEPPC64LE=${BASE_DOCKER_IMAGEPPC64LE:-ubuntu:18.04}
+
+# Specify the date of build
+DBUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+if [ -z "${DBUILD_REPO_URL}" ]; then
+  DBUILD_REPO_URL="https://github.com/openebs/jiva"
+fi
+
+# Specify the docker arg for website url
+if [ -z "${DBUILD_SITE_URL}" ]; then
+  DBUILD_SITE_URL="https://openebs.io"
+fi
+
+DBUILD_ARGS="--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL} --build-arg ARCH=${ARCH}"
 
 if [ ! -x ../bin/longhorn ]; then
     ../scripts/build_binaries
@@ -20,13 +40,13 @@ cp ../bin/longhorn jivactl
 if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} ${DBUILD_ARGS} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
 elif [ ${ARCH} == "linux_ppc64le" ]
 then
   DOCKERFILE=Dockerfile_build_ppc64le
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} ${DBUILD_ARGS} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva:${TAG} ${DBUILD_ARGS} .
 fi
-echo Built ${REPO}/jiva-${XC_ARCH}:${TAG}
+echo Built ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG}

--- a/scripts/push
+++ b/scripts/push
@@ -1,4 +1,18 @@
 #!/bin/bash
+# Copyright 2019-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 if [ -z ${IMAGE_REPO} ];
@@ -50,7 +64,10 @@ function TagAndPushImage() {
   REPO="$1"
   TAG="$2"
   
-  IMAGE_URI="${REPO}:${TAG}";
+  #Add an option to specify a custom TAG_SUFFIX 
+  #via environment variable. Default is no tag.
+  #Example suffix could be "-debug" of "-dev"
+  IMAGE_URI="${REPO}:${TAG}${TAG_SUFFIX}";
   sudo docker tag ${IMAGEID} ${IMAGE_URI};
   echo " push ${IMAGE_URI}";
   sudo docker push ${IMAGE_URI};


### PR DESCRIPTION
This commit will help customizing docker images via environment variables:
- The following ENV help specify custom docker build args
  - DBUILD_SITE_URL ( default: https://openebs.io )
  - DBUILD_REPO_URL ( default: https://github.com/openebs/jiva )
- The following ENV allows Travis to specify custom image org
  - IMAGE_ORG (default: openebs )
- The following ENV will allow specifying an extra tag suffix
  - TAG_SUFFIX ( default: none )

Signed-off-by: kmova <kiran.mova@mayadata.io>

