### PR TITLE
fix(duplica-replica-remove): Avoid calling AutoRmReplica on replica restarts

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -142,10 +142,12 @@ checkagain:
 		// closed state, then it can be registered, else register replica
 		// will fail.
 		_ = s.Close()
+		// This is not required any more as while adding at controller, canAdd
+		// func checks if the replica is already present
 		// this is just to be sure that replica is not attached to
 		// controller. Assumption is replica might be in RO, RW or in
 		// "" state and not removed from controller.
-		AutoRmReplica(frontendIP, address)
+		// AutoRmReplica(frontendIP, address)
 		if err := AutoAddReplica(s, frontendIP, address, replicaType); err != nil {
 			s.Close()
 			logrus.Fatalf("Failed to add replica to controller, err: %v, Shutting down...", err)

--- a/changelogs/unreleased/278-utkarshmani1997
+++ b/changelogs/unreleased/278-utkarshmani1997
@@ -1,0 +1,1 @@
+feat(replica): run fsync on files & dir after create/remove/rename operation on files

--- a/changelogs/unreleased/290-utkarshmani1997
+++ b/changelogs/unreleased/290-utkarshmani1997
@@ -1,0 +1,1 @@
+feat(replica): add option to flush log to file

--- a/changelogs/unreleased/291-utkarshmani1997
+++ b/changelogs/unreleased/291-utkarshmani1997
@@ -1,0 +1,1 @@
+fix(replica): rm headfile if already exists

--- a/changelogs/unreleased/296-payes
+++ b/changelogs/unreleased/296-payes
@@ -1,0 +1,1 @@
+fix(replica): make preload operations of secondary replicas lockless

--- a/changelogs/unreleased/297-utkarshmani1997
+++ b/changelogs/unreleased/297-utkarshmani1997
@@ -1,0 +1,1 @@
+feat(replica): add command to get rebuild estimation

--- a/changelogs/unreleased/300-payes
+++ b/changelogs/unreleased/300-payes
@@ -1,0 +1,1 @@
+fix(duplica-replica-remove): avoid calling AutoRmReplica on replica restarts


### PR DESCRIPTION
This PR fixes the issue of replica remove being triggered multiple times at controller.
When replica comes up, it was sending a Delete command to controller which was just removing the replica from its data structures and not closing the connection threads. And when the connection threads were getting erred out, they were also removing the replica with a specific IP.
As a fix  remove replica has been left to be triggered only by monitor thread at controller.
Signed-off-by: Payes <payes.anand@mayadata.io>