### PR TITLE
fix(sync): make sync http client timeout configurable

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -335,6 +335,10 @@ func startReplica(c *cli.Context) error {
 			cmd.Dir = dir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
+			httpTimeout := os.Getenv(types.SyncHttpClientTimeoutKey)
+			if httpTimeout != "" {
+				cmd.Env = []string{types.SyncHttpClientTimeoutKey + "=" + httpTimeout}
+			}
 			syncResp <- cmd.Run()
 		}()
 	}

--- a/app/replica.go
+++ b/app/replica.go
@@ -335,9 +335,9 @@ func startReplica(c *cli.Context) error {
 			cmd.Dir = dir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
-			httpTimeout := os.Getenv(types.SyncHttpClientTimeoutKey)
+			httpTimeout := os.Getenv(types.SyncHTTPClientTimeoutKey)
 			if httpTimeout != "" {
-				cmd.Env = []string{types.SyncHttpClientTimeoutKey + "=" + httpTimeout}
+				cmd.Env = []string{types.SyncHTTPClientTimeoutKey + "=" + httpTimeout}
 			}
 			syncResp <- cmd.Run()
 		}()

--- a/changelogs/unreleased/301-utkarshmani1997
+++ b/changelogs/unreleased/301-utkarshmani1997
@@ -1,0 +1,1 @@
+fix(sync): make sync http client timeout configurable

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gostor/gotgt v0.1.1-0.20191128095459-2f1d32710a93
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b
+	github.com/openebs/sparse-tools v1.0.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c
 	github.com/satori/go.uuid v1.2.0
@@ -25,7 +25,4 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
 
-replace (
-	github.com/frostschutz/go-fibmap => github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47
-	github.com/openebs/sparse-tools => github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874
-)
+replace github.com/frostschutz/go-fibmap => github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47

--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,7 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 )
 
-replace github.com/frostschutz/go-fibmap => github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47
+replace (
+	github.com/frostschutz/go-fibmap => github.com/rancher/go-fibmap v0.0.0-20160418233256-5fc9f8c1ed47
+	github.com/openebs/sparse-tools => github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874
+)

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b h1:yULW07dZXT8MhMg6U4BPJQ0vlylLAM23juksiZTX5LU=
-github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -114,6 +112,8 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.22.3 h1:FpNT6zq26xNpHZy08emi755QwzLPs6Pukqjlc7RfOMU=
 github.com/urfave/cli v1.22.3/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
+github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874 h1:JaJqpVPn7xOzAY+GYLg3egizaGBy9pV3D7fmC/JXwds=
+github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/openebs/sparse-tools v1.0.0 h1:Cf5X/X4X+mX//HO2C56H/wp0h+QMm9DDzvg6/QIYyS8=
+github.com/openebs/sparse-tools v1.0.0/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -112,8 +114,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.22.3 h1:FpNT6zq26xNpHZy08emi755QwzLPs6Pukqjlc7RfOMU=
 github.com/urfave/cli v1.22.3/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
-github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874 h1:JaJqpVPn7xOzAY+GYLg3egizaGBy9pV3D7fmC/JXwds=
-github.com/utkarshmani1997/sparse-tools v0.0.0-20200507055612-161fd7e50874/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/multierr v1.5.0 h1:KCa4XfM8CWFCpxXRGok+Q0SS/0XBhMDbHHGABQLvD2A=

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -200,7 +200,7 @@ func (s *Server) launchSync(p *Process) error {
 	//ssync client is trying to connect for 120 seconds, it can cause corruption
 	//as ssync client and server are looking at different files.
 	args = append(args, "-timeout", strconv.Itoa(7))
-	httpTimeout := os.Getenv(types.SyncHttpClientTimeoutKey)
+	httpTimeout := os.Getenv(types.SyncHTTPClientTimeoutKey)
 	if httpTimeout != "" {
 		logrus.Infof("Add sync client http timeout: %vs", httpTimeout)
 		args = append(args, "-httpTimeout", httpTimeout)

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/gorilla/mux"
+	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/sirupsen/logrus"
@@ -199,7 +200,11 @@ func (s *Server) launchSync(p *Process) error {
 	//ssync client is trying to connect for 120 seconds, it can cause corruption
 	//as ssync client and server are looking at different files.
 	args = append(args, "-timeout", strconv.Itoa(7))
-
+	httpTimeout := os.Getenv(types.SyncHttpClientTimeoutKey)
+	if httpTimeout != "" {
+		logrus.Infof("Add sync client http timeout: %vs", httpTimeout)
+		args = append(args, "-httpTimeout", httpTimeout)
+	}
 	if p.Port != 0 {
 		args = append(args, "-port", strconv.Itoa(p.Port))
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -18,7 +18,7 @@ const (
 	RebuildPending           = "Pending"
 	RebuildInProgress        = "InProgress"
 	RebuildCompleted         = "Completed"
-	SyncHttpClientTimeoutKey = "SYNC_HTTP_CLIENT_TIMEOUT"
+	SyncHTTPClientTimeoutKey = "SYNC_HTTP_CLIENT_TIMEOUT"
 )
 
 var (

--- a/types/types.go
+++ b/types/types.go
@@ -15,9 +15,10 @@ const (
 	StateUp   = State("Up")
 	StateDown = State("Down")
 
-	RebuildPending    = "Pending"
-	RebuildInProgress = "InProgress"
-	RebuildCompleted  = "Completed"
+	RebuildPending           = "Pending"
+	RebuildInProgress        = "InProgress"
+	RebuildCompleted         = "Completed"
+	SyncHttpClientTimeoutKey = "SYNC_HTTP_CLIENT_TIMEOUT"
 )
 
 var (


### PR DESCRIPTION
Add env SYNC_HTTP_CLIENT_TIMEOUT to make sync client http request timeout configurable.
This env can be passed as container argument.
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>