### PR TITLE
fix(sync): make sync http client timeout configurable (#301)

### DIFF
--- a/app/replica.go
+++ b/app/replica.go
@@ -335,6 +335,10 @@ func startReplica(c *cli.Context) error {
 			cmd.Dir = dir
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
+			httpTimeout := os.Getenv(types.SyncHTTPClientTimeoutKey)
+			if httpTimeout != "" {
+				cmd.Env = []string{types.SyncHTTPClientTimeoutKey + "=" + httpTimeout}
+			}
 			syncResp <- cmd.Run()
 		}()
 	}

--- a/changelogs/unreleased/301-utkarshmani1997
+++ b/changelogs/unreleased/301-utkarshmani1997
@@ -1,0 +1,1 @@
+fix(sync): make sync http client timeout configurable

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gostor/gotgt v0.1.1-0.20191128095459-2f1d32710a93
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b
+	github.com/openebs/sparse-tools v1.0.0
 	github.com/prometheus/client_golang v1.5.1
 	github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4
 github.com/natefinch/lumberjack v2.0.0+incompatible/go.mod h1:Wi9p2TTF5DG5oU+6YfsmYQpsTIOm0B1VNzQg9Mw6nPk=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b h1:yULW07dZXT8MhMg6U4BPJQ0vlylLAM23juksiZTX5LU=
-github.com/openebs/sparse-tools v0.0.0-20200401072849-c3bccb89a06b/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
+github.com/openebs/sparse-tools v1.0.0 h1:Cf5X/X4X+mX//HO2C56H/wp0h+QMm9DDzvg6/QIYyS8=
+github.com/openebs/sparse-tools v1.0.0/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/sync/agent/process.go
+++ b/sync/agent/process.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/gorilla/mux"
+	"github.com/openebs/jiva/types"
 	"github.com/rancher/go-rancher/api"
 	"github.com/rancher/go-rancher/client"
 	"github.com/sirupsen/logrus"
@@ -199,7 +200,11 @@ func (s *Server) launchSync(p *Process) error {
 	//ssync client is trying to connect for 120 seconds, it can cause corruption
 	//as ssync client and server are looking at different files.
 	args = append(args, "-timeout", strconv.Itoa(7))
-
+	httpTimeout := os.Getenv(types.SyncHTTPClientTimeoutKey)
+	if httpTimeout != "" {
+		logrus.Infof("Add sync client http timeout: %vs", httpTimeout)
+		args = append(args, "-httpTimeout", httpTimeout)
+	}
 	if p.Port != 0 {
 		args = append(args, "-port", strconv.Itoa(p.Port))
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -15,9 +15,10 @@ const (
 	StateUp   = State("Up")
 	StateDown = State("Down")
 
-	RebuildPending    = "Pending"
-	RebuildInProgress = "InProgress"
-	RebuildCompleted  = "Completed"
+	RebuildPending           = "Pending"
+	RebuildInProgress        = "InProgress"
+	RebuildCompleted         = "Completed"
+	SyncHTTPClientTimeoutKey = "SYNC_HTTP_CLIENT_TIMEOUT"
 )
 
 var (


### PR DESCRIPTION
cherry-pick fix(sync): make sync http client timeout configurable (#301)
Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>
