### PR TITLE
fix(maxChainLen): Increase default maxChainLen to 1024

### DIFF
--- a/ci/feature_tests.sh
+++ b/ci/feature_tests.sh
@@ -12,6 +12,7 @@ if [ "$ARCH" != "linux_amd64" ]; then
 fi
 
 prepare_test_env
+test_max_chain_env
 test_volume_resize
 test_delete_snapshot
 test_duplicate_data_delete

--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -2103,11 +2103,11 @@ test_sync_progress() {
 
 test_max_chain_env() {
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2" "15")
-	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
-	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "10")
+	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "10")
 
 	i=0
-	while [ "$i" -lt "1024" ];
+	while [ "$i" -lt "10" ];
 	do
 		sudo docker stop $replica2_id
 		sudo docker start $replica2_id
@@ -2128,8 +2128,8 @@ test_max_chain_env() {
 	done
 	sudo docker stop $replica1_id
 	sudo docker stop $replica2_id
-	debug_replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "2048")
-	debug_replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "2048")
+	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "20")
+	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "20")
 	verify_rw_rep_count "2"
 	cleanup
 }

--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -2103,16 +2103,16 @@ test_sync_progress() {
 
 test_max_chain_env() {
 	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2" "15")
-	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "10")
+	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "MAX_CHAIN_LENGTH" "10")
 	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "10")
 
-	i=0
-	while [ "$i" -lt "10" ];
+	iter=0
+	while [ "$iter" -lt "8" ];
 	do
 		sudo docker stop $replica2_id
 		sudo docker start $replica2_id
 		verify_rw_rep_count "2"
-		i=$((i + 1))
+		iter=$((iter + 1))
 	done
 	sudo docker stop $replica2_id
 	sudo docker start $replica2_id
@@ -2128,7 +2128,7 @@ test_max_chain_env() {
 	done
 	sudo docker stop $replica1_id
 	sudo docker stop $replica2_id
-	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "20")
+	replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1" "MAX_CHAIN_LENGTH" "20")
 	replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "20")
 	verify_rw_rep_count "2"
 	cleanup

--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -2101,3 +2101,35 @@ test_sync_progress() {
     docker exec "$orig_controller_id" jivactl syncinfo
 }
 
+test_max_chain_env() {
+	orig_controller_id=$(start_controller "$CONTROLLER_IP" "store1" "2" "15")
+	replica1_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP1" "vol1")
+	replica2_id=$(start_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2")
+
+	i=0
+	while [ "$i" -lt "1024" ];
+	do
+		sudo docker stop $replica2_id
+		sudo docker start $replica2_id
+		verify_rw_rep_count "2"
+		i=$((i + 1))
+	done
+	sudo docker stop $replica2_id
+	sudo docker start $replica2_id
+	success=0
+	iter=0
+	while [ "$success" -lt 1 ]; do
+		success=`docker logs $orig_controller_id 2>&1 | grep -c "Too many snapshots created"`
+		if [ "$iter" == 100 ]; then
+			collect_logs_and_exit
+		fi
+		let iter=iter+1
+		sleep 2
+	done
+	sudo docker stop $replica1_id
+	sudo docker stop $replica2_id
+	debug_replica1_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol1" "MAX_CHAIN_LENGTH" "2048")
+	debug_replica2_id=$(start_debug_replica "$CONTROLLER_IP" "$REPLICA_IP2" "vol2" "MAX_CHAIN_LENGTH" "2048")
+	verify_rw_rep_count "2"
+	cleanup
+}

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -32,7 +32,7 @@ const (
 	diskPrefix         = "volume-snap-"
 	diskSuffix         = ".img"
 	diskName           = diskPrefix + "%s" + diskSuffix
-	maximumChainLength = 512
+	maximumChainLength = 1024
 )
 
 var (
@@ -1076,7 +1076,11 @@ func (r *Replica) openLiveChain() error {
 		return err
 	}
 
-	if len(chain) > maximumChainLength {
+	maxChainLen := maximumChainLength
+	if types.MaxChainLength != 0 {
+		maxChainLen = types.MaxChainLength
+	}
+	if len(chain) > maxChainLen {
 		return fmt.Errorf("Live chain is too long: %v", len(chain))
 	}
 


### PR DESCRIPTION
As part of data connection formation between controller and replica, snapshots gets created to allow replicas in WO mode.
And, with few fixes done in 1.7 build, auto snapshot deletion feature has been disabled.
This opened up the issue with the limitation on the number of snapshots.
However, MAX_CHAIN_LENGTH should come for rescue, but, it got a bug with it.

This PR is to fix that bug in honoring value given in MAX_CHAIN_LENGTH env, and, also to increase the default value for max snapshot count.
 
Signed-off-by: Payes <payes.anand@mayadata.io>