### PR TITLE
refactor(build): fix travis errors on forked repo (#311)

### DIFF
--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -x
 
@@ -9,6 +8,12 @@ REPLICA_IP2="172.18.0.4"
 REPLICA_IP3="172.18.0.5"
 CLONED_CONTROLLER_IP="172.18.0.6"
 CLONED_REPLICA_IP="172.18.0.7"
+
+# IMAGE_ORG can be used to customize the organization 
+# under which images should be pushed. 
+# By default the organization name is `openebs`. 
+IMAGE_ORG=${IMAGE_ORG:-openebs}
+
 
 snapIndx=1
 
@@ -95,8 +100,8 @@ prepare_test_env() {
 	mkdir -pv /mnt/store /mnt/store2
 
 	docker network create --subnet=172.18.0.0/16 stg-net
-	JI=$(docker images | grep openebs/jiva | awk '{print $1":"$2}' | awk 'NR == 2 {print}')
-	JI_DEBUG=$(docker images | grep openebs/jiva | awk '{print $1":"$2}' | awk 'NR == 1 {print}')
+	JI=$(docker images | grep ${IMAGE_ORG}/jiva | awk '{print $1":"$2}' | awk 'NR == 2 {print}')
+	JI_DEBUG=$(docker images | grep ${IMAGE_ORG}/jiva | awk '{print $1":"$2}' | awk 'NR == 1 {print}')
 	echo "Run CI tests on $JI and $JI_DEBUG"
 }
 

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -6,7 +6,11 @@ source $(dirname $0)/version
 cd $(dirname $0)/../package
 
 TAG=${TAG:-${VERSION}-DEBUG}
-REPO=${REPO:-openebs}
+# IMAGE_ORG can be used to customize the organization 
+# under which images should be pushed. 
+# By default the organization name is `openebs`. 
+IMAGE_ORG=${IMAGE_ORG:-openebs}
+
 BASE_DOCKER_IMAGEARM64=${BASE_DOCKER_IMAGEARM64:-arm64v8/ubuntu:18.04}
 BASE_DOCKER_IMAGEPPC64LE=${BASE_DOCKER_IMAGEPPC64LE:-ubuntu:18.04}
 
@@ -19,13 +23,13 @@ cp ../bin/debug/longhorn* .
 if [ ${ARCH} == "linux_arm64" ]
 then
   DOCKERFILE=Dockerfile_build_arm64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEARM64} .
 elif [ ${ARCH} == "linux_ppc64le" ]
 then
   DOCKERFILE=Dockerfile_build_ppc64le
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
-  docker build -f ${DOCKERFILE} -t ${REPO}/jiva:${TAG} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva:${TAG} .
 fi
-echo Built ${REPO}/jiva-${XC_ARCH}:${TAG}
+echo Built ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG}


### PR DESCRIPTION
When building on Travis with IMAGE_REPO env set to forked repo, the CI scripts were failing due to a hardcoding of container registry org name.

This commit helps to re-use the IMAGE ORG specified in the TRAVIS ENV.

Signed-off-by: kmova <kiran.mova@mayadata.io>
(cherry picked from commit 2d0395bb99fa709bc290f4f889bd943705462d78)

