### PR TITLE
Revert "fix(replica): lock contention on clone volume"

### DIFF
--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -819,7 +819,7 @@ test_two_replica_stop_start() {
 		docker start $replica2_id
 		wait
 		verify_replica_cnt "2" "Two replica count test3"
-		test_sync_progress "$orig_controller_id"
+		test_sync_progress
 		verify_vol_status "RW" "when there are 2 replicas and replicas restarted multiple times"
 
 		count=`expr $count + 1`
@@ -827,7 +827,7 @@ test_two_replica_stop_start() {
 	verify_controller_quorum "2" "when there are 2 replicas and they are restarted multiple times"
 	verify_vol_status "RW" "when there are 2 replicas and they are restarted multiple times"
 
-	test_sync_progress "$orig_controller_id"
+	test_sync_progress
 	docker stop $replica1_id
 	docker stop $replica2_id
 	verify_vol_status "RO" "when there are 2 replicas and both are stopped"
@@ -838,10 +838,10 @@ test_two_replica_stop_start() {
 	verify_rep_state 1 "Replica1 status after stopping both, and starting it" "$REPLICA_IP1" "NA"
     
 	docker start $replica2_id
-	test_sync_progress "$orig_controller_id"
+	test_sync_progress
 	verify_vol_status "RW" "when there are 2 replicas and are brought down. Then, both are started"
 	verify_replica_cnt "2" "when there are 2 replicas and are brought down. Then, both are started"
-	test_sync_progress "$orig_controller_id"
+	test_sync_progress
 
 	reader_exit=`docker logs $orig_controller_id 2>&1 | grep "Exiting rpc reader" | wc -l`
 	writer_exit=`docker logs $orig_controller_id 2>&1 | grep "Exiting rpc writer" | wc -l`
@@ -972,7 +972,7 @@ test_three_replica_stop_start() {
 
 	docker start $replica3_id
 	sleep 5
-	test_sync_progress "$orig_controller_id"
+	test_sync_progress
 	if [ $(verify_rw_status "RW") == 0 ]; then
 		echo "stop/start test passed when there are 3 replicas and all are restarted"
 	else
@@ -1220,7 +1220,12 @@ test_clone_feature() {
 	cloned_controller_id=$(start_controller "$CLONED_CONTROLLER_IP" "store2" "1")
 	start_cloned_replica "$CONTROLLER_IP"  "$CLONED_CONTROLLER_IP" "$CLONED_REPLICA_IP" "vol4"
 
-	verify_clone_status "completed"
+	if [ $(verify_clone_status "completed") == "0" ]; then
+		echo "clone created successfully"
+	else
+		echo "Clone creation failed"
+		collect_logs_and_exit
+	fi
 
 	login_to_volume "$CLONED_CONTROLLER_IP:3260"
 	get_scsi_disk
@@ -1248,18 +1253,17 @@ verify_clone_status() {
 	local i=0
 	local clonestatus=""
 	while [ "$clonestatus" != "$1" ]; do
-		test_sync_progress "$cloned_controller_id"
 		sleep 5
 		clonestatus=$(curl -s http://$CLONED_REPLICA_IP:9502/v1/replicas/1 | jq '.clonestatus' | tr -d '"')
 		i=`expr $i + 1`
-		if [[ $i -eq 20 ]] && [[ "$clonestatus" != "$1" ]]; then
-			echo "clone creation failed, clonestatus: $clonestatus"
+		if [ $i -eq 20 ]; then
+			echo "1"
 			return
 		else
 			continue
 		fi
 	done
-	echo "clone creation successful"
+	echo "0"
 }
 
 create_device() {
@@ -2099,7 +2103,7 @@ test_write_io_timeout_with_readwrite_env() {
 
 test_sync_progress() {
     echo "--------------------Test replica sync progress-------------------"
-    docker exec "$1" jivactl syncinfo
+    docker exec "$orig_controller_id" jivactl syncinfo
 }
 
 test_max_chain_env() {

--- a/controller/control.go
+++ b/controller/control.go
@@ -779,41 +779,11 @@ func (c *Controller) startFrontend() error {
 	return nil
 }
 
-func (c *Controller) checkCloneStatusAndUpdateReplica(address string) error {
-clone:
-	for {
-		c.Lock()
-		status, err := c.backend.GetCloneStatus(address)
-		c.Unlock()
-		if err != nil {
-			_ = c.RemoveReplica(address)
-			return err
-		}
-		switch status {
-		case "", "inProgress":
-			logrus.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
-			time.Sleep(2 * time.Second)
-			continue
-		case "error":
-			_ = c.RemoveReplica(address)
-			return fmt.Errorf("Replica clone status returned error %s", address)
-		default:
-			break clone
-		}
-	}
-
-	c.Lock()
-	defer c.Unlock()
-	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
-		_ = c.RemoveReplicaNoLock(address)
-		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
-	}
-
-	c.setReplicaModeNoLock(address, types.RW)
-	return nil
-}
-
 func (c *Controller) addReplicaDuringStartNoLock(address string) error {
+	var (
+		status string
+		err1   error
+	)
 	newBackend, err := c.factory.Create(address)
 	if err != nil {
 		c.rmReplicaFromRegisteredReplicas(address)
@@ -849,6 +819,27 @@ func (c *Controller) addReplicaDuringStartNoLock(address string) error {
 		c.rmReplicaFromRegisteredReplicas(address)
 		return err
 	}
+getCloneStatus:
+	if status, err1 = c.backend.GetCloneStatus(address); err1 != nil {
+		_ = c.RemoveReplicaNoLock(address)
+		return err1
+	}
+
+	if status == "" || status == "inProgress" {
+		logrus.Errorf("Waiting for replica to update CloneStatus to Completed/NA, retry after 2s")
+		time.Sleep(2 * time.Second)
+		goto getCloneStatus
+	} else if status == "error" {
+		_ = c.RemoveReplicaNoLock(address)
+		return fmt.Errorf("Replica clone status returned error %s", address)
+	}
+
+	if err := c.backend.SetReplicaMode(address, types.RW); err != nil {
+		_ = c.RemoveReplicaNoLock(address)
+		return fmt.Errorf("Fail to set replica mode for %v: %v", address, err)
+	}
+
+	c.setReplicaModeNoLock(address, types.RW)
 	return nil
 }
 
@@ -859,38 +850,30 @@ func (c *Controller) Start(addresses ...string) error {
 	)
 
 	c.Lock()
+	defer c.Unlock()
 
 	if len(addresses) == 0 {
-		c.Unlock()
 		logrus.Infof("addresses is null")
 		return nil
 	}
 
 	if len(c.replicas) > 0 {
-		c.Unlock()
 		logrus.Infof("already %d replicas are started and added", len(c.replicas))
 		return nil
 	}
 
 	c.reset()
 
+	defer c.startFrontend()
+
 	c.size = math.MaxInt64
-	c.Unlock()
 	for _, address := range addresses {
-		c.Lock()
 		err := c.addReplicaDuringStartNoLock(address)
-		c.Unlock()
 		if err != nil {
 			logrus.Errorf("err %v adding %s replica during start", err, address)
 			return err
 		}
-		if err := c.checkCloneStatusAndUpdateReplica(address); err != nil {
-			return err
-		}
 	}
-	c.Lock()
-	defer c.Unlock()
-	defer c.startFrontend()
 
 	revisionCounters := make(map[string]int64)
 	for _, r := range c.replicas {


### PR DESCRIPTION
Below PR has been flagged as not important as clone is not being supported and a bit risky. Lock at controller is being released in between adding replica which might cause race conditions among replicas to get added as leader replica. On error, there will be 2 threads in race to remove the replica, monitoring thread and checkCloneStatus thread.  There can be a case where checkCloneStatus thread removes the replica, replica connects back and after that monitoring thread tries to remove the replica based on errors on old connection.
Reverts openebs/jiva#298