### PR TITLE
fix(pattern): fix pattern to avoid repetition of head file names after every 10 snapshots

### DIFF
--- a/replica/replica.go
+++ b/replica/replica.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	diskPattern = regexp.MustCompile(`volume-head-(\d)+.img`)
+	diskPattern = regexp.MustCompile(`volume-head-(\d+).img`)
 )
 
 type Replica struct {


### PR DESCRIPTION
Head file names were getting repeated after every 10 snapshots. Although this was not causing any  problems as of now but fixing this will help in future implementations where these head file names will be used to sync data. Besides the repetition was not intended.
Signed-off-by: Payes Anand <payes.anand@mayadata.io>