### PR TITLE
fix(auto-delete-snapshot): Remove empty elements from DeleteCandidateChain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ test_resiliency:
 	sudo -E bash -x ./ci/resiliency_tests.sh
 
 test_functional:
-	go build && cp ./jiva tests/functional/
+	go build --tags=debug && cp ./jiva tests/functional/
 	cd tests/functional && go build --tags=debug && sudo bash -x test.sh
 
 test_e2e:

--- a/controller/control.go
+++ b/controller/control.go
@@ -495,6 +495,12 @@ func (c *Controller) Snapshot(name string) (string, error) {
 	if name == "" {
 		name = util.UUID()
 	}
+	if c.RWReplicaCount != c.ReplicationFactor {
+		return "", fmt.Errorf(
+			"RWReplicaCount(%v) != ReplicationFactor(%v)",
+			c.RWReplicaCount, c.ReplicationFactor,
+		)
+	}
 
 	if remain, err := c.backend.RemainSnapshots(); err != nil {
 		return "", err

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -757,6 +757,10 @@ func GetDeleteCandidateChain(r *replica.Replica, checkpoint string) ([]string, e
 		if replicaDisks[disk].UserCreated && !replicaDisks[disk].Removed {
 			continue
 		}
+		parent := replicaDisks[disk].Parent
+		if replicaDisks[parent].UserCreated && !replicaDisks[parent].Removed {
+			continue
+		}
 		snapList[i].name = disk
 		snapList[i].size, err = strconv.ParseInt(replicaDisks[disk].Size, 10, 64)
 		if err != nil {
@@ -771,6 +775,9 @@ func GetDeleteCandidateChain(r *replica.Replica, checkpoint string) ([]string, e
 
 	var sortedList []string
 	for _, snap := range snapList {
+		if snap.name == "" {
+			continue
+		}
 		sortedList = append(sortedList, snap.name)
 	}
 	return sortedList, err

--- a/tests/e2e/chaos.go
+++ b/tests/e2e/chaos.go
@@ -7,11 +7,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+var TestRunTime time.Duration = 60
+
 func restartOneReplicaTest() {
 	config := buildConfig("172.18.0.10", []string{"172.18.0.11", "172.18.0.12", "172.18.0.13"})
 	setupTest(config)
 	config.verifyRWReplicaCount(3)
-	config.runIOs()
+	go config.testSequentialData()
 	go config.snapshotCreateDelete()
 	ctrlClient := getControllerClient(config.ControllerIP)
 	startTime := time.Now()
@@ -25,18 +27,23 @@ func restartOneReplicaTest() {
 		stopContainer(config.Replicas[striped(replicas[0].Address)])
 		startContainer(config.Replicas[striped(replicas[0].Address)])
 		config.verifyRWReplicaCount(3)
-		time.Sleep(30 * time.Second)
-		if time.Since(startTime) > time.Minute*20 {
+		time.Sleep(65 * time.Second) // 65 so that auto-snapshot delete is triggered
+		if time.Since(startTime) > time.Minute*TestRunTime {
 			break
 		}
 		iteration++
 	}
 	config.Stop = true
-	for {
+	for range time.NewTicker(5 * time.Second).C {
 		if config.ThreadCount == 0 {
 			break
 		}
+		logrus.Infof(
+			"RestartControllerTest Completed, waiting for threads to exit, pending tc:%v",
+			config.ThreadCount,
+		)
 	}
+	logrus.Infof("Exiting RestartOneReplicaTest, threads exited successfully")
 	scrap(config)
 }
 
@@ -44,7 +51,7 @@ func restartTwoReplicasTest() {
 	config := buildConfig("172.18.0.20", []string{"172.18.0.21", "172.18.0.22", "172.18.0.23"})
 	setupTest(config)
 	config.verifyRWReplicaCount(3)
-	config.runIOs()
+	go config.testSequentialData()
 	go config.snapshotCreateDelete()
 	ctrlClient := getControllerClient(config.ControllerIP)
 	startTime := time.Now()
@@ -60,18 +67,23 @@ func restartTwoReplicasTest() {
 		startContainer(config.Replicas[striped(replicas[0].Address)])
 		startContainer(config.Replicas[striped(replicas[1].Address)])
 		config.verifyRWReplicaCount(3)
-		time.Sleep(30 * time.Second)
-		if time.Since(startTime) > time.Minute*20 {
+		time.Sleep(65 * time.Second) // 65 so that auto-snapshot delete is triggered
+		if time.Since(startTime) > time.Minute*TestRunTime {
 			break
 		}
 		iteration++
 	}
 	config.Stop = true
-	for {
+	for range time.NewTicker(5 * time.Second).C {
 		if config.ThreadCount == 0 {
 			break
 		}
+		logrus.Infof(
+			"RestartControllerTest Completed, waiting for threads to exit, pending tc:%v",
+			config.ThreadCount,
+		)
 	}
+	logrus.Infof("Exiting RestartTwoReplicaTest, threads exited successfully")
 	scrap(config)
 }
 
@@ -79,7 +91,7 @@ func restartThreeReplicasTest() {
 	config := buildConfig("172.18.0.30", []string{"172.18.0.31", "172.18.0.32", "172.18.0.33"})
 	setupTest(config)
 	config.verifyRWReplicaCount(3)
-	config.runIOs()
+	go config.testSequentialData()
 	go config.snapshotCreateDelete()
 	ctrlClient := getControllerClient(config.ControllerIP)
 	startTime := time.Now()
@@ -97,18 +109,23 @@ func restartThreeReplicasTest() {
 		startContainer(config.Replicas[striped(replicas[1].Address)])
 		startContainer(config.Replicas[striped(replicas[2].Address)])
 		config.verifyRWReplicaCount(3)
-		time.Sleep(30 * time.Second)
-		if time.Since(startTime) > time.Minute*20 {
+		time.Sleep(65 * time.Second) // 65 so that auto-snapshot delete is triggered
+		if time.Since(startTime) > time.Minute*TestRunTime {
 			break
 		}
 		iteration++
 	}
 	config.Stop = true
-	for {
+	for range time.NewTicker(5 * time.Second).C {
 		if config.ThreadCount == 0 {
 			break
 		}
+		logrus.Infof(
+			"RestartControllerTest Completed, waiting for threads to exit, pending tc:%v",
+			config.ThreadCount,
+		)
 	}
+	logrus.Infof("Exiting RestartThreeReplicaTest, threads exited successfully")
 	scrap(config)
 }
 
@@ -116,7 +133,7 @@ func restartControllerTest() {
 	config := buildConfig("172.18.0.40", []string{"172.18.0.41", "172.18.0.42", "172.18.0.43"})
 	setupTest(config)
 	config.verifyRWReplicaCount(3)
-	config.runIOs()
+	go config.testSequentialData()
 	go config.snapshotCreateDelete()
 	startTime := time.Now()
 	iteration := 1
@@ -125,23 +142,30 @@ func restartControllerTest() {
 		stopContainer(config.Controller[striped(config.ControllerIP)])
 		startContainer(config.Controller[striped(config.ControllerIP)])
 		config.verifyRWReplicaCount(3)
-		time.Sleep(30 * time.Second)
-		if time.Since(startTime) > time.Minute*20 {
+		time.Sleep(65 * time.Second) // 65 so that auto-snapshot delete is triggered
+		if time.Since(startTime) > time.Minute*TestRunTime {
 			break
 		}
 		iteration++
 	}
 	config.Stop = true
-	for {
+	for range time.NewTicker(5 * time.Second).C {
 		if config.ThreadCount == 0 {
 			break
 		}
+		logrus.Infof(
+			"RestartControllerTest Completed, waiting for threads to exit, pending tc:%v",
+			config.ThreadCount,
+		)
 	}
+	logrus.Infof("Exiting RestartControllerTest, threads exited successfully")
 	scrap(config)
 }
 func chaosTest() {
+	logrus.Infof("Start chaos Test")
 	var wg sync.WaitGroup
-	wg.Add(4)
+	wg.Add(1)
+
 	go func() {
 		restartOneReplicaTest()
 		wg.Done()
@@ -159,4 +183,5 @@ func chaosTest() {
 		wg.Done()
 	}()
 	wg.Wait()
+	logrus.Infof("Chaos Test completed successfully")
 }

--- a/tests/e2e/chaos.go
+++ b/tests/e2e/chaos.go
@@ -164,7 +164,7 @@ func restartControllerTest() {
 func chaosTest() {
 	logrus.Infof("Start chaos Test")
 	var wg sync.WaitGroup
-	wg.Add(1)
+	wg.Add(4)
 
 	go func() {
 		restartOneReplicaTest()

--- a/tests/e2e/container_start_stop.go
+++ b/tests/e2e/container_start_stop.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -90,7 +91,7 @@ func createReplica(replicaIP string, config *testConfig) string {
 			},
 			NetworkMode:     "stg-net",
 			PublishAllPorts: true,
-			Binds:           []string{"/tmp/" + replicaIP + "vol:/vol"},
+			Binds:           []string{"/tmp1/" + replicaIP + "vol:/vol"},
 		},
 		&network.NetworkingConfig{
 			EndpointsConfig: map[string]*network.EndpointSettings{
@@ -209,5 +210,6 @@ func verifyRestartCount(containerID string, restartCount int) {
 		if containerInspect.ContainerJSONBase.RestartCount >= restartCount {
 			break
 		}
+		time.Sleep(5 * time.Second)
 	}
 }

--- a/tests/e2e/ios.go
+++ b/tests/e2e/ios.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bytes"
+	"github.com/sirupsen/logrus"
 	"math/rand"
 	"os"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -15,10 +17,13 @@ const (
 	gb = 1024 * mb
 )
 
-func verifyData(fd int, tid, iter, offset int64) {
+func (config *testConfig) verifyData(fd int, tid, iter, offset int64) {
 	readBuf := make([]byte, 1024)
 	prevWriteBuf := make([]byte, 1024)
 	for {
+		if config.Stop {
+			return
+		}
 		_, err := syscall.Pread(fd, readBuf, offset)
 		if err == nil {
 			break
@@ -27,13 +32,19 @@ func verifyData(fd int, tid, iter, offset int64) {
 	}
 	copy(prevWriteBuf, []byte(strconv.FormatInt(offset*tid*(iter-1), 10)))
 	if !bytes.Equal(readBuf, prevWriteBuf) {
-		panic("Data Integrity check failed")
+		if config.Stop {
+			return
+		}
+		logrus.Fatalf("Data Integrity check failed")
 	}
 }
 
-func writeData(fd int, tid, iter, offset int64) {
+func (config *testConfig) writeData(fd int, tid, iter, offset int64) {
 	writeBuf := []byte(strconv.FormatInt(offset*tid*iter, 10))
 	for {
+		if config.Stop {
+			return
+		}
 		_, err := syscall.Pwrite(fd, writeBuf, offset)
 		if err == nil {
 			break
@@ -48,13 +59,13 @@ func (config *testConfig) readVerifyWriteTestForIter(fd int, tid int64, region [
 			return
 		}
 		if iter != 1 {
-			verifyData(fd, tid, iter, offset)
+			config.verifyData(fd, tid, iter, offset)
 		}
-		writeData(fd, tid, iter, offset)
+		config.writeData(fd, tid, iter, offset)
 	}
 }
 
-func (config *testConfig) startIOs(tid int64, devPath string) {
+func (config *testConfig) startIOs(tid, iter int64, devPath string) {
 	config.insertThread()
 	defer config.releaseThread()
 	var (
@@ -62,30 +73,52 @@ func (config *testConfig) startIOs(tid int64, devPath string) {
 		fd  int
 	)
 
-	if fd, err = syscall.Open(devPath, os.O_RDWR, 0777); err != nil {
-		panic(err)
-	}
-
 	region := []int64{(tid - 1) * gb, tid * gb}
-	iter := int64(1)
-	for {
-		config.readVerifyWriteTestForIter(fd, tid, region, iter)
-		if config.Stop {
-			return
-		}
-		time.Sleep(1 * time.Second)
-		iter++
+	logrus.Infof("IO Iteration: %v for %v, tid: %v", iter, devPath, tid)
+	if fd, err = syscall.Open(devPath, os.O_RDWR, 0777); err != nil {
+		logrus.Fatalf("%v", err)
+	}
+	config.readVerifyWriteTestForIter(fd, tid, region, iter)
+	if config.Stop {
+		return
+	}
+	if err = syscall.Close(fd); err != nil {
+		logrus.Fatalf("%v", err)
 	}
 }
 
 func (config *testConfig) runIOs() {
-	devPath, err := config.attachDisk()
-	if err != nil {
-		panic(err)
-	}
-	for i := 1; i <= 5; i++ {
-		tid := i
-		go config.startIOs(int64(tid), devPath)
+	config.insertThread()
+	defer config.releaseThread()
+
+	wg := sync.WaitGroup{}
+	iter := int64(1)
+	for {
+		if config.Stop {
+			return
+		}
+		devPath, err := config.attachDisk()
+		if err != nil {
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		time.Sleep(5 * time.Second) // It takes some time for iscsi device to appear
+		wg.Add(5)
+		for i := 1; i <= 5; i++ {
+			tid := i
+			go func(tid int, iter int64) {
+				config.startIOs(int64(tid), iter, devPath)
+				wg.Done()
+			}(tid, iter)
+		}
+		wg.Wait()
+		for {
+			if err = config.detachDisk(); err == nil {
+				break
+			}
+			time.Sleep(2 * time.Second)
+		}
+		iter++
 	}
 }
 
@@ -112,12 +145,12 @@ func (config *testConfig) writeRandomData() []int64 {
 	table := generateRandomIOTable()
 	devPath, err := config.attachDisk()
 	if err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 	fillBlocks(devPath, table)
 	err = config.detachDisk()
 	if err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 	return table
 }
@@ -127,7 +160,7 @@ func fillBlocks(devPath string, table []int64) {
 		err error
 	)
 	if fd, err = syscall.Open(devPath, os.O_RDWR, 0777); err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 	for offset, data := range table {
 		writeBuf := []byte(strconv.FormatInt(data, 10))
@@ -140,19 +173,19 @@ func fillBlocks(devPath string, table []int64) {
 		}
 	}
 	if err = syscall.Close(fd); err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 }
 
 func (config *testConfig) verifyRandomData(table []int64) {
 	devPath, err := config.attachDisk()
 	if err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 	verifyBlocks(devPath, table)
 	err = config.detachDisk()
 	if err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 }
 func verifyBlocks(devPath string, table []int64) {
@@ -161,7 +194,7 @@ func verifyBlocks(devPath string, table []int64) {
 		err error
 	)
 	if fd, err = syscall.Open(devPath, os.O_RDWR, 0777); err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 	for offset, data := range table {
 		//Skip checking empty blocks
@@ -179,10 +212,10 @@ func verifyBlocks(devPath string, table []int64) {
 		}
 		copy(prevWriteBuf, []byte(strconv.FormatInt(data, 10)))
 		if !bytes.Equal(readBuf, prevWriteBuf) {
-			panic("Data Integrity check failed")
+			logrus.Fatalf("Data Integrity check failed")
 		}
 	}
 	if err = syscall.Close(fd); err != nil {
-		panic(err)
+		logrus.Fatalf("%v", err)
 	}
 }

--- a/tests/e2e/replica.go
+++ b/tests/e2e/replica.go
@@ -42,7 +42,7 @@ func (config *testConfig) verifyRWReplicaCount(count int) {
 func createReplicas(config *testConfig) {
 	replicas := config.Replicas
 	for replicaIP := range replicas {
-		os.Mkdir("/tmp"+replicaIP+"vol", 0755)
+		os.Mkdir("/tmp1/"+replicaIP+"vol", 0755)
 		config.Replicas[replicaIP] = createReplica(replicaIP, config)
 	}
 }
@@ -52,7 +52,7 @@ func deleteReplicas(config *testConfig) {
 	for replicaIP := range replicas {
 		stopContainer(config.Replicas[replicaIP])
 		removeContainer(config.Replicas[replicaIP])
-		os.RemoveAll("/tmp" + replicaIP + "vol")
+		os.RemoveAll("/tmp1/" + replicaIP + "vol")
 	}
 }
 

--- a/tests/e2e/snapshot.go
+++ b/tests/e2e/snapshot.go
@@ -12,11 +12,12 @@ func (config *testConfig) snapshotCreateDelete() {
 	i := 0
 	for {
 		ctrlClient.Snapshot("snap-" + strconv.Itoa(i))
-		time.Sleep(5 * time.Second)
+		time.Sleep(30 * time.Second)
 		ctrlClient.DeleteSnapshot("snap-" + strconv.Itoa(i))
 		i++
 		if config.Stop {
 			return
 		}
+		time.Sleep(30 * time.Second)
 	}
 }

--- a/tests/functional/add_replica.go
+++ b/tests/functional/add_replica.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"github.com/openebs/jiva/alertlog"
 	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/sync"
+	"github.com/sirupsen/logrus"
 )
 
 func addReplica(replica string) error {
@@ -14,23 +14,10 @@ func autoAddReplica(s *replica.Server, frontendIP string, replica string, replic
 	var err error
 	url := "http://" + frontendIP + ":9501"
 	task := sync.NewTask(url)
-	if replicaType == "quorum" {
-		err = task.AddQuorumReplica(replica, s)
-	} else {
-		err = task.AddReplica(replica, s)
+	if err = task.AddReplica(replica, s); err != nil {
+		logrus.Errorf("jiva.volume.replica.add.failure rname:%v err: %v", replica, err)
+		return err
 	}
-	if err != nil {
-		alertlog.Logger.Errorw("",
-			"eventcode", "jiva.volume.replica.add.failure",
-			"msg", "Failed to add Jiva volume replica",
-			"rname", replica,
-		)
-	} else {
-		alertlog.Logger.Infow("",
-			"eventcode", "jiva.volume.replica.add.success",
-			"msg", "Successfully added Jiva volume replica",
-			"rname", replica,
-		)
-	}
-	return err
+	logrus.Infof("jiva.volume.replica.add.success rname: %v", replica)
+	return nil
 }

--- a/tests/functional/config.go
+++ b/tests/functional/config.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	controllerRest "github.com/openebs/jiva/controller/rest"
 	inject "github.com/openebs/jiva/error-inject"
@@ -24,7 +25,7 @@ type testConfig struct {
 	Replicas           map[string]*replicaInfo
 	ControllerEnvs     map[string]string
 	ReplicaEnvs        map[string]string
-	ReplicaRestartList []string
+	ReplicaRestartList map[string]time.Time
 	Close              map[string]chan struct{}
 }
 
@@ -44,6 +45,7 @@ func buildConfig(controllerIP string, replicas []string) *testConfig {
 	config := &testConfig{
 		ControllerIP: controllerIP,
 	}
+	config.ReplicaRestartList = map[string]time.Time{}
 	config.ReplicationFactor = 3
 	config.VolumeName = "vol" + config.ControllerIP
 	config.Size = "5G"

--- a/tests/functional/controller.go
+++ b/tests/functional/controller.go
@@ -90,7 +90,7 @@ func (config *testConfig) startTestController(controllerIP string) error {
 func (config *testConfig) verifyRWReplicaCount(count int) {
 	controller := config.Controller[config.ControllerIP].GetController()
 	for controller.RWReplicaCount != count {
-		logrus.Infof("Sleep while verifyRWReplicaCount, Actual: %v Desired: %v", count, controller.RWReplicaCount)
+		logrus.Infof("Sleep while verifyRWReplicaCount, Actual: %v Desired: %v", controller.RWReplicaCount, count)
 		time.Sleep(2 * time.Second)
 	}
 }
@@ -103,9 +103,15 @@ func (config *testConfig) verifyCheckpoint(set bool) {
 	}
 }
 func (config *testConfig) verifyCheckpointSameAtReplicas(replicas []string) bool {
+reverify:
 	controller := config.Controller[config.ControllerIP].GetController()
 	checkpoint := controller.Checkpoint
+	time.Sleep(5 * time.Second)
 	for _, rep := range replicas {
+		if config.Replicas[rep].Server.Replica() == nil {
+			config.verifyRWReplicaCount(3)
+			goto reverify
+		}
 		if config.Replicas[rep].Server.Replica().Info().Checkpoint != checkpoint {
 			return false
 		}

--- a/tests/functional/test_checkpoint.go
+++ b/tests/functional/test_checkpoint.go
@@ -4,9 +4,11 @@ import (
 	"time"
 
 	inject "github.com/openebs/jiva/error-inject"
+	"github.com/sirupsen/logrus"
 )
 
 func testCheckpoint() {
+	logrus.Infof("Test Checkpoint")
 	replicas := []string{"172.18.0.111", "172.18.0.112", "172.18.0.113"}
 	c := buildConfig("172.18.0.110", replicas)
 	// Start controller

--- a/tests/functional/test_functions.go
+++ b/tests/functional/test_functions.go
@@ -172,7 +172,7 @@ func getDeleteCandidateChainFuncTest() {
 	// User Created snapshot test
 	list, err = sync.GetDeleteCandidateChain(r, "volume-snap-005.img")
 	c.Assert(err, checkV1.IsNil)
-	verifyList(list, []string{"volume-snap-001.img", "volume-snap-002.img", "volume-snap-004.img"})
+	verifyList(list, []string{"volume-snap-001.img", "volume-snap-002.img"})
 
 	_, err = r.PrepareRemoveDisk("volume-snap-003.img")
 	c.Assert(err, checkV1.IsNil)


### PR DESCRIPTION
This PR addresses the following:
1. Remove empty elements from DeleteCandidateChain. This might occur due to the skipping of user created snapshots.
2. Error out user triggered deletion of snapshots if all the replicas are not connected.
3. Avoid deletion of snapshots whose parent is user created and has not been removed.
4. Update e2e tests to detach disk after every IO iteration to avoid caching at client side.
Signed-off-by: payes <payes.anand@mayadata.io>