### PR TITLE
chore(build): add support for multiarch build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,10 @@ jobs:
           if [ ${BRANCH} = "master" ]; then
             CI_TAG="ci"
           fi
-          echo "::set-env name=TAG::${CI_TAG}"
+          echo "::set-env name=IMAGE_TAG::${CI_TAG}"
           echo "::set-env name=BRANCH::${BRANCH}"
           echo "BRANCH: ${BRANCH}"
-          echo "TAG: ${CI_TAG}"
+          echo "IMAGE_TAG: ${CI_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,76 @@
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: build
+
+on: ['push']
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: '.'
+          pattern: '*.sh'
+          exclude: './vendor/*'
+  
+  jiva:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set tag
+        run: |
+          BRANCH="${GITHUB_REF##*/}"
+          CI_TAG=${BRANCH#v}-ci
+          if [ ${BRANCH} = "master" ]; then
+            CI_TAG="ci"
+          fi
+          echo "::set-env name=TAG::${CI_TAG}"
+          echo "::set-env name=BRANCH::${BRANCH}"
+          echo "BRANCH: ${BRANCH}"
+          echo "TAG: ${CI_TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.jiva
+          make buildx.push.jiva
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,61 @@
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ci
+
+on:
+  pull_request:
+    branches:
+      # on pull requests to master and release branches
+      - master
+      - 'v*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Shellcheck
+        uses: reviewdog/action-shellcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+          path: '.'
+          pattern: '*.sh'
+          exclude: './vendor/*'
+
+  jiva:
+    runs-on: ubuntu-latest
+    needs: ['lint']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Build Image
+        env:
+          IMG_RESULT: cache
+        run: make docker.buildx.jiva

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,10 @@ jobs:
 
       - name: Set Tag
         run: |
-          TAG="${GITHUB_REF#refs/*/v}"
-          echo "::set-env name=TAG::${TAG}"
-          echo "::set-env name=RELEASE_TAG::${TAG}"
-          echo "RELEASE_TAG ${TAG}"
+          IMAGE_TAG="${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=IMAGE_TAG::${IMAGE_TAG}"
+          echo "::set-env name=RELEASE_TAG::${IMAGE_TAG}"
+          echo "RELEASE_TAG ${IMAGE_TAG}"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: release
+
+on:
+  create:
+    tags:
+      - 'v*'
+
+jobs:
+  jiva:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Set Tag
+        run: |
+          TAG="${GITHUB_REF#refs/*/v}"
+          echo "::set-env name=TAG::${TAG}"
+          echo "::set-env name=RELEASE_TAG::${TAG}"
+          echo "RELEASE_TAG ${TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Image
+        env:
+          IMAGE_ORG: ${{ secrets.IMAGE_ORG}}
+        run: |
+          make docker.buildx.jiva
+          make buildx.push.jiva

--- a/Makefile
+++ b/Makefile
@@ -151,3 +151,5 @@ license-check:
                exit 1; \
        fi
 	@echo "Done checking license."
+
+include Makefile.buildx.mk

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -1,0 +1,76 @@
+# Copyright 2018-2020 The OpenEBS Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ==============================================================================
+# Build Options
+
+ifeq (${TAG}, )
+	export TAG=ci
+endif
+
+# Specify the date of build
+DBUILD_DATE=$(date +'%Y-%m-%dT%H:%M:%SZ')
+
+# Specify the docker arg for repository url
+ifeq (${DBUILD_REPO_URL}, )
+  DBUILD_REPO_URL="https://github.com/openebs/jiva"
+endif
+
+# Specify the docker arg for website url
+ifeq (${DBUILD_SITE_URL}, )
+  DBUILD_SITE_URL="https://openebs.io"
+endif
+
+DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=${DBUILD_REPO_URL} --build-arg DBUILD_SITE_URL=${DBUILD_SITE_URL}
+
+# Build jiva docker image with buildx
+# Experimental docker feature to build cross platform multi-architecture docker images
+# https://docs.docker.com/buildx/working-with-buildx/
+
+# default list of platforms for which multiarch image is built
+ifeq (${PLATFORMS}, )
+	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+endif
+
+# if IMG_RESULT is unspecified, by default the image will be pushed to registry
+ifeq (${IMG_RESULT}, load)
+	export PUSH_ARG="--load"
+	# if load is specified, image will be built only for the build machine architecture.
+	export PLATFORMS="local"
+else ifeq (${IMG_RESULT}, cache)
+	# if cache is specified, image will only be available in the build cache, it won't be pushed or loaded
+	# therefore no PUSH_ARG will be specified
+else
+	export PUSH_ARG="--push"
+endif
+
+# Name of the multiarch image for jiva
+DOCKERX_IMAGE_JIVA:=${IMAGE_ORG}/jiva:${TAG}
+
+.PHONY: docker.buildx.jiva
+docker.buildx.jiva:
+	export DOCKER_CLI_EXPERIMENTAL=enabled
+	@if ! docker buildx ls | grep -q container-builder; then\
+		docker buildx create --platform ${PLATFORMS} --name container-builder --use;\
+	fi
+	@docker buildx build --platform ${PLATFORMS} \
+		-t "$(DOCKERX_IMAGE_JIVA)" ${DBUILD_ARGS} -f $(PWD)/package/jiva.Dockerfile \
+		. ${PUSH_ARG}
+	@echo "--> Build docker image: $(DOCKERX_IMAGE_JIVA)"
+	@echo
+
+.PHONY: buildx.push.jiva
+buildx.push.jiva:
+	BUILDX=true DIMAGE=${IMAGE_ORG}/jiva ./scripts/push
+

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -15,8 +15,8 @@
 # ==============================================================================
 # Build Options
 
-ifeq (${TAG}, )
-	export TAG=ci
+ifeq (${IMAGE_TAG}, )
+	export IMAGE_TAG=ci
 endif
 
 # Specify the date of build
@@ -56,7 +56,7 @@ else
 endif
 
 # Name of the multiarch image for jiva
-DOCKERX_IMAGE_JIVA:=${IMAGE_ORG}/jiva:${TAG}
+DOCKERX_IMAGE_JIVA:=${IMAGE_ORG}/jiva:${IMAGE_TAG}
 
 .PHONY: docker.buildx.jiva
 docker.buildx.jiva:

--- a/ci/suite.sh
+++ b/ci/suite.sh
@@ -115,8 +115,8 @@ prepare_test_env() {
 	mkdir -pv /mnt/store /mnt/store2
 
 	docker network create --subnet=172.18.0.0/16 stg-net
-	JI=$(docker images | grep ${IMAGE_ORG}/jiva | awk '{print $1":"$2}' | awk 'NR == 2 {print}')
-	JI_DEBUG=$(docker images | grep ${IMAGE_ORG}/jiva | awk '{print $1":"$2}' | awk 'NR == 1 {print}')
+	JI=$(docker images | grep ${IMAGE_ORG}/jiva-amd64 | awk '{print $1":"$2}' | awk 'NR == 2 {print}')
+	JI_DEBUG=$(docker images | grep ${IMAGE_ORG}/jiva-amd64 | awk '{print $1":"$2}' | awk 'NR == 1 {print}')
 	echo "Run CI tests on $JI and $JI_DEBUG"
 }
 

--- a/package/jiva.Dockerfile
+++ b/package/jiva.Dockerfile
@@ -1,0 +1,67 @@
+# Copyright © 2020 The OpenEBS Authors
+#
+# This file was originally authored by Rancher Labs
+# under Apache License 2018.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.14.7 as build
+
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT=""
+
+ENV GO111MODULE=on \
+  GOOS=${TARGETOS} \
+  GOARCH=${TARGETARCH} \
+  GOARM=${TARGETVARIANT} \
+  DEBIAN_FRONTEND=noninteractive \
+  PATH="/root/go/bin:${PATH}"
+
+WORKDIR /go/src/github.com/openebs/jiva
+
+RUN apt-get update && apt-get install -y make git
+
+COPY go.mod go.sum ./
+# Get dependancies - will also be cached if we won't change mod/sum
+RUN go mod download
+
+COPY . .
+
+RUN ./scripts/build_binaries
+
+FROM ubuntu:xenial-20200212 
+
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG DBUILD_DATE
+ARG DBUILD_REPO_URL
+ARG DBUILD_SITE_URL
+
+LABEL org.label-schema.schema-version="1.0"
+LABEL org.label-schema.name="jiva"
+LABEL org.label-schema.description="OpenEBS Jiva"
+LABEL org.label-schema.build-date=$DBUILD_DATE
+LABEL org.label-schema.vcs-url=$DBUILD_REPO_URL
+LABEL org.label-schema.url=$DBUILD_SITE_URL
+
+COPY --from=build /go/src/github.com/openebs/jiva/bin/longhorn /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/jiva/bin/longhorn /usr/local/bin/jivactl
+COPY --from=build /go/src/github.com/openebs/jiva/package/launch /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/jiva/package/copy-binary /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/jiva/package/launch-with-vm-backing-file /usr/local/bin/
+COPY --from=build /go/src/github.com/openebs/jiva/package/launch-simple-jiva /usr/local/bin/
+
+VOLUME /usr/local/bin
+CMD ["longhorn"]

--- a/scripts/package
+++ b/scripts/package
@@ -65,6 +65,6 @@ then
   docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} ${DBUILD_ARGS} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
-  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva:${TAG} ${DBUILD_ARGS} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} ${DBUILD_ARGS} .
 fi
 echo Built ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG}

--- a/scripts/package_debug
+++ b/scripts/package_debug
@@ -48,6 +48,6 @@ then
   docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} --build-arg BASE_IMAGE=${BASE_DOCKER_IMAGEPPC64LE} .
 else
   DOCKERFILE=Dockerfile_build_amd64
-  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva:${TAG} .
+  docker build -f ${DOCKERFILE} -t ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG} .
 fi
 echo Built ${IMAGE_ORG}/jiva-${XC_ARCH}:${TAG}

--- a/scripts/push
+++ b/scripts/push
@@ -23,13 +23,33 @@ then
   exit 1
 fi
 
-source "$(dirname $0)/version"
-if [ ${ARCH} != "linux_amd64" ]; then
-  IMAGEID=$( docker images -q ${DIMAGE}-${XC_ARCH}:${VERSION} )
-  DIMAGE="${DIMAGE}-${XC_ARCH}"
-else 
-  IMAGEID=$( docker images -q ${DIMAGE}:${VERSION} )
+function pushBuildx() {
+  BUILD_TAG="latest"
+  TARGET_IMG=${DIMAGE}
+
+# TODO Currently ci builds with commit tag will not be generated,
+# since buildx does not support multiple repo
+  # if not a release build set the tag and ci image
+  if [ -z "${RELEASE_TAG}" ]; then
+    return
+#    BUILD_ID=$(git describe --tags --always)
+#    BUILD_TAG="${BRANCH}-${BUILD_ID}"
+#    TARGET_IMG="${DIMAGE}-ci"
+  fi
+
+  echo "Tagging and pushing ${DIMAGE}:${TAG} as ${TARGET_IMG}:${BUILD_TAG}"
+  docker buildx imagetools create "${DIMAGE}:${TAG}" -t "${TARGET_IMG}:${BUILD_TAG}"
+}
+
+# if the push is for a buildx build
+if [[ ${BUILDX} ]]; then
+  pushBuildx
+  exit 0
 fi
+
+source "$(dirname $0)/version"
+IMAGEID=$( docker images -q ${DIMAGE}-${XC_ARCH}:${VERSION} )
+DIMAGE="${DIMAGE}-${XC_ARCH}"
 
 echo $IMAGEID 
 if [ -z ${IMAGEID} ];


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?:**
This PR adds support for multi-arch builds using github actions.
It also appends the amd64 suffix to the single arch image pushed by travis.

Successfully tested the image locally.