### PR TITLE
refact(builds): enable amd64 and arm64 multi arch builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,6 @@ jobs:
         - RUN_FEATURE_TESTS=0
         - RUN_RESILIENCY_TESTS=0
         - RUN_E2E_AND_FUNCTIONAL_TESTS=1
-    - os: linux
-      arch: arm64
-    - os: linux
-      arch: ppc64le
 
 addons:
   apt:

--- a/Makefile.buildx.mk
+++ b/Makefile.buildx.mk
@@ -40,7 +40,7 @@ DBUILD_ARGS=--build-arg DBUILD_DATE=${DBUILD_DATE} --build-arg DBUILD_REPO_URL=$
 
 # default list of platforms for which multiarch image is built
 ifeq (${PLATFORMS}, )
-	export PLATFORMS="linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le"
+	export PLATFORMS="linux/amd64,linux/arm64"
 endif
 
 # if IMG_RESULT is unspecified, by default the image will be pushed to registry


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>


**Why is this PR required? What issue does it fix?**:
Enabling more than two arch in the multi-arch builds is resulting in increased build times as well as
intermittent failures in running the builds.

Limiting to two archs - amd64 and arm64 for now.