### PR TITLE
cherry-pick(metaFiles-fix): open MetaFiles with O_SYNC flag (#337)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.0.1 // indirect
-	github.com/openebs/sparse-tools v1.0.0
+	github.com/openebs/sparse-tools v1.1.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.5.1
 	github.com/rancher/go-rancher v0.1.1-0.20190307222549-9756097e5e4c

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/openebs/sparse-tools v1.0.0 h1:Cf5X/X4X+mX//HO2C56H/wp0h+QMm9DDzvg6/QIYyS8=
-github.com/openebs/sparse-tools v1.0.0/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
+github.com/openebs/sparse-tools v1.1.0 h1:oMNHgvxPXOUfwubKVFJZ1e0qmfl5c2YoEFm56DOkRL0=
+github.com/openebs/sparse-tools v1.1.0/go.mod h1:/PPl9gH4GPPbP28mei6t3f3VZEzA4Oc93IhBkdo7i1c=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -442,6 +442,15 @@ func (t *Task) reloadAndVerify(s *replica.Server, address string, repClient *rep
 		logrus.Errorf("Error in reloadreplica %s", address)
 		return err
 	}
+
+	// Sync is being called over here so that after the reload is complete
+	// metadata for this dir is synced to disk. While syncing this replica
+	// from a healthy replica some snapshot files might have been pulled.
+	if err := s.Replica().SyncDir(); err != nil {
+		logrus.Errorf("Directory Sync Failed %v", err)
+		return err
+	}
+
 	if err := s.UpdateLUNMap(); err != nil {
 		return fmt.Errorf("UpdateLUNMap() failed, err: %v", err.Error())
 	}


### PR DESCRIPTION
This PR along with https://github.com/openebs/sparse-tools/pull/7 fixes the following issue: https://github.com/openebs/jiva/issues/338
On crashing the kernel simultaneously at all the nodes, one of the replica fails to come up and enters into CrashLoopBackOff state with this error:
 ```failed to read disk data, error while unmarshalling file: volume-snap-1db04a94-0aa0-4404-bbbb-3641392d587f.img.meta```

This issue occured because metadata files are not synced to disk immediately. It is not seen with data files as those are opened with O_DIRECT flag.

As a fix, Metadata files are now being opened with O_SYNC flag.

Signed-off-by: Payes Anand <payes.anand@mayadata.io>