### PR TITLE
refact(UUID): include replica address while creating UUID hash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install: true
 services:
   - docker
 go:
-  - 1.13.x
+  - 1.14.7
 env:
   global:
     - GOARCH=$(go env GOARCH)

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -159,6 +159,11 @@ func CreateTempReplica(s *Server) (*Replica, error) {
 		ReplicaStartTime: StartTime,
 		mode:             types.INIT,
 	}
+
+	if r.info, err = ReadInfo(r.dir); err != nil {
+		return nil, err
+	}
+
 	if err = r.initRevisionCounter(); err != nil {
 		logrus.Errorf("Error in initializing revision counter while creating temp replica")
 		return nil, err

--- a/replica/replica.go
+++ b/replica/replica.go
@@ -33,7 +33,6 @@ import (
 	"time"
 
 	units "github.com/docker/go-units"
-	guuid "github.com/google/uuid"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 	"github.com/openebs/sparse-tools/sparse"
@@ -149,14 +148,14 @@ const (
 	OpReplace  = "replace"
 )
 
-func CreateTempReplica() (*Replica, error) {
+func CreateTempReplica(s *Server) (*Replica, error) {
 	var err error
-	if err = os.Mkdir(Dir, 0700); err != nil && !os.IsExist(err) {
+	if err = os.Mkdir(s.Dir, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 
 	r := &Replica{
-		dir:              Dir,
+		dir:              s.Dir,
 		ReplicaStartTime: StartTime,
 		mode:             types.INIT,
 	}
@@ -164,19 +163,12 @@ func CreateTempReplica() (*Replica, error) {
 		logrus.Errorf("Error in initializing revision counter while creating temp replica")
 		return nil, err
 	}
-	if r.info, err = ReadInfo(r.dir); err != nil {
-		return nil, err
-	}
-	if r.info.UUID == "" {
-		r.info.UUID = guuid.New().String()
-		r.writeVolumeMetaData(r.info.Dirty, r.info.Rebuilding)
-	}
 	return r, nil
 }
 
-func CreateTempServer() (*Server, error) {
+func CreateTempServer(s *Server) (*Server, error) {
 	return &Server{
-		dir: Dir,
+		Dir: s.Dir,
 	}, nil
 }
 
@@ -1205,9 +1197,6 @@ func (r *Replica) readMetadata() (bool, error) {
 			}
 			if r.info.Head == "" {
 				return false, fmt.Errorf("r.info.Head is nil")
-			}
-			if r.info.UUID == "" {
-				r.info.UUID = guuid.New().String()
 			}
 			file = fileMap[r.info.Head+metadataSuffix]
 		} else if strings.HasSuffix(file.Name(), metadataSuffix) {

--- a/replica/replica_test.go
+++ b/replica/replica_test.go
@@ -671,7 +671,7 @@ func (s *TestSuite) TestUpdateLUNMap(c *C) {
 	c.Assert(err, IsNil)
 	server := &Server{
 		r:   r,
-		dir: dir,
+		Dir: dir,
 	}
 	// Fill data for S0
 	lunMapS0 := []int{1, 3, 5, 6}

--- a/replica/rest/replica.go
+++ b/replica/rest/replica.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
-	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/sync/rebuild"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
@@ -119,7 +118,7 @@ func (s *Server) GetVolUsage(rw http.ResponseWriter, req *http.Request) error {
 
 func (s *Server) GetRebuildInfo(rw http.ResponseWriter, req *http.Request) error {
 	apiContext := api.GetApiContext(req)
-	info := rebuild.GetRebuildInfo()
+	info := rebuild.GetRebuildInfo(s.s.Dir)
 	resp := &RebuildInfoOutput{
 		Resource: client.Resource{
 			Type:    "rebuildinfo",
@@ -155,7 +154,7 @@ func (s *Server) SetLogging(rw http.ResponseWriter, req *http.Request) error {
 	}
 	logrus.Infof("SetLogging to %v", input.LogToFile)
 
-	return s.doOp(req, util.SetLogging(replica.Dir, input.LogToFile))
+	return s.doOp(req, util.SetLogging(s.s.Dir, input.LogToFile))
 }
 
 func (s *Server) SetRebuilding(rw http.ResponseWriter, req *http.Request) error {

--- a/sync/rebuild/progress.go
+++ b/sync/rebuild/progress.go
@@ -19,7 +19,6 @@ package rebuild
 import (
 	"path"
 
-	"github.com/openebs/jiva/replica"
 	"github.com/openebs/jiva/types"
 	"github.com/openebs/jiva/util"
 )
@@ -47,13 +46,13 @@ func SetStatus(disk, status string) {
 
 // GetRebuildInfo returns the updated SyncInfo such as total
 // used size of snapshots and size of individual snapshots.
-func GetRebuildInfo() *types.SyncInfo {
+func GetRebuildInfo(dir string) *types.SyncInfo {
 	if Info == nil {
 		return nil
 	}
 	var totSize int64
 	for i, snap := range Info.Snapshots {
-		size := util.GetFileActualSize(path.Join(replica.Dir, snap.Name))
+		size := util.GetFileActualSize(path.Join(dir, snap.Name))
 		if size == -1 {
 			Info.Snapshots[i].WOSize = "NA"
 		} else {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -98,7 +98,7 @@ func find(list []string, item string) int {
 	return -1
 }
 
-func (t *Task) AddQuorumReplica(replicaAddress string, _ *replica.Server) error {
+func (t *Task) AddQuorumReplica(replicaAddress string, s *replica.Server) error {
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 Register:
@@ -108,8 +108,8 @@ Register:
 	}
 	addr := strings.Split(replicaAddress, "://")
 	parts := strings.Split(addr[1], ":")
-	Replica, _ := replica.CreateTempReplica()
-	server, _ := replica.CreateTempServer()
+	Replica, _ := replica.CreateTempReplica(s)
+	server, _ := replica.CreateTempServer(s)
 
 	if volume.ReplicaCount == 0 {
 		revisionCount := Replica.GetRevisionCounter()
@@ -243,11 +243,11 @@ func (t *Task) AddReplica(replicaAddress string, s *replica.Server) error {
 	}
 	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
-	Replica, err := replica.CreateTempReplica()
+	Replica, err := replica.CreateTempReplica(s)
 	if err != nil {
 		return fmt.Errorf("failed to create temp replica, error: %s", err.Error())
 	}
-	server, err := replica.CreateTempServer()
+	server, err := replica.CreateTempServer(s)
 	if err != nil {
 		return fmt.Errorf("failed to create temp server, error: %s", err.Error())
 	}


### PR DESCRIPTION
This PR implements the following:
1. Update go version to 1.14.7
2. Avoid using `Dir` global variable in replica package to aid unit testing.
3.  Use replica IP to create UUID hash
Signed-off-by: Payes Anand <payes.anand@mayadata.io>