### PR TITLE
fix(actions): fix the image tag for branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
           tag-latest: false
           tag-custom-only: true
           tag-custom: |
-            ${{ env.TAG }}
+            ${{ env.IMAGE_TAG }}
 
       - name: Print Tag info
         run: |


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This Pr fixes the tags for branches other than master. The images pushed via build workflow for branches should have -ci at the end which is missing due to a variable mismatch. The TAG variable is used by the build_binary script so keeping the variable with a different name.
https://github.com/openebs/jiva/blob/d3d9f36eae48befafcbe2396f9fa6bd235e50525/.github/workflows/build.yml#L103