### PR TITLE
fix(Makefile): update test target to run go test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ export XC_ARCH
 ARCH:=${XC_OS}_${XC_ARCH}
 export ARCH
 
+PACKAGES = $(shell go list ./... | grep -v 'vendor\|tests')
+
 help:
 	@echo ""
 	@echo "Usage:-"
@@ -89,8 +91,9 @@ _run_ci:
 	sudo -E bash ./ci/start_init_test.sh
 
 test:
-	@echo "INFO:\tRun ci over jiva image"
-	sudo -E bash -x ./ci/start_init_test.sh
+	go fmt ./...
+	@echo "--> Running go test" ;
+	@go test -v $(PACKAGES)
 
 test_features:
 	sudo -E bash -x ./ci/feature_tests.sh


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

This PR updates the test target in Makefile to run go test instead of the outdated test script which has been removed.
